### PR TITLE
fixed owner of /var/log/itsecorg to syslog (not root)

### DIFF
--- a/roles/iso-common/tasks/main.yml
+++ b/roles/iso-common/tasks/main.yml
@@ -13,8 +13,8 @@
        file:
          path: "/var/log/itsecorg/"
          state: directory
-         owner: root
-         group: root
+         owner: syslog
+         group: syslog
          mode: 0775
 
      - name: edit rsyslog


### PR DESCRIPTION
this repairs logging via rsyslog