### PR TITLE
First draft NatRules, translations html report, fixes

### DIFF
--- a/documentation/revision-history.md
+++ b/documentation/revision-history.md
@@ -155,3 +155,6 @@ adding report template format fk and permissions
 - introducing swagger REST API for user management
 - adding swagger REST API interactive documentation for user management
 - moving to hasura 2.0.10 for slight performance boost (see https://github.com/hasura/graphql-engine/releases/tag/v2.0.10)
+
+### 5.5.2 - 06.11.2021
+- new default report template for NAT rules

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ### general settings
-product_version: "5.5.1"
+product_version: "5.5.2"
 ansible_python_interpreter: /usr/bin/python3
 ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 product_name: fworch

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -21,6 +21,8 @@ INSERT INTO "report_template" ("report_filter","report_template_name","report_te
 INSERT INTO "report_template" ("report_filter","report_template_name","report_template_comment","report_template_owner") 
     VALUES ('type=rules and time=now and (src=any or dst=any or svc=any or src=all or dst=all or svc=all) and not(action=drop or action=reject or action=deny) ',
         'Compliance: Pass rules with ANY','T0104', 0);
+INSERT INTO "report_template" ("report_filter","report_template_name","report_template_comment","report_template_owner") 
+    VALUES ('type=natrules and time=now ','Current NAT Rules','T0105', 0);
 
 insert into parent_rule_type (id, name) VALUES (1, 'section');          -- do not restart numbering
 insert into parent_rule_type (id, name) VALUES (2, 'guarded-layer');    -- restart numbering, rule restrictions are ANDed to all rules below it, layer is not entered if guard does not apply

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -222,6 +222,12 @@ INSERT INTO txt VALUES ('destination', 			'German', 	'Ziel');
 INSERT INTO txt VALUES ('destination', 			'English', 	'Destination');
 INSERT INTO txt VALUES ('services', 			'German', 	'Dienste');
 INSERT INTO txt VALUES ('services', 			'English', 	'Services');
+INSERT INTO txt VALUES ('trans_source', 		'German', 	'Umgesetzte Quelle');
+INSERT INTO txt VALUES ('trans_source', 		'English', 	'Translated Source');
+INSERT INTO txt VALUES ('trans_destination', 	'German', 	'Umgesetztes Ziel');
+INSERT INTO txt VALUES ('trans_destination', 	'English', 	'Translated Destination');
+INSERT INTO txt VALUES ('trans_services', 		'German', 	'Umgesetzte Dienste');
+INSERT INTO txt VALUES ('trans_services', 		'English', 	'Translated Services');
 INSERT INTO txt VALUES ('action', 				'German', 	'Aktionen');
 INSERT INTO txt VALUES ('action', 				'English', 	'Actions');
 INSERT INTO txt VALUES ('track', 				'German', 	'Logging');
@@ -230,12 +236,18 @@ INSERT INTO txt VALUES ('disabled',				'German', 	'Deaktiviert');
 INSERT INTO txt VALUES ('disabled',				'English', 	'Disabled');
 INSERT INTO txt VALUES ('comment',				'German', 	'Kommentar');
 INSERT INTO txt VALUES ('comment',				'English', 	'Comment');
+INSERT INTO txt VALUES ('ip_address',		    'German', 	'IP-Adresse');
+INSERT INTO txt VALUES ('ip_address',		    'English', 	'IP Address');
+INSERT INTO txt VALUES ('members',		        'German', 	'Mitglieder');
+INSERT INTO txt VALUES ('members',		        'English', 	'Members');
 INSERT INTO txt VALUES ('templates',			'German', 	'Vorlagen');
 INSERT INTO txt VALUES ('templates',			'English', 	'Templates');
 INSERT INTO txt VALUES ('creation_date',		'German', 	'Erstelldatum');
 INSERT INTO txt VALUES ('creation_date',		'English', 	'Creation Date');
 INSERT INTO txt VALUES ('report_template',		'German', 	'Reportvorlage');
 INSERT INTO txt VALUES ('report_template',		'English', 	'Report Template');
+INSERT INTO txt VALUES ('no_of_obj',		    'German', 	'Anzahl der Objekte');
+INSERT INTO txt VALUES ('no_of_obj',		    'English', 	'Number of Objects');
 INSERT INTO txt VALUES ('glob_no_obj',		    'German', 	'Gesamtzahl der Objekte');
 INSERT INTO txt VALUES ('glob_no_obj',		    'English', 	'Global number of Objects');
 INSERT INTO txt VALUES ('total_no_obj_mgt',		'German', 	'Gesamtzahl der Objekte pro Management');
@@ -245,7 +257,9 @@ INSERT INTO txt VALUES ('no_rules_gtw',		    'English', 	'Number of Rules per Ga
 INSERT INTO txt VALUES ('negated',		        'German', 	'negated');
 INSERT INTO txt VALUES ('negated',		        'English', 	'negiert');
 INSERT INTO txt VALUES ('network_objects',		'German', 	'Netzwerkobjekte');
-INSERT INTO txt VALUES ('network_objects',		'English', 	'Network objects');
+INSERT INTO txt VALUES ('network_objects',		'English', 	'Network Objects');
+INSERT INTO txt VALUES ('network_services',		'German', 	'Netzwerkdienste');
+INSERT INTO txt VALUES ('network_services',		'English', 	'Network Services');
 INSERT INTO txt VALUES ('service_objects',		'German', 	'Serviceobjekte');
 INSERT INTO txt VALUES ('service_objects',		'English', 	'Service objects');
 INSERT INTO txt VALUES ('user_objects',		    'German', 	'Nutzerobjekte');
@@ -270,6 +284,8 @@ INSERT INTO txt VALUES ('source_zone',		    'German', 	'Quellzone');
 INSERT INTO txt VALUES ('source_zone',		    'English', 	'Source Zone');
 INSERT INTO txt VALUES ('destination_zone',		'German', 	'Zielzone');
 INSERT INTO txt VALUES ('destination_zone',		'English', 	'Destination Zone');
+INSERT INTO txt VALUES ('anything_but',		    'German', 	'alles ausser');
+INSERT INTO txt VALUES ('anything_but',		    'English', 	'anything but');
 INSERT INTO txt VALUES ('enabled',		        'German', 	'Aktiviert');
 INSERT INTO txt VALUES ('enabled',		        'English', 	'Enabled');
 INSERT INTO txt VALUES ('uid',		            'German', 	'UID');
@@ -314,6 +330,18 @@ INSERT INTO txt VALUES ('edit_template',        'German', 	'&Auml;ndern der Vorl
 INSERT INTO txt VALUES ('edit_template',        'English', 	'Edit Report Template');
 INSERT INTO txt VALUES ('delete_template',      'German', 	'L&ouml;schen der Vorlage');
 INSERT INTO txt VALUES ('delete_template',      'English', 	'Delete Report Template');
+INSERT INTO txt VALUES ('no_changes_found',	    'German', 	'Keine Changes gefunden!');
+INSERT INTO txt VALUES ('no_changes_found',	    'English', 	'No changes found!');
+INSERT INTO txt VALUES ('rules_report',	        'German', 	'Regel-Report');
+INSERT INTO txt VALUES ('rules_report',	        'English', 	'Rules Report');
+INSERT INTO txt VALUES ('natrules_report',	    'German', 	'NAT-Regel-Report');
+INSERT INTO txt VALUES ('natrules_report',	    'English', 	'NAT Rules Report');
+INSERT INTO txt VALUES ('changes_report',	    'German', 	'Changes-Report');
+INSERT INTO txt VALUES ('changes_report',	    'English', 	'Changes Report');
+INSERT INTO txt VALUES ('statistics_report',	'German', 	'Statistik-Report');
+INSERT INTO txt VALUES ('statistics_report',	'English', 	'Statistics Report');
+INSERT INTO txt VALUES ('generated_on',	        'German', 	'Erstellt am');
+INSERT INTO txt VALUES ('generated_on',	        'English', 	'Generated on');
 
 -- schedule
 INSERT INTO txt VALUES ('schedule', 			'German',	'Terminplan');
@@ -934,6 +962,9 @@ INSERT INTO txt VALUES ('E1001', 'English', 'Please select at least one device i
 INSERT INTO txt VALUES ('E1002', 'German',  'Kein Report vorhanden zum Exportieren. Bitte zuerst Report generieren!');
 INSERT INTO txt VALUES ('E1002', 'English', 'No generated report to export. Please generate report first!');
 
+INSERT INTO txt VALUES ('E2001', 'German',  'Bitte eine Vorlage ausw&auml;hlen');
+INSERT INTO txt VALUES ('E2001', 'English', 'Please select a template');
+
 INSERT INTO txt VALUES ('E4001', 'German',  'Bitte Kommentar hinzuf&uuml;gen');
 INSERT INTO txt VALUES ('E4001', 'English', 'Please insert a comment');
 
@@ -1161,10 +1192,10 @@ INSERT INTO txt VALUES ('H1101', 'English', '<li> All filtering is case insensit
     <li> Rules are always deep-searched, meaning all groups in source, destination and service fields are resolved.
         There is currently no option to only search at the rule top-level.</li>
 ');
-INSERT INTO txt VALUES ('H1111', 'German',  '<li>reporttype (type): M&ouml;gliche Werte: statistics, rules, changes</li>
+INSERT INTO txt VALUES ('H1111', 'German',  '<li>reporttype (type): M&ouml;gliche Werte: statistics, rules, changes, natrule</li>
     <li>time: In Abh&auml;ngigkeit vom Reporttyp werden verschiedene Werte/Formate erwartet:
         <ul>
-            <li>f&uuml;r "rules" oder "statistics" muss ein Datums- oder Zeitwert im Format YYYYMMDD, YYYYMMDD HHMMSS, YYYY-MM-DD ... &uuml;bergeben werden.
+            <li>f&uuml;r "rules", "natrules" oder "statistics" muss ein Datums- oder Zeitwert im Format YYYYMMDD, YYYYMMDD HHMMSS, YYYY-MM-DD ... &uuml;bergeben werden.
                 Zur Vereinfachung kann auch "now" f&uuml;r das aktuelle Datum eingegeben werden.</li>
             <li>f&uuml;r "changes" m&uuml;ssen zwei Datums-/Zeitwerte &uuml;bergeben werden, getrennt durch "/". Als Format wird YYYY-MM-DD oder YY-MM-DD HH:mm[:ss] erwartet.
                 Wenn ein Datum ohne Zeitangabe &uuml;bergeben wird, wird f&uuml;r die Startzeit 00:00:00, f&uuml;r die Endezeit 23:59:59 angenommen.
@@ -1184,10 +1215,10 @@ INSERT INTO txt VALUES ('H1111', 'German',  '<li>reporttype (type): M&ouml;glich
     <li>recertdisplay (recertdisp): Definiert den Zeitraum f&uuml;r die Vorausschau (in Tagen) f&uuml;r die n&auml;chste Rezertifizierung. Nur Regeln in diesem Zeitfenster werden gesucht.</li>
     <li>fulltext (full, fulltextsearch, fts, text, textsearch)</li>
 ');
-INSERT INTO txt VALUES ('H1111', 'English', '<li>reporttype (type): Possible Values: statistics, rules, changes</li>
+INSERT INTO txt VALUES ('H1111', 'English', '<li>reporttype (type): Possible Values: statistics, rules, changes, natrules</li>
     <li>time: Depending on report type there are different possible Values/Formats: 
         <ul>
-            <li>for "rules" or "statistics" there has to be one date or date/time value YYYYMMDD, YYYYMMDD HHMMSS, YYYY-MM-DD ... 
+            <li>for "rules", "natrules" or "statistics" there has to be one date or date/time value YYYYMMDD, YYYYMMDD HHMMSS, YYYY-MM-DD ... 
                 As a shortcut also "now" is possible.</li>
             <li>for "changes" two dates have to be given separated by "/". The format of each date is expexted as YYYY-MM-DD or YY-MM-DD HH:mm[:ss].
                 If a date without time is given, for the start date 00:00:00 is assumed, for the end date 23:59:59.

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -1139,6 +1139,8 @@ INSERT INTO txt VALUES ('T0103', 'German',  'Anzahl der Objekte und Regeln pro D
 INSERT INTO txt VALUES ('T0103', 'English', 'Number of objects and rules per device');
 INSERT INTO txt VALUES ('T0104', 'German',  'Alle Regeln, die offene Quellen, Ziele oder Dienste haben');
 INSERT INTO txt VALUES ('T0104', 'English', 'All pass rules that contain any as source, destination or service');
+INSERT INTO txt VALUES ('T0105', 'German',  'Aktuell aktive NAT-Regeln aller Gateways');
+INSERT INTO txt VALUES ('T0105', 'English', 'Currently active NAT rules of all gateways');
 
 -- help pages
 INSERT INTO txt VALUES ('H0001', 'German',  'Firewall Orchestrator ist eine Anwendung zum Erzeugen und Verwalten von verschiedenen Reports aus Konfigurationsdaten verteilter Firewallsysteme.

--- a/roles/database/files/upgrade/5.5.2.sql
+++ b/roles/database/files/upgrade/5.5.2.sql
@@ -1,0 +1,2 @@
+INSERT INTO "report_template" ("report_filter","report_template_name","report_template_comment","report_template_owner") 
+    VALUES ('type=natrules and time=now ','Current NAT Rules','T0105', 0);

--- a/roles/lib/files/FWO.Api.Client/APIConnection.cs
+++ b/roles/lib/files/FWO.Api.Client/APIConnection.cs
@@ -103,7 +103,7 @@ namespace FWO.ApiClient
 
             catch (Exception exception)
             {
-                Log.WriteError("API Connection", $"Error while sending query to GraphQL API. Query: {query}, variables: {variables.ToString()}", exception);
+                Log.WriteError("API Connection", $"Error while sending query to GraphQL API. Query: {(query != null ? query : "")}, variables: {(variables != null ? variables.ToString() : "")}", exception);
                 // todo: #1220 add variables readable
                 throw;
             }

--- a/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleDetails.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleDetails.graphql
@@ -3,10 +3,13 @@ fragment natRuleDetails on rule {
   translate: ruleByXlateRule {
     rule_src
     rule_src_refs
+    rule_src_neg
     rule_dst
     rule_dst_refs
+    rule_dst_neg
     rule_svc
     rule_svc_refs
+    rule_svc_neg
     rule_froms {
       usr {
         ...userDetails

--- a/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleDetails.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleDetails.graphql
@@ -1,0 +1,29 @@
+fragment natRuleDetails on rule {
+  ...ruleDetails
+  translate: ruleByXlateRule {
+    rule_src
+    rule_src_refs
+    rule_dst
+    rule_dst_refs
+    rule_svc
+    rule_svc_refs
+    rule_froms {
+      usr {
+        ...userDetails
+      }
+      object {
+        ...networkObjectDetails
+      }
+    }
+    rule_tos {
+      object {
+        ...networkObjectDetails
+      }
+    }
+    rule_services {
+      service {
+        ...networkServiceDetails
+      }
+    }
+  }
+}

--- a/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleDetailsForReport.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleDetailsForReport.graphql
@@ -3,10 +3,13 @@
   translate: ruleByXlateRule {
     rule_src
     rule_src_refs
+    rule_src_neg
     rule_dst
     rule_dst_refs
+    rule_dst_neg
     rule_svc
     rule_svc_refs
+    rule_svc_neg
     rule_froms(where: {object:{obj_create:{_lte:$relevantImportId}, obj_last_seen:{_gte:$relevantImportId}}}) {
       usr {
         ...userDetails

--- a/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleDetailsForReport.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleDetailsForReport.graphql
@@ -1,0 +1,29 @@
+﻿fragment natRuleDetails on rule {
+  ...ruleDetails
+  translate: ruleByXlateRule {
+    rule_src
+    rule_src_refs
+    rule_dst
+    rule_dst_refs
+    rule_svc
+    rule_svc_refs
+    rule_froms(where: {object:{obj_create:{_lte:$relevantImportId}, obj_last_seen:{_gte:$relevantImportId}}}) {
+      usr {
+        ...userDetails
+      }
+      object {
+        ...networkObjectDetails
+      }
+    }
+    rule_tos(where: {object:{obj_create:{_lte:$relevantImportId}, obj_last_seen:{_gte:$relevantImportId}}}) {
+      object {
+        ...networkObjectDetails
+      }
+    }
+    rule_services(where: {service:{svc_create:{_lte:$relevantImportId}, svc_last_seen:{_gte:$relevantImportId}}}) {
+      service {
+        ...networkServiceDetails
+      }
+    }
+  }
+}

--- a/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleOverview.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleOverview.graphql
@@ -1,0 +1,29 @@
+fragment natRuleOverview on rule {
+  ...ruleOverview
+  translate: ruleByXlateRule {
+    rule_src
+    rule_src_refs
+    rule_dst
+    rule_dst_refs
+    rule_svc
+    rule_svc_refs
+    rule_froms(where: {object:{obj_create:{_lte:$relevantImportId}, obj_last_seen:{_gte:$relevantImportId}}}) {
+      usr {
+        ...userOverview
+      }
+      object {
+        ...networkObjectOverview
+      }
+    }
+    rule_tos(where: {object:{obj_create:{_lte:$relevantImportId}, obj_last_seen:{_gte:$relevantImportId}}}) {
+      object {
+        ...networkObjectOverview
+      }
+    }
+    rule_services(where: {service:{svc_create:{_lte:$relevantImportId}, svc_last_seen:{_gte:$relevantImportId}}}) {
+      service {
+        ...networkServiceOverview
+      }
+    }
+  }
+}

--- a/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleOverview.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/rule/fragments/natRuleOverview.graphql
@@ -3,10 +3,13 @@ fragment natRuleOverview on rule {
   translate: ruleByXlateRule {
     rule_src
     rule_src_refs
+    rule_src_neg
     rule_dst
     rule_dst_refs
+    rule_dst_neg
     rule_svc
     rule_svc_refs
+    rule_svc_neg
     rule_froms(where: {object:{obj_create:{_lte:$relevantImportId}, obj_last_seen:{_gte:$relevantImportId}}}) {
       usr {
         ...userOverview

--- a/roles/lib/files/FWO.Api.Client/APIcalls/rule/getNatRuleDetails.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/rule/getNatRuleDetails.graphql
@@ -1,0 +1,40 @@
+query listNatRulesDetails(
+  $management_id: [Int!]
+  $device_id: [Int!]
+  $rule_id: [bigint!]
+  $rule_uid: [String!]
+  $ruleSrcName: [String!]
+  $ruleSrcIp: [cidr!]
+  $limit: Int
+  $offset: Int
+) {
+  management(
+    where: { mgm_id: { _in: $management_id } }
+    order_by: { mgm_name: asc }
+  ) {
+    id: mgm_id
+    name: mgm_name
+    devices(
+      where: { dev_id: { _in: $device_id } }
+      order_by: { dev_name: asc }
+    ) {
+      dev_id
+      dev_name
+      rules(
+        limit: $limit
+        offset: $offset
+        where: {
+          rule_id: { _in: $rule_id }
+          rule_uid: { _in: $rule_uid }
+          active: { _eq: true }
+          rule_src: { _in: $ruleSrcName }
+          rule_froms: { object: { obj_ip: { _in: $ruleSrcIp } } }
+          nat_rule: { _eq: true }
+        }
+        order_by: { rule_num_numeric: asc }
+      ) {
+        ...natRuleDetails
+      }
+    }
+  }
+}

--- a/roles/lib/files/FWO.Api.Client/APIcalls/rule/getNatRuleOverview.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/rule/getNatRuleOverview.graphql
@@ -33,15 +33,21 @@ query getNatRulesOverview($mgmId: [Int!], $device_id: [Int!]) {
         rule_src
         rule_dst
         rule_svc
+        rule_src_neg
+        rule_dst_neg
+        rule_svc_neg
         access_rule
         nat_rule
         translate: ruleByXlateRule {
           rule_src
           rule_src_refs
+          rule_src_neg
           rule_dst
           rule_dst_refs
+          rule_dst_neg
           rule_svc
           rule_svc_refs
+          rule_svc_neg
         }
       }
     }

--- a/roles/lib/files/FWO.Api.Client/Data/NatData.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/NatData.cs
@@ -1,0 +1,36 @@
+﻿using System.Text.Json.Serialization;
+
+namespace FWO.Api.Data
+{
+    public class NatData
+    {
+        [JsonPropertyName("rule_svc_neg")]
+        public bool TranslatedServiceNegated { get; set; }
+
+        [JsonPropertyName("rule_svc")]
+        public string TranslatedService { get; set; }
+
+        [JsonPropertyName("rule_services")]
+        public ServiceWrapper[] TranslatedServices { get; set; }
+
+
+        [JsonPropertyName("rule_src_neg")]
+        public bool TranslatedSourceNegated { get; set; }
+
+        [JsonPropertyName("rule_src")]
+        public string TranslatedSource { get; set; }
+
+        [JsonPropertyName("rule_froms")]
+        public NetworkLocation[] TranslatedFroms { get; set; }
+
+
+        [JsonPropertyName("rule_dst_neg")]
+        public bool TranslatedDestinationNegated { get; set; }
+
+        [JsonPropertyName("rule_dst")]
+        public string TranslatedDestination { get; set; }
+
+        [JsonPropertyName("rule_tos")]
+        public NetworkLocation[] TranslatedTos { get; set; }
+    }
+}

--- a/roles/lib/files/FWO.Api.Client/Data/Rule.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/Rule.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Security;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
 namespace FWO.Api.Data
 {
@@ -73,6 +66,9 @@ namespace FWO.Api.Data
 
         [JsonPropertyName("rule_metadatum")]
         public RuleMetadata Metadata {get; set;}
+
+        [JsonPropertyName("translate")]
+        public NatData NatData {get; set;}
 
         public bool Certified { get; set; }
         public string DeviceName { get; set; }

--- a/roles/lib/files/FWO.Api.Client/Queries/RuleQueries.cs
+++ b/roles/lib/files/FWO.Api.Client/Queries/RuleQueries.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.IO;
 using FWO.Logging;
 
@@ -19,6 +16,13 @@ namespace FWO.ApiClient.Queries
         public static readonly string getRuleIdsOfImport;
         public static readonly string updateRuleMetadataRecert;
         public static readonly string updateRuleMetadataDecert;
+
+        public static readonly string natRuleOverviewFragments;
+        public static readonly string natRuleDetailsFragments;
+        public static readonly string natRuleDetailsForReportFragments;
+        public static readonly string getNatRuleOverview;
+        public static readonly string getNatRuleDetails;
+        public static readonly string getNatRuleDetailsForReport;
 
         static RuleQueries()
         {
@@ -63,6 +67,33 @@ namespace FWO.ApiClient.Queries
 
                 updateRuleMetadataDecert =
                     File.ReadAllText(QueryPath + "rule/updateRuleMetadataDecert.graphql");
+
+
+                natRuleOverviewFragments = ruleOverviewFragments +
+                    File.ReadAllText(QueryPath + "rule/fragments/natRuleOverview.graphql");
+
+                getNatRuleOverview = natRuleOverviewFragments + File.ReadAllText(QueryPath + "rule/getNatRuleOverview.graphql");
+
+                natRuleDetailsFragments =
+                    ObjectQueries.networkObjectDetailsFragment +
+                    ObjectQueries.networkServiceObjectDetailsFragment +
+                    ObjectQueries.userDetailsFragment +
+                    File.ReadAllText(QueryPath + "rule/fragments/natRuleDetails.graphql");
+
+                natRuleDetailsForReportFragments =
+                    ObjectQueries.networkObjectDetailsFragment +
+                    ObjectQueries.networkServiceObjectDetailsFragment +
+                    ObjectQueries.userDetailsFragment +
+                    File.ReadAllText(QueryPath + "rule/fragments/natRuleDetailsForReport.graphql");
+
+                getNatRuleDetails =
+                    natRuleDetailsFragments +
+                    File.ReadAllText(QueryPath + "rule/getNatRuleDetails.graphql");
+
+                getNatRuleDetailsForReport =
+                    natRuleDetailsForReportFragments +
+                    File.ReadAllText(QueryPath + "rule/getNatRuleDetails.graphql");
+
             }
             catch (Exception exception)
             {

--- a/roles/lib/files/FWO.Report.Filter/Ast/AstNodeFilter.cs
+++ b/roles/lib/files/FWO.Report.Filter/Ast/AstNodeFilter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Text;
 using FWO.Logging;
 using FWO.Report.Filter.Exceptions;
 
@@ -50,7 +49,7 @@ namespace FWO.Report.Filter.Ast
 
         private DynGraphqlQuery ExtractTimeQuery(DynGraphqlQuery query)
         {
-            if (query.ReportType == "rules" || query.ReportType == "statistics")
+            if (query.ReportType == "rules" || query.ReportType == "natrules" || query.ReportType == "statistics")
             {
                 query.ruleWhereStatement +=
                     $"import_control: {{ control_id: {{_lte: $relevantImportId }} }}, " +

--- a/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
+++ b/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
@@ -140,6 +140,33 @@ namespace FWO.Report.Filter
                         }}
                     ";
                     break;
+
+                case "natrules":
+                    query.FullQuery = $@"
+                    {(detailed ? RuleQueries.natRuleDetailsForReportFragments : RuleQueries.natRuleOverviewFragments)}
+
+                    query natRulesReport ({paramString}) 
+                    {{ 
+                        management( where: {{ mgm_id: {{_in: $mgmId }}, hide_in_gui: {{_eq: false }} }} order_by: {{ mgm_name: asc }} ) 
+                            {{
+                                id: mgm_id
+                                name: mgm_name
+                                devices ( where: {{ hide_in_gui: {{_eq: false }} }} order_by: {{ dev_name: asc }} ) 
+                                    {{
+                                        id: dev_id
+                                        name: dev_name
+                                        rules(
+                                            limit: $limit 
+                                            offset: $offset
+                                            where: {{  nat_rule: {{_eq: true}}, ruleByXlateRule: {{}} {query.ruleWhereStatement} }} 
+                                            order_by: {{ rule_num_numeric: asc }} )
+                                            {{
+                                                ...{(detailed ? "natRuleDetails" : "natRuleOverview")}
+                                            }} 
+                                    }}
+                            }} 
+                    }}";
+                    break;
             }
 
             // remove line breaks and duplicate whitespaces

--- a/roles/lib/files/FWO.Report/Display/NatRuleDisplay.cs
+++ b/roles/lib/files/FWO.Report/Display/NatRuleDisplay.cs
@@ -38,12 +38,13 @@ namespace FWO.Ui.Display
             }
             result.AppendLine("</p>");
 
-            string translSrc = result.ToString();
-            if(translSrc == DisplaySource(rule, style))
-            {
-                return "origin";
-            }
-            return translSrc;
+//            string translSrc = result.ToString();
+//            if(translSrc == DisplaySource(rule, style))
+//            {
+//                return "origin";
+//            }
+//            return translSrc;
+            return result.ToString();
         }
 
         public string DisplayTranslatedDestination(Rule rule, string style = "")
@@ -73,12 +74,13 @@ namespace FWO.Ui.Display
             }
             result.AppendLine("</p>");
 
-            string translDst = result.ToString();
-            if(translDst == DisplayDestination(rule, style))
-            {
-                return "origin";
-            }
-            return translDst;
+//            string translDst = result.ToString();
+//            if(translDst == DisplayDestination(rule, style))
+//            {
+//                return "origin";
+//            }
+//            return translDst;
+            return result.ToString();
         }
 
         public string DisplayTranslatedService(Rule rule, string style = "")
@@ -109,12 +111,13 @@ namespace FWO.Ui.Display
             }
             result.AppendLine("</p>");
 
-            string translSvc = result.ToString();
-            if(translSvc == DisplayService(rule, style))
-            {
-                return "origin";
-            }
-            return translSvc;
+//            string translSvc = result.ToString();
+//            if(translSvc == DisplayService(rule, style))
+//            {
+//                return "origin";
+//            }
+//            return translSvc;
+            return result.ToString();
         }
     }
 }

--- a/roles/lib/files/FWO.Report/Display/NatRuleDisplay.cs
+++ b/roles/lib/files/FWO.Report/Display/NatRuleDisplay.cs
@@ -1,58 +1,27 @@
 ﻿using FWO.Api.Data;
 using FWO.Config.Api;
-using System;
 using System.Text;
 
 namespace FWO.Ui.Display
 {
-    public class RuleDisplay
+    public class NatRuleDisplay : RuleDisplay
     {
-        protected StringBuilder result;
-        protected UserConfig userConfig;
+        public NatRuleDisplay(UserConfig userConfig) : base(userConfig)
+        {}
 
-        public RuleDisplay(UserConfig userConfig)
-        {
-            this.userConfig = userConfig;
-        }
-
-        public string DisplayNumber(Rule rule, Rule[] rules)
-        {
-            result = new StringBuilder();
-            if (rules != null)
-            {
-                int ruleNumber = Array.IndexOf(rules, rule) + 1;
-
-                for (int i = 0; i < Array.IndexOf(rules, rule) + 1; i++)
-                    if (!string.IsNullOrEmpty(rules[i].SectionHeader))
-                        ruleNumber--;
-
-                result.AppendLine($"{ruleNumber}");
-            }
-            //result.AppendLine($"DEBUG: {rule.OrderNumber}");
-            return result.ToString();
-        }
-
-        public string DisplayName(Rule rule)
-        {
-            return rule.Name;
-        }
-
-        public string DisplaySourceZone(Rule rule)
-        {
-            return rule.SourceZone?.Name;
-        }
-
-        public string DisplaySource(Rule rule, string style = "")
+        public string DisplayTranslatedSource(Rule rule, string style = "")
         {
             result = new StringBuilder();
 
             result.AppendLine("<p>");
 
-            if (rule.SourceNegated)
+            if (rule.NatData.TranslatedSourceNegated)
+            {
                 result.AppendLine(userConfig.GetText("anything_but") + " <br>");
+            }
 
             string symbol = "";
-            foreach (NetworkLocation source in rule.Froms)
+            foreach (NetworkLocation source in rule.NatData.TranslatedFroms)
             {
                 if (source.Object.Type.Name == "group")
                     symbol = "oi oi-list-rich";
@@ -67,30 +36,29 @@ namespace FWO.Ui.Display
                 result.Append((source.Object.IP != null ? $" ({source.Object.IP})" : ""));
                 result.AppendLine("<br>");
             }
-
             result.AppendLine("</p>");
 
-            return result.ToString();
+            string translSrc = result.ToString();
+            if(translSrc == DisplaySource(rule, style))
+            {
+                return "origin";
+            }
+            return translSrc;
         }
 
-        public string DisplayDestinationZone(Rule rule)
-        {
-            return rule.DestinationZone?.Name;
-        }
-
-        public string DisplayDestination(Rule rule, string style = "")
+        public string DisplayTranslatedDestination(Rule rule, string style = "")
         {
             result = new StringBuilder();
 
             result.AppendLine("<p>");
 
-            if (rule.DestinationNegated)
+            if (rule.NatData.TranslatedDestinationNegated)
             {
                 result.AppendLine(userConfig.GetText("anything_but") + " <br>");
             }
 
             string symbol = "";
-            foreach (NetworkLocation destination in rule.Tos)
+            foreach (NetworkLocation destination in rule.NatData.TranslatedTos)
             {
                 if (destination.Object.Type.Name == "group")
                     symbol = "oi oi-list-rich";
@@ -103,25 +71,29 @@ namespace FWO.Ui.Display
                 result.Append(destination.Object.IP != null ? $" ({destination.Object.IP})" : "");
                 result.AppendLine("<br>");
             }
-
             result.AppendLine("</p>");
 
-            return result.ToString();
+            string translDst = result.ToString();
+            if(translDst == DisplayDestination(rule, style))
+            {
+                return "origin";
+            }
+            return translDst;
         }
 
-        public string DisplayService(Rule rule, string style = "")
+        public string DisplayTranslatedService(Rule rule, string style = "")
         {
             result = new StringBuilder();
 
             result.AppendLine("<p>");
 
-            if (rule.ServiceNegated)
+            if (rule.NatData.TranslatedServiceNegated)
             {
                 result.AppendLine(userConfig.GetText("anything_but") + " <br>");
             }
 
             string symbol = "";
-            foreach (ServiceWrapper service in rule.Services)
+            foreach (ServiceWrapper service in rule.NatData.TranslatedServices)
             {
                 if (service.Content.Type.Name == "group")
                     symbol = "oi oi-list-rich";
@@ -135,42 +107,14 @@ namespace FWO.Ui.Display
                         : $" ({service.Content.DestinationPort}-{service.Content.DestinationPortEnd}/{service.Content.Protocol?.Name})");
                 result.AppendLine("<br>");
             }
-
             result.AppendLine("</p>");
 
-            return result.ToString();
-        }
-
-        public string DisplayAction(Rule rule)
-        {
-            return rule.Action;
-        }
-
-        public string DisplayTrack(Rule rule)
-        {
-            return rule.Track;
-        }
-
-        public string DisplayEnabled(Rule rule, bool export = false)
-        {
-            if (export)
+            string translSvc = result.ToString();
+            if(translSvc == DisplayService(rule, style))
             {
-                return $"<b>{(rule.Disabled ? "N" : "Y")}</b>";
+                return "origin";
             }
-            else
-            {
-                return $"<div class=\"oi {(rule.Disabled ? "oi-x" : "oi-check")}\"></div>";
-            }
-        }
-
-        public string DisplayUid(Rule rule)
-        {
-            return rule.Uid;
-        }
-
-        public string DisplayComment(Rule rule)
-        {
-            return rule.Comment;
+            return translSvc;
         }
     }
 }

--- a/roles/lib/files/FWO.Report/Display/RuleChangeDisplay.cs
+++ b/roles/lib/files/FWO.Report/Display/RuleChangeDisplay.cs
@@ -218,8 +218,8 @@ namespace FWO.Ui.Display
                 }
 
                 return string.Join("<br>", unchanged) 
-                       + (deleted.Count > 0 ? $" deleted: <p style=\"color: red; text-decoration: line-through red;\">{string.Join("<br>", deleted)}</p>" : "")
-                       + (added.Count > 0 ? $" added: <p style=\"color: green; text-decoration: bold;\">{string.Join("<br>", added)}</p>" : "");
+                       + (deleted.Count > 0 ? $" {userConfig.GetText("deleted")}: <p style=\"color: red; text-decoration: line-through red;\">{string.Join("<br>", deleted)}</p>" : "")
+                       + (added.Count > 0 ? $" {userConfig.GetText("added")}: <p style=\"color: green; text-decoration: bold;\">{string.Join("<br>", added)}</p>" : "");
             }
         }
         

--- a/roles/lib/files/FWO.Report/ReportBase.cs
+++ b/roles/lib/files/FWO.Report/ReportBase.cs
@@ -1,12 +1,11 @@
 ﻿using FWO.ApiClient;
 using FWO.Api.Data;
 using FWO.Report.Filter;
+using FWO.Config.Api;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using FWO.ApiClient.Queries;
 using System.Text.Json;
 using System.Text;
 using WkHtmlToPdfDotNet;
@@ -45,7 +44,7 @@ namespace FWO.Report
     </head>
     <body>
         <h2>##Title##</h2>
-        <p>Filter: ##Filter## - Generated on: ##Date##</p>
+        <p>Filter: ##Filter## - ##GeneratedOn##: ##Date##</p>
         <hr>
         ##Body##
     </body>
@@ -57,15 +56,17 @@ namespace FWO.Report
         
 
         public readonly DynGraphqlQuery Query;
+        protected UserConfig userConfig;
 
         private string htmlExport = "";
 
         // Pdf converter
         protected static readonly SynchronizedConverter converter = new SynchronizedConverter(new PdfTools());
 
-        public ReportBase(DynGraphqlQuery query)
+        public ReportBase(DynGraphqlQuery query, UserConfig UserConfig)
         {
             Query = query;
+            userConfig = UserConfig;
         }
 
         public abstract Task Generate(int rulesPerFetch, APIConnection apiConnection, Func<Management[], Task> callback);
@@ -91,6 +92,7 @@ namespace FWO.Report
                 HtmlTemplate = HtmlTemplate.Replace("##Title##", title);
                 HtmlTemplate = HtmlTemplate.Replace("##Filter##", filter);
                 HtmlTemplate = HtmlTemplate.Replace("##Date##", date.ToString());
+                HtmlTemplate = HtmlTemplate.Replace("##GeneratedOn##", userConfig.GetText("generated_on"));
                 htmlExport = HtmlTemplate.ToString();
             }
             return htmlExport;
@@ -140,15 +142,16 @@ namespace FWO.Report
             //}
         }
 
-        public static ReportBase ConstructReport(string filterInput)
+        public static ReportBase ConstructReport(string filterInput, UserConfig userConfig)
         {
             DynGraphqlQuery query = Compiler.Compile(filterInput);
 
             return query.ReportType switch
             {
-                "statistics" => new ReportStatistics(query),
-                "rules" => new ReportRules(query),
-                "changes" => new ReportChanges(query),
+                "statistics" => new ReportStatistics(query, userConfig),
+                "rules" => new ReportRules(query, userConfig),
+                "changes" => new ReportChanges(query, userConfig),
+                "natrules" => new ReportNatRules(query, userConfig),
                 _ => throw new NotSupportedException("Report Type is not supported."),
             };
         }

--- a/roles/lib/files/FWO.Report/ReportChanges.cs
+++ b/roles/lib/files/FWO.Report/ReportChanges.cs
@@ -1,7 +1,6 @@
 ﻿using FWO.Api.Data;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,12 +8,13 @@ using FWO.ApiClient;
 using FWO.Report.Filter;
 using FWO.ApiClient.Queries;
 using FWO.Ui.Display;
+using FWO.Config.Api;
 
 namespace FWO.Report
 {
     public class ReportChanges : ReportBase
     {
-        public ReportChanges(DynGraphqlQuery query) : base(query) { }
+        public ReportChanges(DynGraphqlQuery query, UserConfig userConfig) : base(query, userConfig) { }
 
         public override async Task GetObjectsInReport(int objectsPerFetch, APIConnection apiConnection, Func<Management[], Task> callback)
         {
@@ -70,7 +70,7 @@ namespace FWO.Report
         public override string ExportToHtml()
         {
             StringBuilder report = new StringBuilder();
-            RuleChangeDisplay ruleChangeDisplay = new RuleChangeDisplay(null); // TODO: Add real UserConfig     
+            RuleChangeDisplay ruleChangeDisplay = new RuleChangeDisplay(userConfig);
 
             foreach (Management management in Managements.Where(mgt => !mgt.Ignore))
             {
@@ -84,19 +84,19 @@ namespace FWO.Report
 
                     report.AppendLine("<table>");
                     report.AppendLine("<tr>");
-                    report.AppendLine("<th>Change Time</th>");
-                    report.AppendLine("<th>Change Type</th>");
-                    report.AppendLine("<th>Name</th>");
-                    report.AppendLine("<th>Source Zone</th>");
-                    report.AppendLine("<th>Source</th>");
-                    report.AppendLine("<th>Destination Zone</th>");
-                    report.AppendLine("<th>Destination</th>");
-                    report.AppendLine("<th>Services</th>");
-                    report.AppendLine("<th>Action</th>");
-                    report.AppendLine("<th>Track</th>");
-                    report.AppendLine("<th>Enabled</th>");
-                    report.AppendLine("<th>UID</th>");
-                    report.AppendLine("<th>Comment</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("change_time")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("change_type")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("name")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("source_zone")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("source")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("destination_zone")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("destination")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("services")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("action")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("track")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("enabled")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("uid")}</th>");
+                    report.AppendLine($"<th>{userConfig.GetText("comment")}</th>");
                     report.AppendLine("</tr>");
 
                     if (device.RuleChanges.Length > 0)
@@ -123,7 +123,7 @@ namespace FWO.Report
                     else
                     {
                         report.AppendLine("<tr>");
-                        report.AppendLine($"<td colspan=\"{ColumnCount}\">No changes found!</td>");
+                        report.AppendLine($"<td colspan=\"{ColumnCount}\">{userConfig.GetText("no_changes_found")}</td>");
                         report.AppendLine("</tr>");
                     }
 
@@ -131,7 +131,7 @@ namespace FWO.Report
                 }
             }
 
-            return GenerateHtmlFrame(title: "Changes Report", Query.RawFilter, DateTime.Now, report);
+            return GenerateHtmlFrame(title: userConfig.GetText("changes_report"), Query.RawFilter, DateTime.Now, report);
         }
     }
 }

--- a/roles/lib/files/FWO.Report/ReportNatRules.cs
+++ b/roles/lib/files/FWO.Report/ReportNatRules.cs
@@ -7,16 +7,15 @@ using System.Threading.Tasks;
 using FWO.ApiClient;
 using FWO.Report.Filter;
 using FWO.ApiClient.Queries;
-using System.Text.Json;
 using FWO.Ui.Display;
 using FWO.Logging;
 using FWO.Config.Api;
 
 namespace FWO.Report
 {
-    public class ReportRules : ReportBase
+    public class ReportNatRules : ReportBase
     {
-        public ReportRules(DynGraphqlQuery query, UserConfig userConfig) : base(query, userConfig) { }
+        public ReportNatRules(DynGraphqlQuery query, UserConfig userConfig) : base(query, userConfig) { }
 
         private const byte all = 0, nobj = 1, nsrv = 2, user = 3;
         public bool GotReportedRuleIds { get; protected set; } = false;
@@ -209,7 +208,7 @@ namespace FWO.Report
         public override string ExportToHtml()
         {
             StringBuilder report = new StringBuilder();
-            RuleDisplay ruleDisplay = new RuleDisplay(userConfig);
+            NatRuleDisplay ruleDisplay = new NatRuleDisplay(userConfig);
 
             foreach (Management management in Managements.Where(mgt => !mgt.Ignore))
             {
@@ -232,6 +231,9 @@ namespace FWO.Report
                         report.AppendLine($"<th>{userConfig.GetText("destination_zone")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("destination")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("services")}</th>");
+                        report.AppendLine($"<th>{userConfig.GetText("trans_source")}</th>");
+                        report.AppendLine($"<th>{userConfig.GetText("trans_destination")}</th>");
+                        report.AppendLine($"<th>{userConfig.GetText("trans_services")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("action")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("track")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("enabled")}</th>");
@@ -251,6 +253,9 @@ namespace FWO.Report
                                 report.AppendLine($"<td>{ruleDisplay.DisplayDestinationZone(rule)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayDestination(rule)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayService(rule)}</td>");
+                                report.AppendLine($"<td>{ruleDisplay.DisplayTranslatedSource(rule)}</td>");
+                                report.AppendLine($"<td>{ruleDisplay.DisplayTranslatedDestination(rule)}</td>");
+                                report.AppendLine($"<td>{ruleDisplay.DisplayTranslatedService(rule)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayAction(rule)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayTrack(rule)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayEnabled(rule, export: true)}</td>");
@@ -377,7 +382,7 @@ namespace FWO.Report
                 report.AppendLine("</table>");
             }
 
-            return GenerateHtmlFrame(title: userConfig.GetText("rules_report"), Query.RawFilter, DateTime.Now, report);
+            return GenerateHtmlFrame(title: userConfig.GetText("natrules_report"), Query.RawFilter, DateTime.Now, report);
         }
     }
 }

--- a/roles/lib/files/FWO.Report/ReportNatRules.cs
+++ b/roles/lib/files/FWO.Report/ReportNatRules.cs
@@ -234,8 +234,6 @@ namespace FWO.Report
                         report.AppendLine($"<th>{userConfig.GetText("trans_source")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("trans_destination")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("trans_services")}</th>");
-                        report.AppendLine($"<th>{userConfig.GetText("action")}</th>");
-                        report.AppendLine($"<th>{userConfig.GetText("track")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("enabled")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("uid")}</th>");
                         report.AppendLine($"<th>{userConfig.GetText("comment")}</th>");
@@ -256,8 +254,6 @@ namespace FWO.Report
                                 report.AppendLine($"<td>{ruleDisplay.DisplayTranslatedSource(rule)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayTranslatedDestination(rule)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayTranslatedService(rule)}</td>");
-                                report.AppendLine($"<td>{ruleDisplay.DisplayAction(rule)}</td>");
-                                report.AppendLine($"<td>{ruleDisplay.DisplayTrack(rule)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayEnabled(rule, export: true)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayUid(rule)}</td>");
                                 report.AppendLine($"<td>{ruleDisplay.DisplayComment(rule)}</td>");

--- a/roles/lib/files/FWO.Report/ReportStatistics.cs
+++ b/roles/lib/files/FWO.Report/ReportStatistics.cs
@@ -1,7 +1,6 @@
 using FWO.Api.Data;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,6 +8,7 @@ using FWO.ApiClient;
 using FWO.Report.Filter;
 using FWO.ApiClient.Queries;
 using System.Text.Json;
+using FWO.Config.Api;
 
 namespace FWO.Report
 {
@@ -17,7 +17,7 @@ namespace FWO.Report
         // TODO: Currently generated in Report.razor as well as here, because of export. Remove dupliacte.
         private Management globalStatisticsManagament = new Management();
 
-        public ReportStatistics(DynGraphqlQuery query) : base(query) { }
+        public ReportStatistics(DynGraphqlQuery query, UserConfig userConfig) : base(query, userConfig) { }
 
         public override async Task GetObjectsInReport(int objectsPerFetch, APIConnection apiConnection, Func<Management[], Task> callback)
         {
@@ -98,13 +98,13 @@ namespace FWO.Report
         {
             StringBuilder report = new StringBuilder();
 
-            report.AppendLine($"<h3>Global number of Objects</h3>");
+            report.AppendLine($"<h3>{userConfig.GetText("glob_no_obj")}</h3>");
             report.AppendLine("<table>");
             report.AppendLine("<tr>");
-            report.AppendLine("<th>Network objects</th>");
-            report.AppendLine("<th>Service objects</th>");
-            report.AppendLine("<th>User objects</th>");
-            report.AppendLine("<th>Rules</th>");
+            report.AppendLine($"<th>{userConfig.GetText("network_objects")}</th>");
+            report.AppendLine($"<th>{userConfig.GetText("service_objects")}</th>");
+            report.AppendLine($"<th>{userConfig.GetText("user_objects")}</th>");
+            report.AppendLine($"<th>{userConfig.GetText("rules")}</th>");
             report.AppendLine("</tr>");
             report.AppendLine("<tr>");
             report.AppendLine($"<td>{globalStatisticsManagament.NetworkObjectStatistics.ObjectAggregate.ObjectCount}</td>");
@@ -117,13 +117,13 @@ namespace FWO.Report
 
             foreach (Management management in Managements.Where(mgt => !mgt.Ignore))
             {
-                report.AppendLine($"<h4>Number of Objects - {management.Name}</h4>");
+                report.AppendLine($"<h4>{userConfig.GetText("no_of_obj")} - {management.Name}</h4>");
                 report.AppendLine("<table>");
                 report.AppendLine("<tr>");
-                report.AppendLine("<th>Network objects</th>");
-                report.AppendLine("<th>Service objects</th>");
-                report.AppendLine("<th>User objects</th>");
-                report.AppendLine("<th>Rules</th>");
+                report.AppendLine($"<th>{userConfig.GetText("network_objects")}</th>");
+                report.AppendLine($"<th>{userConfig.GetText("service_objects")}</th>");
+                report.AppendLine($"<th>{userConfig.GetText("user_objects")}</th>");
+                report.AppendLine($"<th>{userConfig.GetText("rules")}</th>");
                 report.AppendLine("</tr>");
                 report.AppendLine("<tr>");
                 report.AppendLine($"<td>{management.NetworkObjectStatistics.ObjectAggregate.ObjectCount}</td>");
@@ -134,11 +134,11 @@ namespace FWO.Report
                 report.AppendLine("</table>");
                 report.AppendLine("<br>");
 
-                report.AppendLine($"<h4>Number of Rules per Gateway</h4>");
+                report.AppendLine($"<h4>{userConfig.GetText("no_rules_gtw")}</h4>");
                 report.AppendLine("<table>");
                 report.AppendLine("<tr>");
-                report.AppendLine("<th>Gateway</th>");
-                report.AppendLine("<th>Rules</th>");
+                report.AppendLine($"<th>{userConfig.GetText("gateway")}</th>");
+                report.AppendLine($"<th>{userConfig.GetText("rules")}</th>");
                 report.AppendLine("</tr>");
                 foreach (Device device in management.Devices)
                 {
@@ -151,7 +151,7 @@ namespace FWO.Report
                 report.AppendLine("<hr>");
             }
 
-            return GenerateHtmlFrame(title: "Statistic Report", Query.RawFilter, DateTime.Now, report);
+            return GenerateHtmlFrame(title: userConfig.GetText("statistics_report"), Query.RawFilter, DateTime.Now, report);
         }
     }
 }

--- a/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
@@ -1,6 +1,7 @@
 ﻿using FWO.Api.Data;
 using FWO.ApiClient;
 using FWO.ApiClient.Queries;
+using FWO.Config.Api;
 using FWO.Logging;
 using FWO.Middleware.Controllers;
 using FWO.Report;
@@ -136,9 +137,11 @@ namespace FWO.Middleware.Server
                     
                     report.Owner.Roles = await authHandler.GetRoles(report.Owner);
                     report.Owner.Tenant = await authHandler.GetTenantAsync(report.Owner);
-                    APIConnection apiConnectionUserContext = new APIConnection(apiServerUri, await jwtWriter.CreateJWT(report.Owner));
+                    string jwt = await jwtWriter.CreateJWT(report.Owner);
+                    APIConnection apiConnectionUserContext = new APIConnection(apiServerUri, jwt);
 
-                    ReportBase reportRules = ReportBase.ConstructReport(report.Template.Filter);
+                    UserConfig userConfig = new UserConfig(new GlobalConfig(jwt));
+                    ReportBase reportRules = ReportBase.ConstructReport(report.Template.Filter, userConfig);
                     await reportRules.Generate
                     (
                         int.MaxValue,

--- a/roles/ui/files/FWO.UI/Pages/Certification.razor
+++ b/roles/ui/files/FWO.UI/Pages/Certification.razor
@@ -173,7 +173,7 @@
             DeviceFilter.syncFilterLineToLSBFilter(filterInput, managements);
             SyncFilterToDisplay();
 
-            currentReport = ReportBase.ConstructReport(filterInput);
+            currentReport = ReportBase.ConstructReport(filterInput, userConfig);
             if (!DeviceFilter.isAnyDeviceFilterSet(managements, currentReport.Query))  // display pop-up with warning, todo: check if device is selected in filter line
             {
                 DisplayMessageInUi(null, userConfig.GetText("no_device_selected"), userConfig.GetText("E1001"), true);

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Archive.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Archive.razor
@@ -8,7 +8,7 @@
 
 <h3>@(userConfig.GetText("archive"))</h3>
 
-<Table TableClass="table table-bordered table-sm table-responsive" TableItem="ReportFile" Items="archivedReports">
+<Table TableClass="table table-bordered table-sm table-responsive" TableItem="ReportFile" Items="archivedReports" PageSize="0">
     <Column TableItem="ReportFile" Title="@(userConfig.GetText("action"))">
         <Template>
             <div class="btn-group">

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Report.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Report.razor
@@ -1,12 +1,8 @@
 @using FWO.Config.Api
 @using FWO.Report
-@using FWO.Ui.Display
 @using FWO.Report.Filter
 @using FWO.Report.Filter.Exceptions
-@using System.Text
 @using System
-@using System.Collections
-@using FWO.Ui.Services
 @using FWO.Ui.Data
 @using FWO.Ui.Pages.Reporting.Reports
 
@@ -68,6 +64,10 @@
                 {
                     case ReportRules rulesReport:
                         <RulesReport Managements="managementsReport" RulesPerPage="rulesPerPage" @bind-SelectedRules="selectedItemsRuleReportTable"></RulesReport>
+                        break;
+
+                    case ReportNatRules natRulesReport:
+                        <RulesReport NatRules="true" Managements="managementsReport" RulesPerPage="rulesPerPage" @bind-SelectedRules="selectedItemsRuleReportTable"></RulesReport>
                         break;
 
                     case ReportChanges changesReport:
@@ -340,7 +340,7 @@
             // when generating report, filter line overrules LSB filter, as this can be triggered by changing the filter line and pressing enter
             DeviceFilter.syncFilterLineToLSBFilter(filterInput, managementsReport);
 
-            currentReport = ReportBase.ConstructReport(filterInput);
+            currentReport = ReportBase.ConstructReport(filterInput, userConfig);
             if (!DeviceFilter.isAnyDeviceFilterSet(managementsReport, currentReport.Query))  // display warning
             {
                 DisplayMessageInUi(null, userConfig.GetText("no_device_selected"), userConfig.GetText("E1001"), true);
@@ -355,16 +355,8 @@
             switch (currentReport)
             {
                 case ReportRules rulesReport:
-                    await currentReport.Generate(elementsPerFetch, Connection,
-                        managementsReportIntermediate =>
-                        {
-                            managementsReport = managementsReportIntermediate;
-                            setRelevantManagements(relevantManagements);
-                            return InvokeAsync(StateHasChanged);
-                        });
-                    break;
-
                 case ReportChanges changesReport:
+                case ReportNatRules natRulesReport:
                     await currentReport.Generate(elementsPerFetch, Connection,
                         managementsReportIntermediate =>
                         {

--- a/roles/ui/files/FWO.UI/Pages/Reporting/ReportTemplateComponent.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/ReportTemplateComponent.razor
@@ -7,7 +7,7 @@
 <div class="mr-1 ml-1 mb-1 shadow">
     <Collapse Title="@(userConfig.GetText("templates"))" Style="@("primary")" @ref="collapseControl">
         <div class="card-body">
-            <Table TableClass="table table-bordered table-sm table-responsive" TableItem="ReportTemplate" Items="reportTemplates">
+            <Table TableClass="table table-bordered table-sm table-responsive" TableItem="ReportTemplate" Items="reportTemplates" PageSize="0">
                 <Column Title="@(userConfig.GetText("action"))" TableItem="ReportTemplate">
                     <Template Context="template">
                         <div class="btn-group">
@@ -35,7 +35,7 @@
                 </Column>
                 <Column Title="@(userConfig.GetText("comment"))" TableItem="ReportTemplate" Field="x => x.Comment" >
                     <Template>
-                        @if (context.Comment.StartsWith("T01"))
+                        @if (context.Comment != null && context.Comment.StartsWith("T01"))
                         {
                             @(userConfig.GetText(context.Comment))
                         }

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/ChangesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/ChangesReport.razor
@@ -132,5 +132,10 @@
     [Parameter]
     public Management[] Managements { get; set; }
 
-    public RuleChangeDisplay ruleChangeDisplay = new RuleChangeDisplay(null); // TODO: add real user config (injection)
+    public RuleChangeDisplay ruleChangeDisplay;
+
+    protected override void OnInitialized()
+    {
+        ruleChangeDisplay = new RuleChangeDisplay(userConfig);
+    }
 }

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
@@ -108,6 +108,24 @@
                                     </Template>
                                 </Column>
                             }
+                            @if(NatRules)
+                            {
+                                <Column TableItem="Rule" Context="rule" Title="@(userConfig.GetText("trans_source"))" Field="@(rChange => rChange.Name)" Sortable="true" Filterable="false" Hideable="true">
+                                    <Template>
+                                        @((MarkupString)ruleDisplay.DisplayTranslatedSource(rule))
+                                    </Template>
+                                </Column>
+                                <Column TableItem="Rule" Context="rule" Title="@(userConfig.GetText("trans_destination"))" Field="@(rChange => rChange.Name)" Sortable="true" Filterable="false" Hideable="true">
+                                    <Template>
+                                        @((MarkupString)ruleDisplay.DisplayTranslatedDestination(rule))
+                                    </Template>
+                                </Column>
+                                <Column TableItem="Rule" Context="rule" Title="@(userConfig.GetText("trans_services"))" Field="@(rChange => rChange.Name)" Sortable="true" Filterable="false" Hideable="true">
+                                    <Template>
+                                        @((MarkupString)ruleDisplay.DisplayTranslatedService(rule))
+                                    </Template>
+                                </Column>
+                            }
                             @if (EmptyColumns[7] == false)
                             {
                                 <Column TableItem="Rule" Title="@(userConfig.GetText("action"))" Field="@(rChange => rChange.Action)" Sortable="true" Filterable="false" Hideable="true" />
@@ -169,6 +187,9 @@
     public bool Recertification { get; set; }
 
     [Parameter]
+    public bool NatRules { get; set; }
+
+    [Parameter]
     public EventCallback<List<Rule>> SelectedRulesChanged { get; set; }
 
     [Parameter]
@@ -190,5 +211,11 @@
     private const int ColumnsCount = 12;
     private bool[] EmptyColumns = new bool[ColumnsCount];
 
-    private RuleDisplay ruleDisplay = new RuleDisplay(null);
+    private NatRuleDisplay ruleDisplay;
+    
+    protected override void OnInitialized()
+    {
+        ruleDisplay = new NatRuleDisplay(userConfig);
+    }
+
 }

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
@@ -126,11 +126,11 @@
                                     </Template>
                                 </Column>
                             }
-                            @if (EmptyColumns[7] == false)
+                            @if (EmptyColumns[7] == false && !NatRules)
                             {
                                 <Column TableItem="Rule" Title="@(userConfig.GetText("action"))" Field="@(rChange => rChange.Action)" Sortable="true" Filterable="false" Hideable="true" />
                             }
-                            @if (EmptyColumns[8] == false)
+                            @if (EmptyColumns[8] == false && !NatRules)
                             {
                                 <Column TableItem="Rule" Title="@(userConfig.GetText("track"))" Field="@(rChange => rChange.Track)" Sortable="true" Filterable="false" Hideable="true" />
                             }

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
@@ -10,7 +10,7 @@
 
 <button class="btn btn-sm btn-success mb-1" @onclick="() => { scheduledReportInEdit = new ScheduledReport() { RepeatInterval = Interval.Never }; ShowSaveScheduledReportDialog = true; }">@(userConfig.GetText("add"))</button>
 
-<Table TableClass="table table-bordered table-sm table-responsive" TableItem="ScheduledReport" Items="scheduledReports">
+<Table TableClass="table table-bordered table-sm table-responsive" TableItem="ScheduledReport" Items="scheduledReports" PageSize="0">
     <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("action"))">
         <Template>
             @if (context.Owner.DbId == uiUserDbId || authenticationState.User.IsInRole("admin"))
@@ -189,37 +189,40 @@
             //$report_schedule_every: Int! # every x days/weeks/months/years
             //$report_schedule_active: Boolean!
 
-            // Add report schedule to DB
-            dynamic queryVariablesReportSchedule = new
+            if (checkInput())
             {
-                report_schedule_name = scheduledReportInEdit.Name,
-                report_schedule_owner_id = uiUserDbId,
-                report_schedule_template_id = scheduledReportInEdit.Template.Id,
-                report_schedule_start_time = scheduledReportInEdit.StartTime,
-                report_schedule_repeat = scheduledReportInEdit.RepeatOffset,
-                report_schedule_every = (int)scheduledReportInEdit.RepeatInterval,
-                report_schedule_active = scheduledReportInEdit.Active,
-                report_schedule_formats = new { data = scheduledReportInEdit.OutputFormat }
-            };
-            scheduledReportInEdit.Id = (await apiConnection.SendQueryAsync<NewReturning>(ReportQueries.addReportSchedule, queryVariablesReportSchedule)).ReturnIds[0].NewId;
+                // Add report schedule to DB
+                dynamic queryVariablesReportSchedule = new
+                {
+                    report_schedule_name = scheduledReportInEdit.Name,
+                    report_schedule_owner_id = uiUserDbId,
+                    report_schedule_template_id = scheduledReportInEdit.Template.Id,
+                    report_schedule_start_time = scheduledReportInEdit.StartTime,
+                    report_schedule_repeat = scheduledReportInEdit.RepeatOffset,
+                    report_schedule_every = (int)scheduledReportInEdit.RepeatInterval,
+                    report_schedule_active = scheduledReportInEdit.Active,
+                    report_schedule_formats = new { data = scheduledReportInEdit.OutputFormat }
+                };
+                scheduledReportInEdit.Id = (await apiConnection.SendQueryAsync<NewReturning>(ReportQueries.addReportSchedule, queryVariablesReportSchedule)).ReturnIds[0].NewId;
 
-            //// Add report schedule output format to DB (needs to be seperated because of unknown report schedule id)
-            //var queryVariablesReportScheduleOutputFormat = new
-            //{
-            //    report_schedule_ids_formats = new
-            //    {
-            //        data = scheduledReportInEdit.OutputFormat.ConvertAll(format =>
-            //        new { report_schedule_format_name = format.Name, report_schedule_id = scheduledReportInEdit.Id }).ToArray()
-            //    }
-            //};
+                //// Add report schedule output format to DB (needs to be seperated because of unknown report schedule id)
+                //var queryVariablesReportScheduleOutputFormat = new
+                //{
+                //    report_schedule_ids_formats = new
+                //    {
+                //        data = scheduledReportInEdit.OutputFormat.ConvertAll(format =>
+                //        new { report_schedule_format_name = format.Name, report_schedule_id = scheduledReportInEdit.Id }).ToArray()
+                //    }
+                //};
 
-            ////string test = JsonSerializer.Serialize(queryVariablesReportScheduleOutputFormat, new JsonSerializerOptions { WriteIndented = true });
-            //ReturnId test = await apiConnection.SendQueryAsync<ReturnId>(ReportQueries.addReportScheduleFileFormats, queryVariablesReportScheduleOutputFormat);
+                ////string test = JsonSerializer.Serialize(queryVariablesReportScheduleOutputFormat, new JsonSerializerOptions { WriteIndented = true });
+                //ReturnId test = await apiConnection.SendQueryAsync<ReturnId>(ReportQueries.addReportScheduleFileFormats, queryVariablesReportScheduleOutputFormat);
 
-            // Update scheduled reports
-            scheduledReports = (await apiConnection.SendQueryAsync<ScheduledReport[]>(ReportQueries.getReportSchedules)).ToList();
+                // Update scheduled reports
+                scheduledReports = (await apiConnection.SendQueryAsync<ScheduledReport[]>(ReportQueries.getReportSchedules)).ToList();
 
-            ShowSaveScheduledReportDialog = false;
+                ShowSaveScheduledReportDialog = false;
+            }
         }
         catch (Exception exception)
         {
@@ -232,25 +235,28 @@
     {
         try
         {
-            var queryVariables = new
+            if (checkInput())
             {
-                report_schedule_id = scheduledReportInEdit.Id,
-                report_schedule_name = scheduledReportInEdit.Name,
-                report_schedule_owner_id = uiUserDbId,
-                report_schedule_template_id = scheduledReportInEdit.Template.Id,
-                report_schedule_start_time = scheduledReportInEdit.StartTime,
-                report_schedule_repeat = scheduledReportInEdit.RepeatOffset,
-                report_schedule_every = (int)scheduledReportInEdit.RepeatInterval,
-                report_schedule_active = scheduledReportInEdit.Active,
-                report_schedule_format_names = scheduledReportInEdit.OutputFormat.ConvertAll(format => format.Name),
-                report_schedule_format_rel = scheduledReportInEdit.OutputFormat.ConvertAll(format =>
-                new { report_schedule_format_name = format.Name, report_schedule_id = scheduledReportInEdit.Id })
-            };
+                var queryVariables = new
+                {
+                    report_schedule_id = scheduledReportInEdit.Id,
+                    report_schedule_name = scheduledReportInEdit.Name,
+                    report_schedule_owner_id = uiUserDbId,
+                    report_schedule_template_id = scheduledReportInEdit.Template.Id,
+                    report_schedule_start_time = scheduledReportInEdit.StartTime,
+                    report_schedule_repeat = scheduledReportInEdit.RepeatOffset,
+                    report_schedule_every = (int)scheduledReportInEdit.RepeatInterval,
+                    report_schedule_active = scheduledReportInEdit.Active,
+                    report_schedule_format_names = scheduledReportInEdit.OutputFormat.ConvertAll(format => format.Name),
+                    report_schedule_format_rel = scheduledReportInEdit.OutputFormat.ConvertAll(format =>
+                    new { report_schedule_format_name = format.Name, report_schedule_id = scheduledReportInEdit.Id })
+                };
 
-            await apiConnection.SendQueryAsync<object>(ReportQueries.editReportSchedule, queryVariables);
-            scheduledReports = (await apiConnection.SendQueryAsync<ScheduledReport[]>(ReportQueries.getReportSchedules)).ToList();
+                await apiConnection.SendQueryAsync<object>(ReportQueries.editReportSchedule, queryVariables);
+                scheduledReports = (await apiConnection.SendQueryAsync<ScheduledReport[]>(ReportQueries.getReportSchedules)).ToList();
 
-            ShowEditScheduledReportDialog = false;
+                ShowEditScheduledReportDialog = false;
+            }
         }
         catch (Exception exception)
         {
@@ -279,4 +285,14 @@
             DisplayMessageInUi(exception, userConfig.GetText("delete_scheduled_report"), null, false);
         }
     }
+
+        private bool checkInput()
+        {
+            if(scheduledReportInEdit.Template == null || scheduledReportInEdit.Template.Id == 0)
+            {
+                DisplayMessageInUi(null, userConfig.GetText("edit_scheduled_report"), userConfig.GetText("E2001"), true);
+                return false;
+            }
+            return true;
+        }
 }


### PR DESCRIPTION
- first throw NatRule report: still close to normal rule report + many things to discuss
- translations in html export, report headers, tables -> scheduled reports appear still in Default Language, maybe there is a better way for/than the creation of a new userConfig
- smaller fixes:
  - allow more than 10 output rows for templates, schedules + archived reports
  - avoid some exceptions for uninitialized objects
  - copy/paste error
-> there is still a strange duplication of scheduled reports (except nat reports), one of them seeming to use very old translations. Maybe this disappears with a new installation resp. doesn't appear for other users at all.