### PR TITLE
UI: sanitize all input fields

### DIFF
--- a/roles/importer/files/importer/fortiadom5ff/fwcommon.py
+++ b/roles/importer/files/importer/fortiadom5ff/fwcommon.py
@@ -11,7 +11,9 @@ import getter, fmgr_network, fmgr_rule, fmgr_zone, fmgr_service, fmgr_user
 
 scope = ['global', 'adom']
 
-rule_access_scope = ['rules_global_header_v4', 'rules_global_header_v6', 'rules_adom_v4', 'rules_adom_v6', 'rules_global_footer_v4', 'rules_global_footer_v6']
+rule_access_scope_v4 = ['rules_global_header_v4', 'rules_adom_v4', 'rules_global_footer_v4']
+rule_access_scope_v6 = ['rules_global_header_v6', 'rules_adom_v6', 'rules_global_footer_v6']
+rule_access_scope = rule_access_scope_v6 + rule_access_scope_v4
 rule_nat_scope = ['rules_global_nat', 'rules_adom_nat']
 rule_scope = rule_access_scope + rule_nat_scope
 

--- a/roles/lib/files/FWO.Api.Client/Data/Device.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/Device.cs
@@ -78,6 +78,15 @@ namespace FWO.Api.Data
                 }
             }
         }
+
+        public void Sanitize()
+        {
+            Name = Sanitizer.SanitizeOpt(Name);
+            LocalRulebase = Sanitizer.SanitizeOpt(LocalRulebase);
+            GlobalRulebase = Sanitizer.SanitizeOpt(GlobalRulebase);
+            Package = Sanitizer.SanitizeOpt(Package);
+            Comment = Sanitizer.SanitizeOpt(Comment);
+        }
     }
 
 

--- a/roles/lib/files/FWO.Api.Client/Data/Management.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/Management.cs
@@ -156,6 +156,18 @@ namespace FWO.Api.Data
                 device.AssignRuleNumbers();
             }
         }
+
+        public void Sanitize()
+        {
+            Name = Sanitizer.SanitizeMand(Name);
+            Hostname = Sanitizer.SanitizeMand(Hostname);
+            ImportUser = Sanitizer.SanitizeOpt(ImportUser);
+            ConfigPath = Sanitizer.SanitizeMand(ConfigPath);
+            ImporterHostname = Sanitizer.SanitizeMand(ImporterHostname);
+            Comment = Sanitizer.SanitizeOpt(Comment);
+            PublicKey = Sanitizer.SanitizePasswOpt(PublicKey);
+            PrivateKey = Sanitizer.SanitizePasswMand(PrivateKey);
+        }
     }
 
     public static class ManagementUtility

--- a/roles/lib/files/FWO.Api.Client/Data/ReportFile.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/ReportFile.cs
@@ -40,5 +40,10 @@ namespace FWO.Api.Data
 
         [JsonProperty("report_csv"), JsonPropertyName("report_csv")]
         public string? Csv { get; set; }
+
+        public void Sanitize()
+        {
+            Name = Sanitizer.SanitizeMand(Name);
+        }
     }
 }

--- a/roles/lib/files/FWO.Api.Client/Data/ReportTemplate.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/ReportTemplate.cs
@@ -36,6 +36,12 @@ namespace FWO.Api.Data
             ReportParams.DeviceFilter = deviceFilter;
             ReportParams.ReportType = reportType;
         }
+
+        public void Sanitize()
+        {
+            Name = Sanitizer.SanitizeMand(Name);
+            Comment = Sanitizer.SanitizeMand(Comment);
+        }
     }
 
     public class ReportParams

--- a/roles/lib/files/FWO.Api.Client/Data/Sanitizer.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/Sanitizer.cs
@@ -1,0 +1,35 @@
+﻿using System.Text.RegularExpressions;
+
+namespace FWO.Api.Data
+{
+    public class Sanitizer
+    {
+        public static string? SanitizeOpt(string? input)
+        {
+            if (input != null)
+            {
+                return SanitizeMand(input);
+            }
+            else return null;
+        }
+
+        public static string SanitizeMand(string input)
+        {
+            return Regex.Replace(input, @"[^\w\.\*\-\:\?@/\(\)]", "").Trim();
+        }
+
+        public static string? SanitizePasswOpt(string? input)
+        {
+            if (input != null)
+            {
+                return SanitizePasswMand(input);
+            }
+            else return null;
+        }
+
+        public static string SanitizePasswMand(string input)
+        {
+            return Regex.Replace(input, @"[^\S ]", "").Trim();
+        }
+    }
+}

--- a/roles/lib/files/FWO.Api.Client/Data/ScheduledReport.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/ScheduledReport.cs
@@ -31,6 +31,11 @@ namespace FWO.Api.Data
 
         [JsonProperty("report_schedule_active"), JsonPropertyName("report_schedule_active")]
         public bool Active { get; set; }
+
+        public void Sanitize()
+        {
+            Name = Sanitizer.SanitizeMand(Name);
+        }
     }
 
     public enum Interval

--- a/roles/lib/files/FWO.Api.Client/Data/Tenant.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/Tenant.cs
@@ -83,6 +83,13 @@ namespace FWO.Api.Data
             return string.Join(", ", deviceList);
         }
 
+        public void Sanitize()
+        {
+            Name = Sanitizer.SanitizeMand(Name);
+            Comment = Sanitizer.SanitizeOpt(Comment);
+            Project = Sanitizer.SanitizeOpt(Project);
+        }
+
         public TenantGetReturnParameters ToApiParams()
         {
             TenantGetReturnParameters tenantGetParams = new TenantGetReturnParameters

--- a/roles/lib/files/FWO.Api.Client/Data/UiLdapConnection.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/UiLdapConnection.cs
@@ -57,6 +57,20 @@ namespace FWO.Api.Data
             GlobalTenantName = ldapConnection.GlobalTenantName;
         }
 
+        public void Sanitize()
+        {
+            Name = Sanitizer.SanitizeMand(Name);
+            Address = Sanitizer.SanitizeMand(Address);
+            SearchUser = Sanitizer.SanitizeOpt(SearchUser);
+            UserSearchPath = Sanitizer.SanitizeOpt(UserSearchPath);
+            RoleSearchPath = Sanitizer.SanitizeOpt(RoleSearchPath);
+            GroupSearchPath = Sanitizer.SanitizeOpt(GroupSearchPath);
+            WriteUser = Sanitizer.SanitizeOpt(WriteUser);
+            GlobalTenantName = Sanitizer.SanitizeOpt(GlobalTenantName);
+            SearchUserPwd = Sanitizer.SanitizePasswOpt(SearchUserPwd);
+            WriteUserPwd = Sanitizer.SanitizePasswOpt(WriteUserPwd);
+        }
+
         public LdapGetUpdateParameters ToApiParams()
         {
             return new LdapGetUpdateParameters

--- a/roles/lib/files/FWO.Api.Client/Data/UiUser.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/UiUser.cs
@@ -100,6 +100,13 @@ namespace FWO.Api.Data
             return new DistName(Dn).IsInternal();
         }
 
+        public void Sanitize()
+        {
+            Name = Sanitizer.SanitizeMand(Name);
+            Email = Sanitizer.SanitizeOpt(Email);
+            Password = Sanitizer.SanitizePasswMand(Password);
+        }
+
         public UserGetReturnParameters ToApiParams()
         {
             return new UserGetReturnParameters

--- a/roles/lib/files/FWO.Api.Client/Data/UserGroup.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/UserGroup.cs
@@ -27,5 +27,10 @@
             }
             return string.Join(", ", userNames);
         }
+
+        public void Sanitize()
+        {
+            Name = Sanitizer.SanitizeMand(Name);
+        }
     }
 }

--- a/roles/ui/files/FWO.UI/Pages/Certification.razor
+++ b/roles/ui/files/FWO.UI/Pages/Certification.razor
@@ -397,6 +397,7 @@
 
     private async Task ExecuteSelected()
     {
+        actComment = Sanitizer.SanitizeMand(actComment);
         if(commentRequired && actComment == "")
         {
             DisplayMessageInUi!(null, userConfig.GetText("execute_selected"), userConfig.GetText("E4001"), true);

--- a/roles/ui/files/FWO.UI/Pages/Reporting/ReportExport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/ReportExport.razor
@@ -114,6 +114,7 @@
 
     private async Task Export()
     {
+        reportExportFile.Sanitize();
         if (ReportToExport != null)
         {
             await Task.Run(async () =>

--- a/roles/ui/files/FWO.UI/Pages/Reporting/ReportTemplateComponent.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/ReportTemplateComponent.razor
@@ -163,6 +163,7 @@
     {
         try
         {
+            reportTemplateInEdit.Sanitize();
             reportTemplateInEdit.CreationDate = DateTime.Now;
             reportTemplateInEdit.Owner = userConfig.User.DbId;
 

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
@@ -188,6 +188,7 @@
             //$report_schedule_every: Int! # every x days/weeks/months/years
             //$report_schedule_active: Boolean!
 
+            scheduledReportInEdit.Sanitize();
             if (checkInput())
             {
                 // Add report schedule to DB

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsGateways.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsGateways.razor
@@ -234,6 +234,7 @@
     {
         try
         {
+            actDevice.Sanitize();
             if (CheckValues())
             {    
                 if (AddMode)

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsGroups.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsGroups.razor
@@ -374,24 +374,17 @@
         EditGroupMode = false;
         try
         {
-            if (AddGroupMode)
+            newGroupName = Sanitizer.SanitizeMand(newGroupName);
+            if (CheckValues())
             {
-                actGroup.Roles = new List<string>();
-                if(selectedRoleName != null)
+                if (AddGroupMode)
                 {
-                    actGroup.Roles.Add(selectedRoleName);
-                }
+                    actGroup.Roles = new List<string>();
+                    if(selectedRoleName != null)
+                    {
+                        actGroup.Roles.Add(selectedRoleName);
+                    }
 
-                if (newGroupName == null || newGroupName == "")
-                {
-                    DisplayMessageInUi!(null, userConfig.GetText("add_new_group"), userConfig.GetText("E5234"), true);
-                }
-                else if(groups.Exists(x => x.Name == newGroupName))
-                {
-                    DisplayMessageInUi!(null, userConfig.GetText("add_new_group"), userConfig.GetText("E5235"), true);
-                }
-                else
-                {
                     // insert new group to ldap
                     GroupAddDeleteParameters addGroupParameters = new GroupAddDeleteParameters { GroupName = newGroupName };
                     IRestResponse<string> middlewareServerResponse = await middlewareClient.AddGroup(addGroupParameters);
@@ -410,24 +403,24 @@
                         EditGroupMode = false;
                     }
                 }
-            }
-            else
-            {
-                // Update existing group in ldap --> currently only name
-                GroupEditParameters groupEditParameters = new GroupEditParameters { OldGroupName = actGroup.Name, NewGroupName = newGroupName };
-                IRestResponse<string> middlewareServerResponse = await middlewareClient.UpdateGroup(groupEditParameters);
-
-                if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == "")
-                {
-                    DisplayMessageInUi!(null, userConfig.GetText("edit_group"), userConfig.GetText("E5237"), true);
-                }
                 else
                 {
-                    string newDn = middlewareServerResponse.Data;
-                    int changedGroup = groups.FindIndex(x => x.Dn == actGroup.Dn);
-                    groups[changedGroup].Dn = newDn;
-                    groups[changedGroup].Name = newGroupName;
-                    EditGroupMode = false;
+                    // Update existing group in ldap --> currently only name
+                    GroupEditParameters groupEditParameters = new GroupEditParameters { OldGroupName = actGroup.Name, NewGroupName = newGroupName };
+                    IRestResponse<string> middlewareServerResponse = await middlewareClient.UpdateGroup(groupEditParameters);
+
+                    if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == "")
+                    {
+                        DisplayMessageInUi!(null, userConfig.GetText("edit_group"), userConfig.GetText("E5237"), true);
+                    }
+                    else
+                    {
+                        string newDn = middlewareServerResponse.Data;
+                        int changedGroup = groups.FindIndex(x => x.Dn == actGroup.Dn);
+                        groups[changedGroup].Dn = newDn;
+                        groups[changedGroup].Name = newGroupName;
+                        EditGroupMode = false;
+                    }
                 }
             }
         }
@@ -435,6 +428,21 @@
         {
             DisplayMessageInUi!(exception, userConfig.GetText("save_group"), "", true);
         }
+    }
+
+    private bool CheckValues()
+    {
+        if (newGroupName == null || newGroupName == "")
+        {
+            DisplayMessageInUi!(null, userConfig.GetText("save_group"), userConfig.GetText("E5234"), true);
+            return false;
+        }
+        else if(groups.Exists(x => x.Name == newGroupName))
+        {
+            DisplayMessageInUi!(null, userConfig.GetText("save_group"), userConfig.GetText("E5235"), true);
+            return false;
+        }
+        return true;
     }
 
     private async Task AddGroupToRolesInLdap(UserGroup group)

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsLdap.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsLdap.razor
@@ -332,6 +332,7 @@
     {
         try
         {
+            actLdapConnection.Sanitize();
             if (CheckValues())
             {    
                 if (AddMode)

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsManagements.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsManagements.razor
@@ -367,6 +367,7 @@
     {
         try
         {
+            actManagement.Sanitize();
             if (CheckValues(actManagement, userConfig.GetText("save_management")))
             {
                 if (AddMode)

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsTenants.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsTenants.razor
@@ -327,6 +327,7 @@
     {
         try
         {
+            actTenant.Sanitize();
             if (actTenant.Name == "")
             {
                 DisplayMessageInUi!(null, userConfig.GetText("save_tenant"), userConfig.GetText("E5234"), true);

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsUsers.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsUsers.razor
@@ -740,6 +740,7 @@
     {
         try
         {
+            actUser.Sanitize();
             if (AddMode)
             {
                 SynchronizeUserData(actUser); 


### PR DESCRIPTION
all string input fields are sanitized before saving. There is a differentiation between usual fields where less characters are allowed (restricted e.g. because of Ldap constraints) and passwords, where only Linefeeds etc are filtered out -> to be reviewed, adaptations can be made easily 