### PR TITLE
Tim/deb install issue missing syslog user

### DIFF
--- a/roles/iso-common/tasks/main.yml
+++ b/roles/iso-common/tasks/main.yml
@@ -18,7 +18,7 @@
          mode: 0775
        when: ansible_facts['distribution'] == "Ubuntu"
          
-     - name: create log dir for itsecorg on ubuntu - owner root
+     - name: create log dir for itsecorg on debian - owner root
        file:
          path: "/var/log/itsecorg/"
          state: directory


### PR DESCRIPTION
fixing error:
TASK [iso-common : create log dir for itsecorg] ********************************************************************************************************************
fatal: [isosrv]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "0755", "msg": "chown failed: failed to look up user syslog", "owner": "root", "path": "/var/log/itsecorg/", "size": 4096, "state": "directory", "uid": 0}
        to retry, use: --limit @/home/achim/firewall-orchestrator/site.retry