### PR TITLE
Fix to include missed special objects

### DIFF
--- a/roles/importer/files/importer/fworch_get_config_cp_r8x_api.py
+++ b/roles/importer/files/importer/fworch_get_config_cp_r8x_api.py
@@ -69,7 +69,7 @@ nw_obj_table_names = ['hosts', 'networks', 'address-ranges', 'groups', 'gateways
 # do not consider: CpmiAnyObject, CpmiGatewayPlain, external 
 svc_obj_table_names = ['services-tcp', 'services-udp', 'service-groups', 'services-dce-rpc', 'services-rpc', 'services-other', 'services-icmp', 'services-icmp6']
 
-# usr_obj_table_names : do net exist yet - not fetchable via API
+# usr_obj_table_names : do not exist yet - not fetchable via API
 
 
 def api_call(ip_addr, port, url, command, json_payload, sid):


### PR DESCRIPTION
- formerly did not include objects whose uid was part of a group used in any rulebase
- added a switch (-n) to get_config to allow for testing enrichment of objects without API connection