### PR TITLE
R80 importer: makes CP-API limit configurable and adds debug mode

### DIFF
--- a/roles/importer/files/importer/iso_get_config_cp_r8x_api.py
+++ b/roles/importer/files/importer/iso_get_config_cp_r8x_api.py
@@ -30,7 +30,7 @@ parser.add_argument('-p', '--port', metavar='api_port', default='443', help='por
 parser.add_argument('-l', '--layer', metavar='policy_layer_name(s)', required=True, help='name of policy layer(s) to read (comma separated)')
 parser.add_argument('-x', '--proxy', metavar='proxy_string', default='', help='proxy server string to use, e.g. 1.2.3.4:8080; default=empty')
 parser.add_argument('-s', '--ssl', metavar='verification_mode', default='', help='[ca]certfile, if value not set, ssl check is off"; default=empty/off')
-parser.add_argument('-i', '--limit', metavar='verification_mode', default='500', help='The maximal number of returned results per HTTPS Connection; default=20')
+parser.add_argument('-i', '--limit', metavar='verification_mode', default='500', help='The maximal number of returned results per HTTPS Connection; default=500')
 parser.add_argument('-d', '--debug', metavar='debug_level', default='0', help='Debug Level: 0(off) 4(DEBUG Console) 41(DEBUG File); default=0') 
 
 args = parser.parse_args()


### PR DESCRIPTION
parser.add_argument('-i', '--limit', metavar='verification_mode', default='500', help='The maximal number of returned results per HTTPS Connection; default=20')
parser.add_argument('-d', '--debug', metavar='debug_level', default='0', help='Debug Level: 0(off) 4(DEBUG Console) 41(DEBUG File); default=0')

The performance problem seems to be on the manager's side.
A solution would be a parallel query of level + rules // objects
Whether that helps is speculation