### PR TITLE
rsb - fixed duplicate users in rule details

### DIFF
--- a/roles/ui/files/FWO_UI/Pages/Certification.razor
+++ b/roles/ui/files/FWO_UI/Pages/Certification.razor
@@ -80,7 +80,7 @@
                                            NameExtractor=@(rule => $"{rule.DeviceName} - Rule {rule.Id} {rule.Name}")
                                            NetworkObjectExtractor="rule => rule.Froms.Select(nl => nl.Object).Union(rule.Tos.Select(nl => nl.Object)).ToArray()"
                                            NetworkServiceExtractor="rule => Array.ConvertAll(rule.Services, wrapper => wrapper.Content)"
-                                           NetworkUserExtractor="rule => Array.FindAll(rule.Froms.Select(nl => nl.User).ToArray(), user => user != null)" />
+                                           NetworkUserExtractor="rule => Array.FindAll(rule.Froms.Select(nl => nl.User).Distinct().ToArray(), user => user != null)" />
                 </CascadingValue>
             </Tab>
         </TabSet>

--- a/roles/ui/files/FWO_UI/Pages/Reporting/Report.razor
+++ b/roles/ui/files/FWO_UI/Pages/Reporting/Report.razor
@@ -148,7 +148,7 @@
                                            NameExtractor=@(rule => $"{rule.DeviceName} - Rule {rule.Id} {rule.Name}")
                                            NetworkObjectExtractor="rule => rule.Froms.Select(nl => nl.Object).Union(rule.Tos.Select(nl => nl.Object)).ToArray()"
                                            NetworkServiceExtractor="rule => Array.ConvertAll(rule.Services, wrapper => wrapper.Content)"
-                                           NetworkUserExtractor="rule => Array.FindAll(rule.Froms.Select(nl => nl.User).ToArray(), user => user != null)" />
+                                           NetworkUserExtractor="rule => Array.FindAll(rule.Froms.Select(nl => nl.User).Distinct().ToArray(), user => user != null)" />
                 </CascadingValue>
             </Tab>
         </TabSet>


### PR DESCRIPTION
src={user1@x, user2@x] should also not be a problem since network objects are already being filtered

(-> #1155)