### PR TITLE
Revert "Bump RestSharp from 106.15.0 to 107.0.0 in /roles"

### DIFF
--- a/roles/lib/files/FWO.DeviceAutoDiscovery/FWO.DeviceAutoDiscovery.csproj
+++ b/roles/lib/files/FWO.DeviceAutoDiscovery/FWO.DeviceAutoDiscovery.csproj
@@ -8,7 +8,7 @@
 
  <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
-    <PackageReference Include="RestSharp" Version="107.0.0" />
+    <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="RestSharp.Serializers.SystemTextJson" Version="106.15.0" />
   </ItemGroup>
 

--- a/roles/lib/files/FWO.Middleware.Client/FWO.Middleware.Client.csproj
+++ b/roles/lib/files/FWO.Middleware.Client/FWO.Middleware.Client.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
-    <PackageReference Include="RestSharp" Version="107.0.0" />
+    <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="RestSharp.Serializers.SystemTextJson" Version="106.15.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Reverts CactuseSecurity/firewall-orchestrator#1410
due to error:
` /usr/local/fworch/lib/files/FWO.Middleware.Client/MiddlewareClient.cs(29,27): error CS0246: The type or namespace name 'IRestResponse<>' could not be found (are you missing a using directive or an assembly reference?) [/usr/local/fworch/lib/files/FWO.Middleware.Client/FWO.Middleware.Client.csproj]`