### PR TITLE
recertify: DB changes, new role, new settings

### DIFF
--- a/documentation/revision-history.md
+++ b/documentation/revision-history.md
@@ -113,3 +113,7 @@ adding report template format fk and permissions
 ### 5.2.4 - 04.06.2021
 - changing db column management.ssh_public_key to nullable
 - adjusting api calls
+
+### 5.2.5 - 04.06.2021
+- new role recertifier
+- adapt rule_metadata table for recertification prototype

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ### general settings
-product_version: "5.2.4"
+product_version: "5.2.5"
 ansible_python_interpreter: /usr/bin/python3
 ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 product_name: fworch

--- a/roles/api/files/hasura_metadata.yaml
+++ b/roles/api/files/hasura_metadata.yaml
@@ -2765,6 +2765,7 @@ tables:
       - dev_id
       - last_change_admin
       - rule_last_certifier
+      - rule_last_certifier_dn
       - rule_owner
       - rule_hit_counter
       - rule_metadata_id
@@ -2774,7 +2775,7 @@ tables:
       - rule_last_certified
       - rule_last_hit
       - rule_last_modified
-      - rule_group_owner
+      - rule_owner_dn
     role: importer
   object_relationships:
   - name: device
@@ -2799,8 +2800,9 @@ tables:
       - rule_hit_counter
       - rule_last_certified
       - rule_last_certifier
+      - rule_last_certifier_dn
       - rule_owner
-      - rule_group_owner
+      - rule_owner_dn
       - rule_to_be_removed
       - last_change_admin
       - dev_id
@@ -2813,6 +2815,7 @@ tables:
       - dev_id
       - last_change_admin
       - rule_last_certifier
+      - rule_last_certifier_dn
       - rule_owner
       - rule_hit_counter
       - rule_metadata_id
@@ -2822,9 +2825,28 @@ tables:
       - rule_last_certified
       - rule_last_hit
       - rule_last_modified
-      - rule_group_owner
+      - rule_owner_dn
       filter: {}
     role: importer
+  - permission:
+      columns:
+      - rule_metadata_id
+      - dev_id
+      - rule_uid
+      - rule_created
+      - rule_last_modified
+      - rule_first_hit
+      - rule_last_hit
+      - rule_hit_counter
+      - rule_last_certified
+      - rule_last_certifier
+      - rule_owner
+      - rule_owner_dn
+      - rule_to_be_removed
+      - last_change_admin
+      - rule_last_certifier_dn
+      filter: {}
+    role: recertifier
   - permission:
       allow_aggregations: true
       columns:
@@ -2832,6 +2854,7 @@ tables:
       - dev_id
       - last_change_admin
       - rule_last_certifier
+      - rule_last_certifier_dn
       - rule_owner
       - rule_hit_counter
       - rule_metadata_id
@@ -2841,7 +2864,7 @@ tables:
       - rule_last_certified
       - rule_last_hit
       - rule_last_modified
-      - rule_group_owner
+      - rule_owner_dn
       filter:
         dev_id:
           _in:
@@ -2859,8 +2882,9 @@ tables:
       - rule_hit_counter
       - rule_last_certified
       - rule_last_certifier
+      - rule_last_certifier_dn
       - rule_owner
-      - rule_group_owner
+      - rule_owner_dn
       - rule_to_be_removed
       - last_change_admin
       - dev_id
@@ -2877,6 +2901,7 @@ tables:
       - dev_id
       - last_change_admin
       - rule_last_certifier
+      - rule_last_certifier_dn
       - rule_owner
       - rule_hit_counter
       - rule_metadata_id
@@ -2886,9 +2911,18 @@ tables:
       - rule_last_certified
       - rule_last_hit
       - rule_last_modified
-      - rule_group_owner
+      - rule_owner_dn
       filter: {}
     role: importer
+  - permission:
+      check: {}
+      columns:
+      - rule_last_certified
+      - rule_last_certifier
+      - rule_last_certifier_dn
+      - rule_to_be_removed
+      filter: {}
+    role: recertifier
 - object_relationships:
   - name: management
     using:

--- a/roles/database/files/sql/creation/fworch-create-tables.sql
+++ b/roles/database/files/sql/creation/fworch-create-tables.sql
@@ -166,7 +166,7 @@ Create table "rule_metadata"
 (
 	"rule_metadata_id" BIGSERIAL,
 	"dev_id" Integer NOT NULL,
-	"rule_uid" Text,
+	"rule_uid" Text NOT NULL,
 	"rule_created" Timestamp NOT NULL Default now(),
 	"rule_last_modified" Timestamp NOT NULL Default now(),
 	"rule_first_hit" Timestamp,
@@ -174,8 +174,9 @@ Create table "rule_metadata"
 	"rule_hit_counter" BIGINT,
 	"rule_last_certified" Timestamp,
 	"rule_last_certifier" Integer,
+	"rule_last_certifier_dn" VARCHAR,
 	"rule_owner" Integer,
-	"rule_group_owner" Varchar, -- distinguished name pointing to ldap group
+	"rule_owner_dn" Varchar, -- distinguished name pointing to ldap group, path or user
 	"rule_to_be_removed" Boolean NOT NULL Default FALSE,
 	"last_change_admin" Integer,
  primary key ("rule_metadata_id")

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -75,6 +75,8 @@ INSERT INTO txt VALUES ('scheduling', 			'German',	'Terminplanung');
 INSERT INTO txt VALUES ('scheduling', 			'English',	'Scheduling');
 INSERT INTO txt VALUES ('archive', 				'German',	'Archiv');
 INSERT INTO txt VALUES ('archive', 				'English',	'Archive');
+INSERT INTO txt VALUES ('recertification', 		'German',	'Rezertifizierung');
+INSERT INTO txt VALUES ('recertification', 		'English',	'Recertification');
 
 -- reporting
 INSERT INTO txt VALUES ('select_device',		'German', 	'Device(s) auswählen');
@@ -287,7 +289,7 @@ INSERT INTO txt VALUES ('roles',		        'German', 	'Rollen');
 INSERT INTO txt VALUES ('roles',		        'English', 	'Roles');
 INSERT INTO txt VALUES ('defaults',		        'German', 	'Voreinstellungen');
 INSERT INTO txt VALUES ('defaults',		        'English', 	'Defaults');
-INSERT INTO txt VALUES ('standards',		    'German', 	'Standards');
+INSERT INTO txt VALUES ('standards',		    'German', 	'Standardeinstellungen');
 INSERT INTO txt VALUES ('standards',		    'English', 	'Defaults');
 INSERT INTO txt VALUES ('password_policy',      'German', 	'Passworteinstellungen');
 INSERT INTO txt VALUES ('password_policy',      'English', 	'Password Policy');
@@ -455,8 +457,16 @@ INSERT INTO txt VALUES ('auto_fill_rsb',        'German', 	'Komplettes Füllen r
 INSERT INTO txt VALUES ('auto_fill_rsb',        'English', 	'Completely auto-fill right sidebar');
 INSERT INTO txt VALUES ('data_retention_time',  'German', 	'Datenaufbewahrungszeit (in Tagen)');
 INSERT INTO txt VALUES ('data_retention_time',  'English', 	'Data retention time (in days)');
-INSERT INTO txt VALUES ('import_sleep_time',    'German', 	'Import Intervall (in Sekunden)');
+INSERT INTO txt VALUES ('import_sleep_time',    'German', 	'Importintervall (in Sekunden)');
 INSERT INTO txt VALUES ('import_sleep_time',    'English', 	'Import sleep time (in seconds)');
+INSERT INTO txt VALUES ('recert_period',        'German', 	'Rezertifizierungsintervall (in Tagen)');
+INSERT INTO txt VALUES ('recert_period',        'English',  'Recertification Period (in days)');
+INSERT INTO txt VALUES ('recert_notice_period', 'German', 	'Rezertifizierungserinnerungsintervall (in Tagen)');
+INSERT INTO txt VALUES ('recert_notice_period', 'English', 	'Recertification Notice Period (in days)');
+INSERT INTO txt VALUES ('recert_display_period','German', 	'Rezertifizierungsanzeigeintervall (in Tagen)');
+INSERT INTO txt VALUES ('recert_display_period','English', 	'Recertification Display Period (in days)');
+INSERT INTO txt VALUES ('rule_rem_grace_period','German', 	'Frist zum Löschen der Regeln (in Tagen)');
+INSERT INTO txt VALUES ('rule_rem_grace_period','English', 	'Rule Removal Grace Period (in days)');
 INSERT INTO txt VALUES ('language_settings',    'German', 	'Spracheinstellungen');
 INSERT INTO txt VALUES ('language_settings',    'English', 	'Language Settings');
 INSERT INTO txt VALUES ('apply_changes',        'German', 	'Änderungen anwenden');
@@ -559,9 +569,28 @@ INSERT INTO txt VALUES ('report_settings',      'German', 	'Reporteinstellungen'
 INSERT INTO txt VALUES ('report_settings',      'English', 	'Report Settings');
 INSERT INTO txt VALUES ('change_language',      'German', 	'Ändern der Passworteinstellungen');
 INSERT INTO txt VALUES ('change_language',      'English', 	'Change Language');
+INSERT INTO txt VALUES ('recert_settings',      'German', 	'Rezertifizierungseinstellungen');
+INSERT INTO txt VALUES ('recert_settings',      'English', 	'Recertification Settings');
 
 
--- user messages (0-999: General, 1000-1999: Reporting, 2000-2999: Schedule, 3000-3999: Archive, 5000-5999: Settings)
+-- text codes (roughly) categorized: 
+-- U: user texts (explanation or confirmation texts)
+-- E: error texts
+-- T: texts from external sources (Ldap, other database tables)
+-- H: help pages (tbd)
+-- 0000-0999: General
+-- 1000-1999: Reporting
+-- 2000-2999: Scheduling
+-- 3000-3999: Archive
+-- 4000-4999: Recertification
+-- 5000-5999: Settings
+--            5000-5099: general
+--            5100-5199: devices
+--            5200-5299: authorization
+--            5300-5399: defaults
+--            5400-5499: personal settings
+
+-- user messages
 INSERT INTO txt VALUES ('U1002', 'German',  'Sind sie sicher, dass sie folgende Reportvorlage löschen wollen: ');
 INSERT INTO txt VALUES ('U1002', 'English', 'Do you really want to delete report template');
 
@@ -597,10 +626,12 @@ INSERT INTO txt VALUES ('U5301', 'German',  'Einstellungen geändert.');
 INSERT INTO txt VALUES ('U5301', 'English', 'Settings changed.');
 INSERT INTO txt VALUES ('U5302', 'German',  'Einstellungen geändert.');
 INSERT INTO txt VALUES ('U5302', 'English', 'Policy changed.');
+INSERT INTO txt VALUES ('U5303', 'German',  '* Einstellungen können vom Nutzer in den persönlichen Einstellungen überschrieben werden.');
+INSERT INTO txt VALUES ('U5303', 'English', '* Settings can be overwritten by user in personal settings.');
 INSERT INTO txt VALUES ('U5401', 'German',  'Passwort geändert.');
 INSERT INTO txt VALUES ('U5401', 'English', 'Password changed.');
 
--- error messages (1-999: General, 1000-1999: Reporting, 2000-2999: Schedule, 3000-3999: Archive, 5000-5999: Settings)
+-- error messages
 INSERT INTO txt VALUES ('E0001', 'German',  'Nicht klassifizierter Fehler: ');
 INSERT INTO txt VALUES ('E0001', 'English', 'Unclassified error: ');
 INSERT INTO txt VALUES ('E0002', 'German',  'Für Details in den Log-Dateien nachsehen!');
@@ -711,18 +742,26 @@ INSERT INTO txt VALUES ('E5263', 'English', 'Pattern Length has to be >= 0');
 INSERT INTO txt VALUES ('E5264', 'German',  'Es gibt bereits eine LDAP-Verbindung mit derselben Adresse und Port');
 INSERT INTO txt VALUES ('E5264', 'English', 'There is already an LDAP connection with the same address and port');
 
-INSERT INTO txt VALUES ('E5301', 'German',  'Konfiguration für defaultLanguage konnte nicht gelesen werden: Wert auf English gesetzt');
-INSERT INTO txt VALUES ('E5301', 'English', 'Error reading Config for defaultLanguage: taking default English');
-INSERT INTO txt VALUES ('E5302', 'German',  'Konfiguration für elementsPerFetch konnte nicht gelesen werden: Wert auf 100 gesetzt');
-INSERT INTO txt VALUES ('E5302', 'English', 'Error reading Config for elementsPerFetch: taking value 100');
-INSERT INTO txt VALUES ('E5303', 'German',  'Konfiguration für maxInitFetch konnte nicht gelesen werden: Wert auf 10 gesetzt');
-INSERT INTO txt VALUES ('E5303', 'English', 'Error reading Config for maxInitFetch: taking value 10');
-INSERT INTO txt VALUES ('E5304', 'German',  'Konfiguration für AutoFillRightSidebar konnte nicht gelesen werden: Wert auf false gesetzt');
-INSERT INTO txt VALUES ('E5304', 'English', 'Error reading Config for AutoFillRightSidebar: taking value false');
-INSERT INTO txt VALUES ('E5305', 'German',  'Konfiguration für dataRetentionTime konnte nicht gelesen werden: Wert auf 731 gesetzt');
-INSERT INTO txt VALUES ('E5305', 'English', 'Error reading Config for dataRetentionTime: taking value 731');
-INSERT INTO txt VALUES ('E5306', 'German',  'Konfiguration für importSleepTime konnte nicht gelesen werden: Wert auf 40 gesetzt');
-INSERT INTO txt VALUES ('E5306', 'English', 'Error reading Config for importSleepTime: taking value 40');
+INSERT INTO txt VALUES ('E5301', 'German',  'Konfiguration für Standardsprache konnte nicht gelesen werden: Wert auf Englisch gesetzt');
+INSERT INTO txt VALUES ('E5301', 'English', 'Error reading Config for default language: taking default English');
+INSERT INTO txt VALUES ('E5302', 'German',  'Konfiguration für pro Abruf geholte Elemente konnte nicht gelesen werden: Wert auf 100 gesetzt');
+INSERT INTO txt VALUES ('E5302', 'English', 'Error reading Config for elements per fetch: taking value 100');
+INSERT INTO txt VALUES ('E5303', 'German',  'Konfiguration für Max initiale Abrufe rechte Randleiste konnte nicht gelesen werden: Wert auf 10 gesetzt');
+INSERT INTO txt VALUES ('E5303', 'English', 'Error reading Config for Max initial fetches right sidebar: taking value 10');
+INSERT INTO txt VALUES ('E5304', 'German',  'Konfiguration für Komplettes Füllen rechte Randleiste konnte nicht gelesen werden: Wert auf false gesetzt');
+INSERT INTO txt VALUES ('E5304', 'English', 'Error reading Config for Completely auto-fill right sidebar: taking value false');
+INSERT INTO txt VALUES ('E5305', 'German',  'Konfiguration für Datenaufbewahrungszeit konnte nicht gelesen werden: Wert auf 731 gesetzt');
+INSERT INTO txt VALUES ('E5305', 'English', 'Error reading Config for Data retention time: taking value 731');
+INSERT INTO txt VALUES ('E5306', 'German',  'Konfiguration für Import Intervall konnte nicht gelesen werden: Wert auf 40 gesetzt');
+INSERT INTO txt VALUES ('E5306', 'English', 'Error reading Config for Import sleep time: taking value 40');
+INSERT INTO txt VALUES ('E5307', 'German',  'Konfiguration für Rezertifizierungsintervall konnte nicht gelesen werden: Wert auf 365 gesetzt');
+INSERT INTO txt VALUES ('E5307', 'English', 'Error reading Config for Recertification Period: taking value 365');
+INSERT INTO txt VALUES ('E5308', 'German',  'Konfiguration für Rezertifizierungserinnerungsintervall konnte nicht gelesen werden: Wert auf 30 gesetzt');
+INSERT INTO txt VALUES ('E5308', 'English', 'Error reading Config for Recertification Notice Period: taking value 30');
+INSERT INTO txt VALUES ('E5309', 'German',  'Konfiguration für Rezertifizierungsanzeigeintervall konnte nicht gelesen werden: Wert auf 30 gesetzt');
+INSERT INTO txt VALUES ('E5309', 'English', 'Error reading Config for Recertification Display Period: taking value 30');
+INSERT INTO txt VALUES ('E5310', 'German',  'Konfiguration für Frist zum Löschen der Regeln konnte nicht gelesen werden: Wert auf 60 gesetzt');
+INSERT INTO txt VALUES ('E5310', 'English', 'Error reading Config for Rule Removal Grace Period: taking value 60');
 INSERT INTO txt VALUES ('E5311', 'German',  'Konfiguration für minLength konnte nicht gelesen werden: Wert auf 10 gesetzt');
 INSERT INTO txt VALUES ('E5311', 'English', 'Error reading Config for minLength: taking value 10');
 INSERT INTO txt VALUES ('E5312', 'German',  'Konfiguration für UpperCaseRequired konnte nicht gelesen werden: Wert auf false gesetzt');
@@ -752,8 +791,8 @@ INSERT INTO txt VALUES ('E5414', 'German',  'Passwort muss mindestens eine Ziffe
 INSERT INTO txt VALUES ('E5414', 'English', 'Password must contain at least one number');
 INSERT INTO txt VALUES ('E5415', 'German',  'Passwort muss mindestens ein Sonderzeichen enthalten (!?(){}=~$%&#*-+.,_)');
 INSERT INTO txt VALUES ('E5415', 'English', 'Password must contain at least one special character (!?(){}=~$%&#*-+.,_)');
-INSERT INTO txt VALUES ('E5421', 'German',  'Schlüssel nicht gefunden oder Wert nicht konvertierbar: Wert wird auf 100 gesetzt');
-INSERT INTO txt VALUES ('E5421', 'English', 'Key not found or could not convert value to int: taking value 100');
+INSERT INTO txt VALUES ('E5421', 'German',  'Schlüssel nicht gefunden oder Wert nicht konvertierbar: Wert wird gesetzt auf: ');
+INSERT INTO txt VALUES ('E5421', 'English', 'Key not found or could not convert value to int: taking value: ');
 
 -- role descriptions
 INSERT INTO txt VALUES ('T0001', 'German',  'kann nur die Anmeldeseite und Systemzustand sehen');
@@ -778,6 +817,8 @@ INSERT INTO txt VALUES ('T0010', 'German',  'Nutzer zum Dokumentieren von offene
 INSERT INTO txt VALUES ('T0010', 'English', 'users who can document open changes');
 INSERT INTO txt VALUES ('T0011', 'German',  'Nutzer mit vollem Zugriff auf den Firewall Orchestrator');
 INSERT INTO txt VALUES ('T0011', 'English', 'users with full access rights to firewall orchestrator');
+INSERT INTO txt VALUES ('T0012', 'German',  'Nutzer mit Berechtigung zum Rezertifizieren von Regeln');
+INSERT INTO txt VALUES ('T0012', 'English', 'users that have the right to recertify rules');
 
 -- template comments
 INSERT INTO txt VALUES ('T0101', 'German',  'Aktuell aktive Regeln aller Gateways');

--- a/roles/database/files/upgrade/5.2.5.sql
+++ b/roles/database/files/upgrade/5.2.5.sql
@@ -1,0 +1,15 @@
+
+Alter table "rule_metadata" ALTER COLUMN "rule_uid" SET NOT NULL;
+
+Alter table "rule_metadata" ADD COLUMN IF NOT EXISTS "rule_last_certifier_dn" Varchar;
+
+DO $$
+BEGIN
+  IF EXISTS(SELECT *
+    FROM information_schema.columns
+    WHERE table_name='rule_metadata' and column_name='rule_group_owner')
+  THEN
+      ALTER TABLE "rule_metadata" RENAME COLUMN "rule_group_owner" TO "rule_owner_dn";
+  END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/roles/lib/files/FWO.ApiConfig/GlobalConfig.cs
+++ b/roles/lib/files/FWO.ApiConfig/GlobalConfig.cs
@@ -25,6 +25,9 @@ namespace FWO.ApiConfig
         /// </summary>
         private readonly APIConnection apiConnection;
 
+        /// <summary>
+        /// Global string constants used e.g. as database keys etc.
+        /// </summary>
         public static readonly string kDefaultLanguage = "DefaultLanguage";
         public static readonly string kEnglish = "English";
         public static readonly string kElementsPerFetch = "elementsPerFetch";
@@ -32,6 +35,10 @@ namespace FWO.ApiConfig
         public static readonly string kAutoFillRightSidebar = "autoFillRightSidebar";
         public static readonly string kDataRetentionTime = "dataRetentionTime";
         public static readonly string kImportSleepTime = "importSleepTime";
+        public static readonly string kRecertificationPeriod = "recertificationPeriod";
+        public static readonly string kRecertificationNoticePeriod = "recertificationNoticePeriod";
+        public static readonly string kRecertificationDisplayPeriod = "recertificationDisplayPeriod";
+        public static readonly string kRuleRemovalGracePeriod = "ruleRemovalGracePeriod";
         public static readonly string kPwMinLength = "pwMinLength";
         public static readonly string kPwUpperCaseRequired = "pwUpperCaseRequired";
         public static readonly string kPwLowerCaseRequired = "pwLowerCaseRequired";

--- a/roles/middleware/templates/ldif_files/tree_roles.ldif.j2
+++ b/roles/middleware/templates/ldif_files/tree_roles.ldif.j2
@@ -117,3 +117,14 @@ cn: admin
 uniqueMember:
 description: T0011
 {%- endif %}
+
+
+dn: cn=recertifier,ou=role,{{ openldap_path }}
+changetype: {{ ldif_changetype }}
+{% if ldif_changetype != 'delete' -%}
+objectClass: top
+objectClass: groupofuniquenames
+cn: recertifier
+uniqueMember:
+description: T0012
+{%- endif %}

--- a/roles/middleware/templates/upgrade/5.2.5.ldif
+++ b/roles/middleware/templates/upgrade/5.2.5.ldif
@@ -1,0 +1,9 @@
+# add new role recertifier
+
+dn: cn=recertifier,ou=role,{{ openldap_path }}
+changetype: add
+objectClass: top
+objectClass: groupofuniquenames
+cn: recertifier
+uniqueMember:
+description: T0012

--- a/roles/test/files/auth/roles.ldif
+++ b/roles/test/files/auth/roles.ldif
@@ -64,3 +64,9 @@ objectClass: top
 objectClass: groupofuniquenames
 cn: admin
 description: T0011
+
+dn: cn=recertifier,ou=role,dc=fworch,dc=internal
+objectClass: top
+objectClass: groupofuniquenames
+cn: recertifier
+description: T0012

--- a/roles/ui/files/FWO_UI/Pages/Settings/SettingsDefaults.razor
+++ b/roles/ui/files/FWO_UI/Pages/Settings/SettingsDefaults.razor
@@ -13,7 +13,7 @@
 <hr />
 
 <form class="form-inline">
-    <label for="languageSelect" class="col-form-label col-sm-3">@(userConfig.GetText("default_language")):</label>
+    <label for="languageSelect" class="col-form-label col-sm-4">@(userConfig.GetText("default_language"))*:</label>
     <div class="col-sm-2">
         <select id="languageSelect" class="form-control form-control-sm" @bind="selectedDefaultLanguage">
             @foreach (Language language in globalConfig.uiLanguages)
@@ -23,39 +23,70 @@
         </select>
     </div>
 </form>
+<hr />
 <form class="form-inline">
-    <label for="elementsPerFetch" class="col-form-label col-sm-3">@(userConfig.GetText("elements_per_fetch")):</label>
+    <label for="elementsPerFetch" class="col-form-label col-sm-4">@(userConfig.GetText("elements_per_fetch"))*:</label>
     <div class="col-sm-2">
         <input id="elementsPerFetch" type="text" class="form-control form-control-sm" @bind="elementsPerFetch" />
     </div>
 </form>
 <form class="form-inline">
-    <label for="maxInitFetch" class="col-form-label col-sm-3">@(userConfig.GetText("max_init_fetch_rsb")):</label>
+    <label for="maxInitFetch" class="col-form-label col-sm-4">@(userConfig.GetText("max_init_fetch_rsb")):</label>
     <div class="col-sm-2">
         <input id="maxInitFetch" type="text" class="form-control form-control-sm" @bind="maxInitFetch" />
     </div>
 </form>
 <form class="form-inline">
-    <label for="autoFillRightSidebar" class="col-form-label col-sm-3">@(userConfig.GetText("auto_fill_rsb")):</label>
+    <label for="autoFillRightSidebar" class="col-form-label col-sm-4">@(userConfig.GetText("auto_fill_rsb")):</label>
     <div class="col-sm-2">
         <input id="autoFillRightSidebar" type="checkbox" class="form-control form-control-sm" @bind="autoFillRightSidebar">
     </div>
 </form>
+<hr />
 <form class="form-inline">
-    <label for="dataRetentionTime" class="col-form-label col-sm-3">@(userConfig.GetText("data_retention_time")):</label>
+    <label for="dataRetentionTime" class="col-form-label col-sm-4">@(userConfig.GetText("data_retention_time")):</label>
     <div class="col-sm-2">
         <input id="dataRetentionTime" type="text" class="form-control form-control-sm" @bind="dataRetentionTime" />
     </div>
 </form>
+<hr />
 <form class="form-inline">
-    <label for="importSleepTime" class="col-form-label col-sm-3">@(userConfig.GetText("import_sleep_time")):</label>
+    <label for="importSleepTime" class="col-form-label col-sm-4">@(userConfig.GetText("import_sleep_time")):</label>
     <div class="col-sm-2">
         <input id="importSleepTime" type="text" class="form-control form-control-sm" @bind="importSleepTime" />
     </div>
 </form>
+<hr />
+<form class="form-inline">
+    <label for="recertificationPeriod" class="col-form-label col-sm-4">@(userConfig.GetText("recert_period")):</label>
+    <div class="col-sm-2">
+        <input id="recertificationPeriod" type="text" class="form-control form-control-sm" @bind="recertificationPeriod" />
+    </div>
+</form>
+<form class="form-inline">
+    <label for="recertificationNoticePeriod" class="col-form-label col-sm-4">@(userConfig.GetText("recert_notice_period")):</label>
+    <div class="col-sm-2">
+        <input id="recertificationNoticePeriod" type="text" class="form-control form-control-sm" @bind="recertificationNoticePeriod" />
+    </div>
+</form>
+<form class="form-inline">
+    <label for="recertificationDisplayPeriod" class="col-form-label col-sm-4">@(userConfig.GetText("recert_display_period"))*:</label>
+    <div class="col-sm-2">
+        <input id="recertificationDisplayPeriod" type="text" class="form-control form-control-sm" @bind="recertificationDisplayPeriod" />
+    </div>
+</form>
+<form class="form-inline">
+    <label for="ruleRemovalGracePeriod" class="col-form-label col-sm-4">@(userConfig.GetText("rule_rem_grace_period")):</label>
+    <div class="col-sm-2">
+        <input id="ruleRemovalGracePeriod" type="text" class="form-control form-control-sm" @bind="ruleRemovalGracePeriod" />
+    </div>
+</form>
+<hr />
 <AuthorizeView Roles="admin">
     <button class="btn btn-sm btn-primary" @onclick="Save" @onclick:preventDefault>@(userConfig.GetText("save"))</button>
 </AuthorizeView>
+<br><br>
+<p>@(userConfig.GetText("U5303"))</p>
 
 @code
 {
@@ -68,6 +99,10 @@
     string selectedDefaultLanguage = GlobalConfig.kEnglish;
     int dataRetentionTime = 731;
     int importSleepTime = 40;
+    int recertificationPeriod = 365;
+    int recertificationNoticePeriod = 30;
+    int recertificationDisplayPeriod = 30;
+    int ruleRemovalGracePeriod = 60;
 
     protected override void OnInitialized()
     {
@@ -131,6 +166,46 @@
         {
             DisplayMessageInUi(exception, userConfig.GetText("read_config"), userConfig.GetText("E5306"), false);
         }
+
+        try
+        {
+            string confValue = config.Get(GlobalConfig.kRecertificationPeriod);
+            recertificationPeriod = (confValue != "" ? Int32.Parse(confValue) : 365);
+        }
+        catch (Exception exception)
+        {
+            DisplayMessageInUi(exception, userConfig.GetText("read_config"), userConfig.GetText("E5307"), false);
+        }
+
+        try
+        {
+            string confValue = config.Get(GlobalConfig.kRecertificationNoticePeriod);
+            recertificationNoticePeriod = (confValue != "" ? Int32.Parse(confValue) : 30);
+        }
+        catch (Exception exception)
+        {
+            DisplayMessageInUi(exception, userConfig.GetText("read_config"), userConfig.GetText("E5308"), false);
+        }
+
+        try
+        {
+            string confValue = config.Get(GlobalConfig.kRecertificationDisplayPeriod);
+            recertificationDisplayPeriod = (confValue != "" ? Int32.Parse(confValue) : 30);
+        }
+        catch (Exception exception)
+        {
+            DisplayMessageInUi(exception, userConfig.GetText("read_config"), userConfig.GetText("E5309"), false);
+        }
+
+        try
+        {
+            string confValue = config.Get(GlobalConfig.kRuleRemovalGracePeriod);
+            ruleRemovalGracePeriod = (confValue != "" ? Int32.Parse(confValue) : 60);
+        }
+        catch (Exception exception)
+        {
+            DisplayMessageInUi(exception, userConfig.GetText("read_config"), userConfig.GetText("E5310"), false);
+        }
     }
 
     private async Task Save()
@@ -141,6 +216,10 @@
         await config.Set(GlobalConfig.kAutoFillRightSidebar, autoFillRightSidebar.ToString());
         await config.Set(GlobalConfig.kDataRetentionTime, dataRetentionTime.ToString());
         await config.Set(GlobalConfig.kImportSleepTime, importSleepTime.ToString());
+        await config.Set(GlobalConfig.kRecertificationPeriod, recertificationPeriod.ToString());
+        await config.Set(GlobalConfig.kRecertificationNoticePeriod, recertificationNoticePeriod.ToString());
+        await config.Set(GlobalConfig.kRecertificationDisplayPeriod, recertificationDisplayPeriod.ToString());
+        await config.Set(GlobalConfig.kRuleRemovalGracePeriod, ruleRemovalGracePeriod.ToString());
 
         await userConfig.ReloadDefaults(apiConnection);
         DisplayMessageInUi(null, userConfig.GetText("change_default"), userConfig.GetText("U5301"), false);

--- a/roles/ui/files/FWO_UI/Pages/Settings/SettingsLanguage.razor
+++ b/roles/ui/files/FWO_UI/Pages/Settings/SettingsLanguage.razor
@@ -20,8 +20,9 @@
             <option value="@(language.Name)">@(userConfig.GetText(language.Name))</option>
         }
     </select>
-    <button class="btn btn-sm btn-success" @onclick="async () => { await ChangeLanguage(selectedLanguage); StateHasChanged(); }" @onclick:preventDefault>@(userConfig.GetText("apply_changes"))</button>
 </form>
+<hr />
+<button class="btn btn-sm btn-primary" @onclick="async () => { await ChangeLanguage(selectedLanguage); StateHasChanged(); }" @onclick:preventDefault>@(userConfig.GetText("apply_changes"))</button>
 
 @code
 {

--- a/roles/ui/files/FWO_UI/Pages/Settings/SettingsPassword.razor
+++ b/roles/ui/files/FWO_UI/Pages/Settings/SettingsPassword.razor
@@ -31,6 +31,7 @@
         </div>
     </div>
 </form>
+<hr />
 <AuthorizeView Roles="admin, reporter, reporter-viewall, workflow-user, workflow-admin">
     <button class="btn btn-sm btn-primary" @onclick:preventDefault="true" @onclick="ChangePassword">@(userConfig.GetText("change_password"))</button>
 </AuthorizeView>

--- a/roles/ui/files/FWO_UI/Pages/Settings/SettingsPasswordPolicy.razor
+++ b/roles/ui/files/FWO_UI/Pages/Settings/SettingsPasswordPolicy.razor
@@ -41,6 +41,7 @@
         <input id="specialCharactersRequired" type="checkbox" class="form-control form-control-sm" @bind="specialCharactersRequired" />
     </div>
 </form>
+<hr />
 <AuthorizeView Roles="admin">
     <button class="btn btn-sm btn-primary" @onclick="Save" @onclick:preventDefault>@(userConfig.GetText("save"))</button>
 </AuthorizeView>

--- a/roles/ui/files/FWO_UI/Pages/Settings/SettingsRecertification.razor
+++ b/roles/ui/files/FWO_UI/Pages/Settings/SettingsRecertification.razor
@@ -1,0 +1,77 @@
+﻿@using FWO.ApiClient
+@using FWO.ApiConfig
+@using FWO.Ui.Services
+
+@page "/settings/recertification"
+@attribute [Authorize(Roles = "admin, recertifier, auditor")]
+
+@inject APIConnection apiConnection
+@inject UserConfig userConfig
+
+<h3>@(userConfig.GetText("recert_settings"))</h3>
+<hr />
+
+<form class="form-inline">
+    <label for="recertificationDisplayPeriod" class="col-form-label mr-2">@(userConfig.GetText("recert_display_period")):</label>
+    <div class="col-sm-2">
+        <input id="recertificationDisplayPeriod" type="number" class="form-control form-control-sm" @bind="recertificationDisplayPeriod" />
+    </div>
+</form>
+<hr />
+<button class="btn btn-sm btn-primary" @onclick="SaveRecertificationDisplayPeriod">@(userConfig.GetText("save"))</button>
+
+
+@code
+{
+    [CascadingParameter]
+    Action<Exception, string, string, bool> DisplayMessageInUi { get; set; }
+
+    [CascadingParameter]
+    private Task<AuthenticationState> authenticationStateTask { get; set; }
+
+    ConfigDbAccess config;
+    int recertificationDisplayPeriod = 30;
+
+    protected override async Task OnInitializedAsync()
+    {
+        AuthenticationState authState = await authenticationStateTask;
+        UiUsersDbAccess uiUser = new UiUsersDbAccess(authState, apiConnection);
+        config = new ConfigDbAccess(apiConnection, uiUser.UiUser.DbId);
+        try
+        {
+            string settingsValue = config.Get(GlobalConfig.kRecertificationDisplayPeriod);
+            if (settingsValue != "")
+            {
+                recertificationDisplayPeriod = Int32.Parse(settingsValue);
+            }
+            else
+            {
+                // get default value
+                ConfigDbAccess defaultConfig = new ConfigDbAccess(apiConnection, 0);
+                settingsValue = defaultConfig.Get(GlobalConfig.kRecertificationDisplayPeriod);
+                if (settingsValue != "")
+                {
+                    recertificationDisplayPeriod = Int32.Parse(settingsValue);
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            DisplayMessageInUi(exception, userConfig.GetText("recert_settings"), userConfig.GetText("E5421")+recertificationDisplayPeriod.ToString(), false);
+        }
+    }
+
+    private async Task SaveRecertificationDisplayPeriod()
+    {
+        string recertificationDisplayPeriodString = recertificationDisplayPeriod.ToString();
+        try
+        {
+            await userConfig.ChangeConfigValue(GlobalConfig.kRecertificationDisplayPeriod, recertificationDisplayPeriodString, apiConnection);
+            DisplayMessageInUi(null, userConfig.GetText("recert_settings"), userConfig.GetText("U5301"), false);
+        }
+        catch (System.Exception exception)
+        {
+            DisplayMessageInUi(exception, userConfig.GetText("recert_settings"), null, true);
+        }
+    }
+}

--- a/roles/ui/files/FWO_UI/Pages/Settings/SettingsReport.razor
+++ b/roles/ui/files/FWO_UI/Pages/Settings/SettingsReport.razor
@@ -20,6 +20,7 @@
         <input id="elementsPerFetch" type="number" class="form-control form-control-sm" @bind="elementsPerFetch" />
     </div>
 </form>
+<hr />
 <button class="btn btn-sm btn-primary" @onclick="SaveElementsPerFetch">@(userConfig.GetText("save"))</button>
 
 
@@ -59,7 +60,7 @@
         }
         catch (Exception exception)
         {
-            DisplayMessageInUi(exception, userConfig.GetText("report_settings"), userConfig.GetText("E5421"), false);
+            DisplayMessageInUi(exception, userConfig.GetText("report_settings"), userConfig.GetText("E5421")+elementsPerFetch.ToString(), false);
         }
     }
 

--- a/roles/ui/files/FWO_UI/Shared/SettingsLayout.razor
+++ b/roles/ui/files/FWO_UI/Shared/SettingsLayout.razor
@@ -94,6 +94,13 @@
                     </NavLink>
                 </li>
             </AuthorizeView>
+            <AuthorizeView Roles="admin, recertifier, auditor">
+                <li class="nav-item px-2">
+                    <NavLink class="nav-link" data-toggle="tooltip" title="Adapt your personal recertification settings" href="settings/recertification">
+                        <span class="oi oi-check"></span> @(userConfig.GetText("recertification"))
+                    </NavLink>
+                </li>
+            </AuthorizeView>
         </ul>
     </div>
 </Sidebar>


### PR DESCRIPTION
- DB changes in rule_metadata
- new role recertifier in Ldap
- new default settings for recertification
- new user settings page for recertification
- some smaller layout changes in settings

to rework
- middleware upgrade file not idempotent (fails at second attempt)
- hasura permissions for recertifier to be reviewed