### PR TITLE
Ldap Deactivation, Connection test, fixes

### DIFF
--- a/documentation/revision-history.md
+++ b/documentation/revision-history.md
@@ -200,3 +200,6 @@ adding report template format fk and permissions
 ### 5.6.6 - 2022
 - allow for users in rule destination (CP)
 - monitoring
+
+### 5.6.7 - 2022
+- allow deactivation of ldap connection

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ### general settings
-product_version: "5.6.6"
+product_version: "5.6.7"
 ansible_python_interpreter: /usr/bin/python3
 ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 product_name: fworch

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -275,6 +275,28 @@
                     ],
                     "filter": {}
                   }
+                },
+                {
+                  "role": "reporter",
+                  "permission": {
+                    "columns": [
+                      "alert_id",
+                      "ref_alert_id",
+                      "ref_log_id",
+                      "description",
+                      "source",
+                      "title",
+                      "ack_by",
+                      "alert_code",
+                      "alert_dev_id",
+                      "alert_mgm_id",
+                      "user_id",
+                      "json_data",
+                      "ack_timestamp",
+                      "alert_timestamp"
+                    ],
+                    "filter": {}
+                  }
                 }
               ],
               "update_permissions": [
@@ -3008,22 +3030,23 @@
                   "permission": {
                     "check": {},
                     "columns": [
+                      "active",
                       "ldap_connection_id",
-                      "ldap_tls",
                       "ldap_global_tenant_name",
                       "ldap_name",
+                      "ldap_pattern_length",
+                      "ldap_port",
+                      "ldap_search_user",
+                      "ldap_search_user_pwd",
                       "ldap_searchpath_for_groups",
                       "ldap_searchpath_for_roles",
                       "ldap_searchpath_for_users",
-                      "ldap_search_user",
-                      "ldap_search_user_pwd",
                       "ldap_server",
+                      "ldap_tenant_level",
+                      "ldap_tls",
+                      "ldap_type",
                       "ldap_write_user",
                       "ldap_write_user_pwd",
-                      "ldap_pattern_length",
-                      "ldap_port",
-                      "ldap_tenant_level",
-                      "ldap_type",
                       "tenant_id"
                     ],
                     "backend_only": false
@@ -3035,22 +3058,23 @@
                   "role": "auditor",
                   "permission": {
                     "columns": [
+                      "active",
                       "ldap_connection_id",
-                      "ldap_tls",
                       "ldap_global_tenant_name",
                       "ldap_name",
+                      "ldap_pattern_length",
+                      "ldap_port",
+                      "ldap_search_user",
+                      "ldap_search_user_pwd",
                       "ldap_searchpath_for_groups",
                       "ldap_searchpath_for_roles",
                       "ldap_searchpath_for_users",
-                      "ldap_search_user",
-                      "ldap_search_user_pwd",
                       "ldap_server",
+                      "ldap_tenant_level",
+                      "ldap_tls",
+                      "ldap_type",
                       "ldap_write_user",
                       "ldap_write_user_pwd",
-                      "ldap_pattern_length",
-                      "ldap_port",
-                      "ldap_tenant_level",
-                      "ldap_type",
                       "tenant_id"
                     ],
                     "filter": {}
@@ -3060,22 +3084,23 @@
                   "role": "middleware-server",
                   "permission": {
                     "columns": [
+                      "active",
                       "ldap_connection_id",
-                      "ldap_tls",
                       "ldap_global_tenant_name",
                       "ldap_name",
+                      "ldap_pattern_length",
+                      "ldap_port",
+                      "ldap_search_user",
+                      "ldap_search_user_pwd",
                       "ldap_searchpath_for_groups",
                       "ldap_searchpath_for_roles",
                       "ldap_searchpath_for_users",
-                      "ldap_search_user",
-                      "ldap_search_user_pwd",
                       "ldap_server",
+                      "ldap_tenant_level",
+                      "ldap_tls",
+                      "ldap_type",
                       "ldap_write_user",
                       "ldap_write_user_pwd",
-                      "ldap_pattern_length",
-                      "ldap_port",
-                      "ldap_tenant_level",
-                      "ldap_type",
                       "tenant_id"
                     ],
                     "filter": {}
@@ -3087,23 +3112,24 @@
                   "role": "middleware-server",
                   "permission": {
                     "columns": [
+                      "active",
                       "ldap_connection_id",
-                      "ldap_server",
+                      "ldap_global_tenant_name",
+                      "ldap_name",
+                      "ldap_pattern_length",
                       "ldap_port",
-                      "ldap_tls",
-                      "ldap_searchpath_for_users",
-                      "ldap_searchpath_for_roles",
-                      "ldap_tenant_level",
                       "ldap_search_user",
                       "ldap_search_user_pwd",
-                      "ldap_write_user",
-                      "tenant_id",
-                      "ldap_write_user_pwd",
                       "ldap_searchpath_for_groups",
+                      "ldap_searchpath_for_roles",
+                      "ldap_searchpath_for_users",
+                      "ldap_server",
+                      "ldap_tenant_level",
+                      "ldap_tls",
                       "ldap_type",
-                      "ldap_pattern_length",
-                      "ldap_name",
-                      "ldap_global_tenant_name"
+                      "ldap_write_user",
+                      "ldap_write_user_pwd",
+                      "tenant_id"
                     ],
                     "filter": {},
                     "check": null
@@ -3200,6 +3226,78 @@
                     ],
                     "backend_only": false
                   }
+                },
+                {
+                  "role": "recertifier",
+                  "permission": {
+                    "check": {},
+                    "columns": [
+                      "data_issue_id",
+                      "import_id",
+                      "rule_id",
+                      "description",
+                      "object_name",
+                      "object_type",
+                      "object_uid",
+                      "rule_uid",
+                      "source",
+                      "suspected_cause",
+                      "issue_dev_id",
+                      "issue_mgm_id",
+                      "severity",
+                      "user_id",
+                      "issue_timestamp"
+                    ],
+                    "backend_only": false
+                  }
+                },
+                {
+                  "role": "reporter",
+                  "permission": {
+                    "check": {},
+                    "columns": [
+                      "data_issue_id",
+                      "import_id",
+                      "rule_id",
+                      "description",
+                      "object_name",
+                      "object_type",
+                      "object_uid",
+                      "rule_uid",
+                      "source",
+                      "suspected_cause",
+                      "issue_dev_id",
+                      "issue_mgm_id",
+                      "severity",
+                      "user_id",
+                      "issue_timestamp"
+                    ],
+                    "backend_only": false
+                  }
+                },
+                {
+                  "role": "reporter-viewall",
+                  "permission": {
+                    "check": {},
+                    "columns": [
+                      "data_issue_id",
+                      "import_id",
+                      "rule_id",
+                      "description",
+                      "object_name",
+                      "object_type",
+                      "object_uid",
+                      "rule_uid",
+                      "source",
+                      "suspected_cause",
+                      "issue_dev_id",
+                      "issue_mgm_id",
+                      "severity",
+                      "user_id",
+                      "issue_timestamp"
+                    ],
+                    "backend_only": false
+                  }
                 }
               ],
               "select_permissions": [
@@ -3277,6 +3375,78 @@
                 },
                 {
                   "role": "middleware-server",
+                  "permission": {
+                    "columns": [
+                      "data_issue_id",
+                      "description",
+                      "import_id",
+                      "issue_dev_id",
+                      "issue_mgm_id",
+                      "issue_timestamp",
+                      "object_name",
+                      "object_type",
+                      "object_uid",
+                      "rule_id",
+                      "rule_uid",
+                      "severity",
+                      "source",
+                      "suspected_cause",
+                      "user_id"
+                    ],
+                    "filter": {},
+                    "allow_aggregations": true
+                  }
+                },
+                {
+                  "role": "recertifier",
+                  "permission": {
+                    "columns": [
+                      "data_issue_id",
+                      "description",
+                      "import_id",
+                      "issue_dev_id",
+                      "issue_mgm_id",
+                      "issue_timestamp",
+                      "object_name",
+                      "object_type",
+                      "object_uid",
+                      "rule_id",
+                      "rule_uid",
+                      "severity",
+                      "source",
+                      "suspected_cause",
+                      "user_id"
+                    ],
+                    "filter": {},
+                    "allow_aggregations": true
+                  }
+                },
+                {
+                  "role": "reporter",
+                  "permission": {
+                    "columns": [
+                      "data_issue_id",
+                      "description",
+                      "import_id",
+                      "issue_dev_id",
+                      "issue_mgm_id",
+                      "issue_timestamp",
+                      "object_name",
+                      "object_type",
+                      "object_uid",
+                      "rule_id",
+                      "rule_uid",
+                      "severity",
+                      "source",
+                      "suspected_cause",
+                      "user_id"
+                    ],
+                    "filter": {},
+                    "allow_aggregations": true
+                  }
+                },
+                {
+                  "role": "reporter-viewall",
                   "permission": {
                     "columns": [
                       "data_issue_id",
@@ -3716,17 +3886,28 @@
                   "permission": {
                     "columns": [
                       "clearing_import_ran",
-                      "tenant_id",
-                      "config_path",
-                      "dev_typ_id",
                       "do_not_import",
                       "force_initial_import",
                       "hide_in_gui",
+                      "config_path",
                       "importer_hostname",
-                      "mgm_comment",
-                      "mgm_create",
-                      "mgm_id",
+                      "last_import_md5_complete_config",
+                      "last_import_md5_objects",
+                      "last_import_md5_rules",
+                      "last_import_md5_users",
                       "mgm_name",
+                      "ssh_hostname",
+                      "ssh_user",
+                      "debug_level",
+                      "dev_typ_id",
+                      "mgm_id",
+                      "multi_device_manager_id",
+                      "ssh_port",
+                      "tenant_id",
+                      "mgm_comment",
+                      "ssh_private_key",
+                      "ssh_public_key",
+                      "mgm_create",
                       "mgm_update"
                     ],
                     "filter": {
@@ -3742,17 +3923,28 @@
                   "permission": {
                     "columns": [
                       "clearing_import_ran",
-                      "tenant_id",
-                      "config_path",
-                      "dev_typ_id",
                       "do_not_import",
                       "force_initial_import",
                       "hide_in_gui",
+                      "config_path",
                       "importer_hostname",
-                      "mgm_comment",
-                      "mgm_create",
-                      "mgm_id",
+                      "last_import_md5_complete_config",
+                      "last_import_md5_objects",
+                      "last_import_md5_rules",
+                      "last_import_md5_users",
                       "mgm_name",
+                      "ssh_hostname",
+                      "ssh_user",
+                      "debug_level",
+                      "dev_typ_id",
+                      "mgm_id",
+                      "multi_device_manager_id",
+                      "ssh_port",
+                      "tenant_id",
+                      "mgm_comment",
+                      "ssh_private_key",
+                      "ssh_public_key",
+                      "mgm_create",
                       "mgm_update"
                     ],
                     "filter": {
@@ -11404,6 +11596,5 @@
         }
       ]
     }
-  
   }
 }

--- a/roles/database/files/sql/creation/fworch-create-tables.sql
+++ b/roles/database/files/sql/creation/fworch-create-tables.sql
@@ -1061,6 +1061,7 @@ Create table "ldap_connection"
 	"ldap_pattern_length" Integer NOT NULL Default 0,
 	"ldap_name" Varchar,
 	"ldap_global_tenant_name" Varchar,
+	"active" Boolean NOT NULL Default TRUE,
 	primary key ("ldap_connection_id")
 );
 

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -705,6 +705,8 @@ INSERT INTO txt VALUES ('add_new_ldap',         'German', 	'Neue LDAP-Verbindung
 INSERT INTO txt VALUES ('add_new_ldap',         'English', 	'Add new LDAP connection');
 INSERT INTO txt VALUES ('edit_ldap',            'German', 	'LDAP-Verbindung bearbeiten');
 INSERT INTO txt VALUES ('edit_ldap',            'English', 	'Edit LDAP connection');
+INSERT INTO txt VALUES ('test_connection',      'German', 	'Verbindung testen');
+INSERT INTO txt VALUES ('test_connection',      'English', 	'Test connection');
 INSERT INTO txt VALUES ('address',              'German', 	'Adresse');
 INSERT INTO txt VALUES ('address',              'English', 	'Address');
 INSERT INTO txt VALUES ('tenant_level',         'German', 	'Mandantenebene');
@@ -1315,6 +1317,8 @@ INSERT INTO txt VALUES ('E5257', 'German',  'Nutzer konnte von keiner Rolle in d
 INSERT INTO txt VALUES ('E5257', 'English', 'User could not be removed from any role in ldaps');
 INSERT INTO txt VALUES ('E5258', 'German',  'Zu l&ouml;schender Nutzer nicht gefunden');
 INSERT INTO txt VALUES ('E5258', 'English', 'User to delete not found');
+INSERT INTO txt VALUES ('E5260', 'German',  'Deaktivieren der LDAP-Verbindung nicht erlaubt, da sie die letzte ist');
+INSERT INTO txt VALUES ('E5260', 'English', 'Deactivation of LDAP Connection not allowed as it is the last one');
 INSERT INTO txt VALUES ('E5261', 'German',  'L&ouml;schen der LDAP-Verbindung nicht erlaubt, da sie die letzte ist');
 INSERT INTO txt VALUES ('E5261', 'English', 'Deletion of LDAP Connection not allowed as it is the last one');
 INSERT INTO txt VALUES ('E5262', 'German',  'L&ouml;schen der LDAP-Verbindung nicht erlaubt, da sie einen Rollensuchpfad enth&auml;lt. Wenn m&ouml;glich diesen zuerst l&ouml;schen');
@@ -1325,6 +1329,10 @@ INSERT INTO txt VALUES ('E5264', 'German',  'Es gibt bereits eine LDAP-Verbindun
 INSERT INTO txt VALUES ('E5264', 'English', 'There is already an LDAP connection with the same address and port');
 INSERT INTO txt VALUES ('E5265', 'German',  'Rollenverwaltung kann nur im internen Ldap erfolgen');
 INSERT INTO txt VALUES ('E5265', 'English', 'Role handling can only be done in internal Ldap');
+INSERT INTO txt VALUES ('E5266', 'German',  'LDAP-Verbindung Ok');
+INSERT INTO txt VALUES ('E5266', 'English', 'LDAP connection Ok');
+INSERT INTO txt VALUES ('E5267', 'German',  'LDAP-Verbindung nicht Ok');
+INSERT INTO txt VALUES ('E5267', 'English', 'LDAP connection not Ok');
 INSERT INTO txt VALUES ('E5271', 'German',  'Keine Gateways zum Hinzuf&uuml;gen gefunden');
 INSERT INTO txt VALUES ('E5271', 'English', 'No remaining gateways found to add');
 INSERT INTO txt VALUES ('E5272', 'German',  'Keine Gateways zum L&ouml;schen gefunden');
@@ -1922,12 +1930,22 @@ INSERT INTO txt VALUES ('H5158', 'German',  'Import Deaktiviert: Schalter um den
 INSERT INTO txt VALUES ('H5158', 'English', 'Import Disabled: Flag if the data import is disabled.');
 INSERT INTO txt VALUES ('H5159', 'German',  'Nicht sichtbar: Wenn gesetzt ist dieses Gateway nicht mit Standard-Reporter-Rolle sichtbar.');
 INSERT INTO txt VALUES ('H5159', 'English', 'Hide in UI: If set, this gateway is not visible to the standard reporter role.');
-INSERT INTO txt VALUES ('H5171', 'German',  'Hier wird ein &Uuml;berblick &uuml;ber den Status der Importjobs der verschiedenen Managements gegeben.');
-INSERT INTO txt VALUES ('H5171', 'English', 'The status of the import jobs for the different managements is displayed here.');
+INSERT INTO txt VALUES ('H5171', 'German',  'Hier wird ein &Uuml;berblick &uuml;ber den Status der Importjobs der verschiedenen Managements gegeben.
+    Dabei werden Managements, die Auff&auml;lligkeiten aufweisen (wie sie auch vom <a href="/help/monitoring/daily_checks">T&auml;glichen Check</a> beanstandet w&uuml;rden), rot unterlegt und zuerst aufgelistet,
+    danach folgen gelb unterlegt die laufenden Imports, dann erst die &uuml;brigen Managements.
+');
+INSERT INTO txt VALUES ('H5171', 'English', 'The status of the import jobs for the different managements is displayed here.
+    Managements which show anomalies (which would also lead to alerts in the <a href="/help/monitoring/daily_checks">Daily Check</a>) are highlighted in red and listed first,
+    followed by running imports highlighted in yellow, finally the remaining managements.
+');
 INSERT INTO txt VALUES ('H5181', 'German',  'Neu anzeigen: Aktualisiert die dargestellten Daten.');
 INSERT INTO txt VALUES ('H5181', 'English', 'Refresh: Updates the displayed data.');
-INSERT INTO txt VALUES ('H5182', 'German',  'Details: F&uuml;r das ausgew&auml;hlte Management wird hier eine genauere &Uuml;bersicht &uuml;ber die Start/Stop-Zeiten des ersten, letzten erfolgreichen und letzten Imports gegeben.');
-INSERT INTO txt VALUES ('H5182', 'English', 'Details: For the selected management a detailed view on Start/Stop times and errors of the first, last successful and last import.');
+INSERT INTO txt VALUES ('H5182', 'German',  'Details: F&uuml;r das ausgew&auml;hlte Management wird hier eine genauere &Uuml;bersicht &uuml;ber die Import-Ids, Start/Stop-Zeiten, 
+    Dauer und Fehler des ersten, letzten erfolgreichen und letzten Imports gegeben, sowie die Anzahl der Fehler seit dem letzten erfolgreichen Import.
+');
+INSERT INTO txt VALUES ('H5182', 'English', 'Details: For the selected management a detailed view on import ids, start/stop times, 
+    duration and errors of the first, last successful and last import, as well as the number of errors since the last successful import.
+');
 INSERT INTO txt VALUES ('H5183', 'German',  'Letzter Unvollendeter: Die Startzeit eines aktuell laufenden Imports falls vorhanden.
     L&auml;uft der Import schon l&auml;nger als 5 Minuten, wird eine Schaltfl&auml;che zum Zur&uuml;cksetzen angeboten. Sie soll f&uuml;r h&auml;ngengebliebene Imports genutzt werden.
     Da ein erfolgreicher Import einige Minuten dauern kann, sollte der Rollback nicht zu fr&uuml;h angestossen werden.
@@ -1949,13 +1967,15 @@ INSERT INTO txt VALUES ('H5201', 'German',  'Admins k&ouml;nnen mehrere untersch
     Die Ldap-Verbindungen k&ouml;nnen hinzugef&uuml;gt, ge&auml;ndert oder gel&ouml;scht werden.
     Eine L&ouml;schung ist nur zul&auml;ssig, wenn es nicht das interne Ldap (definiert durch den gesetzten Rollensuchpfad) und nicht das letzte vorhandene Ldap ist.<br>
     Die "Klonen"-Schaltfl&auml;che unterst&uuml;tzt beim Definieren einer neuen Ldap-Verbindung, indem Daten von einem existierenden kopiert werden.
-    Vor dem Speichern muss mindestens Adresse oder Portnummer ge&auml;ndert werden.
+    Vor dem Speichern muss mindestens Adresse oder Portnummer ge&auml;ndert werden.<br>
+    Beim Editieren kann mit der "Verbindung testen"-Schaltfl&auml;che gepr&uuml;ft werden, ob eine Verbindung mit den aktuellen Parametern aufgebaut werden kann.
 ');
 INSERT INTO txt VALUES ('H5201', 'English', 'Admins can create and administrate several different Ldap connections. All of them can be used for user authentication.<br>
     The internal Ldap (part of the initial installation) is needed at least for role assignment, but can also be used for user authentication and user group handling.<br>
     The Ldap connections can be added, changed and deleted.
     Deletion is only allowed, if it is not the internal Ldap (defined by the existence of a role search path) and if it is not the last Ldap.<br>
-    The clone button helps defining new Ldaps by copying the data from existing ones. Before saving at least the address or port number have to be changed.
+    The clone button helps defining new Ldaps by copying the data from existing ones. Before saving at least the address or port number have to be changed.<br>
+    While editing, a "Test connection" button helps checking, if a connection can be built up with the actual parameters.
 ');
 INSERT INTO txt VALUES ('H5210', 'German',  'Name*: Name des verbundenen Ldap. Kann frei gew&auml;hlt werden. Wenn nicht vergeben, wird der Host (Adresse:Port) dargestellt.');
 INSERT INTO txt VALUES ('H5210', 'English', 'Name*: Name of the connected Ldap to be freely given. If not assigned the Host (Address:Port) is displayed.');
@@ -2007,6 +2027,8 @@ INSERT INTO txt VALUES ('H5225', 'German',  'Globaler Mandantenname: Wenn das Ld
 INSERT INTO txt VALUES ('H5225', 'English', 'Global Tenant Name: If the Ldap is using tenants (Tenant Level > 0), the name of the Global Tenant can be set here.
     This name will be used in the respective position in the Distinguished Name (Dn).
 ');
+INSERT INTO txt VALUES ('H5226', 'German',  'Aktiv: Wenn das Ldap nicht auf aktiv gesetzt ist, wird es f&uuml;r andere Aktionen (Autorisierungen, Rollenzuweisung etc.) nicht ber&uuml;cksichtigt.');
+INSERT INTO txt VALUES ('H5226', 'English', 'Active: If not set to active, the Ldap is not involved in other actions (authorization, role assignment etc.).');
 INSERT INTO txt VALUES ('H5231', 'German',  'Die verf&uuml;gbaren Mandanten werden hier mit den zugeordneten Gateways dargestellt.<br>
     Es ist m&ouml;glich, Mandanten im lokalen Ldap sowie Verkn&uuml;pfungen zu den vorhandenen <a href="/help/settings/gateways">Gateways</a> anzulegen oder zu l&ouml;schen.
     Wenn Beispieldaten (definiert durch die Endung "_demo" vom Mandantennamen) existieren, wird eine Schaltfl&auml;che angezeigt, um diese zu l&ouml;schen.
@@ -2444,13 +2466,15 @@ INSERT INTO txt VALUES ('H7252', 'English', 'Sample data (defined by the ending 
     In productive environments they should not be present. Therefore the system is checked and if necessary an alert is raised. The record contains information about the data domain
     (managements, tenants, users or groups), where sample data were found.
 ');
-INSERT INTO txt VALUES ('H7253', 'German', 'Import-Status
+INSERT INTO txt VALUES ('H7253', 'German', 'Die Ergebnisse der Pr&uuml;fung des Import-Status der aktiven Managements sind hier protokolliert. Werden Anomalien wie &uuml;berlange Import-Zeiten oder fehlende Imports festgestellt,
+    werden einzelne Alarme ausgel&ouml;st, die unter <a href="/help/monitoring/open_alerts">Offenen Alarme</a> analysiert und behandelt werden k&ouml;nnen. Hier wird lediglich die Anzahl der gefundenen Probleme protokolliert.
 ');
-INSERT INTO txt VALUES ('H7253', 'English', 'Import status
+INSERT INTO txt VALUES ('H7253', 'English', 'Results of the Import status checks of the active managements are recorded here. If anomalies as overdue or missing imports are found,
+    separate alerts are raised, which can be analysed and handled at <a href="/help/monitoring/open_alerts">Open Alerts</a>.
 ');
-INSERT INTO txt VALUES ('H7301', 'German', 'Import-Logs
+INSERT INTO txt VALUES ('H7301', 'German', 'Hier werden die Ausgaben der verschiedenen Importe protokolliert.
 ');
-INSERT INTO txt VALUES ('H7301', 'English', 'Import logs
+INSERT INTO txt VALUES ('H7301', 'English', 'Here the output of the different imports are documented.
 ');
 INSERT INTO txt VALUES ('H7302', 'German', 'Schwere
 ');

--- a/roles/database/files/upgrade/5.6.7.sql
+++ b/roles/database/files/upgrade/5.6.7.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE "ldap_connection" ADD column IF NOT EXISTS "active" Boolean NOT NULL Default TRUE;

--- a/roles/lib/files/FWO.Api.Client/APIcalls/auth/getAllLdapConnections.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/auth/getAllLdapConnections.graphql
@@ -1,8 +1,8 @@
 # returns a list of all available ldap connections
 # the field ldap_searchpath_for_roles is not null only for the internal ldap
 
-query getLdapConnections {
-  ldap_connection(where: {active: {_eq: true}} order_by: {ldap_connection_id: desc}) {
+query getAllLdapConnections {
+  ldap_connection(order_by: {ldap_connection_id: desc}) {
     ldap_name
     ldap_server
     ldap_port
@@ -20,5 +20,6 @@ query getLdapConnections {
     ldap_write_user_pwd
     tenant_id
     ldap_global_tenant_name
+    active
   }
 }

--- a/roles/lib/files/FWO.Api.Client/APIcalls/auth/getLdapConnectionsSubscription.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/auth/getLdapConnectionsSubscription.graphql
@@ -1,5 +1,5 @@
 ﻿subscription getLdapConnections {
-  ldap_connection {
+  ldap_connection (where: {active: {_eq: true}}){
     ldap_name
     ldap_server
     ldap_port

--- a/roles/lib/files/FWO.Api.Client/APIcalls/auth/newLdapConnection.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/auth/newLdapConnection.graphql
@@ -15,6 +15,7 @@ mutation newLdapConnection(
   $writeUserPwd: String
   $tenantId: Int
   $globalTenantName: String
+  $active: Boolean!
 ) {
   insert_ldap_connection(
     objects: {
@@ -34,6 +35,7 @@ mutation newLdapConnection(
       ldap_write_user_pwd: $writeUserPwd
       tenant_id: $tenantId
       ldap_global_tenant_name: $globalTenantName
+      active: $active
     }
   ) {
     returning {

--- a/roles/lib/files/FWO.Api.Client/APIcalls/auth/updateLdapConnection.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/auth/updateLdapConnection.graphql
@@ -16,6 +16,7 @@ mutation updateLdapConnection(
   $writeUserPwd: String
   $tenantId: Int
   $globalTenantName: String
+  $active: Boolean!
 ) {
   update_ldap_connection_by_pk(
     pk_columns: { ldap_connection_id: $id }
@@ -36,6 +37,7 @@ mutation updateLdapConnection(
       ldap_write_user_pwd: $writeUserPwd
       tenant_id: $tenantId
       ldap_global_tenant_name: $globalTenantName
+      active: $active
     }
   ) {
     UpdatedId: ldap_connection_id

--- a/roles/lib/files/FWO.Api.Client/APIcalls/device/fragments/managementDetails.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/device/fragments/managementDetails.graphql
@@ -26,6 +26,7 @@ fragment ManagementDetails on management {
   devices {
     id: dev_id
     name: dev_name
+    importDisabled: do_not_import
     local_rulebase_name: local_rulebase_name
   }
 }

--- a/roles/lib/files/FWO.Api.Client/Data/LdapConnectionBase.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/LdapConnectionBase.cs
@@ -61,6 +61,9 @@ namespace FWO.Api.Data
         [JsonProperty("ldap_global_tenant_name"), JsonPropertyName("ldap_global_tenant_name")]
         public string? GlobalTenantName { get; set; }
 
+        [JsonProperty("active"), JsonPropertyName("active")]
+        public bool Active { get; set; } = true;
+
         public LdapConnectionBase()
         {}
 
@@ -82,6 +85,7 @@ namespace FWO.Api.Data
             WriteUserPwd = ldapGetUpdateParameters.WriteUserPwd;
             TenantId = ldapGetUpdateParameters.TenantId;
             GlobalTenantName = ldapGetUpdateParameters.GlobalTenantName;
+            Active = ldapGetUpdateParameters.Active;
         }
 
         public string Host()

--- a/roles/lib/files/FWO.Api.Client/Data/UiLdapConnection.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/UiLdapConnection.cs
@@ -55,6 +55,7 @@ namespace FWO.Api.Data
             WriteUserPwd = ldapConnection.WriteUserPwd;
             TenantId = ldapConnection.TenantId;
             GlobalTenantName = ldapConnection.GlobalTenantName;
+            Active = ldapConnection.Active;
         }
 
         public void Sanitize()
@@ -91,7 +92,8 @@ namespace FWO.Api.Data
                 WriteUser = this.WriteUser,
                 WriteUserPwd = this.WriteUserPwd,
                 TenantId = this.TenantId,
-                GlobalTenantName = this.GlobalTenantName
+                GlobalTenantName = this.GlobalTenantName,
+                Active = this.Active
             };
         }
     }

--- a/roles/lib/files/FWO.Api.Client/Queries/AuthQueries.cs
+++ b/roles/lib/files/FWO.Api.Client/Queries/AuthQueries.cs
@@ -26,6 +26,7 @@ namespace FWO.ApiClient.Queries
         public static readonly string getVisibleDeviceIdsPerTenant;
         public static readonly string getVisibleManagementIdsPerTenant;
         public static readonly string getLdapConnections;
+        public static readonly string getAllLdapConnections;
         public static readonly string getLdapConnectionsSubscription;
         public static readonly string newLdapConnection;
         public static readonly string updateLdapConnection;
@@ -45,6 +46,7 @@ namespace FWO.ApiClient.Queries
                 getVisibleDeviceIdsPerTenant = File.ReadAllText(QueryPath + "auth/getVisibleDeviceIdsPerTenant.graphql");
                 getVisibleManagementIdsPerTenant = File.ReadAllText(QueryPath + "auth/getVisibleManagementIdsPerTenant.graphql");
                 getLdapConnections = File.ReadAllText(QueryPath + "auth/getLdapConnections.graphql");
+                getAllLdapConnections = File.ReadAllText(QueryPath + "auth/getAllLdapConnections.graphql");
                 getLdapConnectionsSubscription = File.ReadAllText(QueryPath + "auth/getLdapConnectionsSubscription.graphql");
                 getUsers = File.ReadAllText(QueryPath + "auth/getUsers.graphql");
                 getUserByDn = File.ReadAllText(QueryPath + "auth/getUserByDn.graphql");

--- a/roles/lib/files/FWO.Middleware.Client/MiddlewareClient.cs
+++ b/roles/lib/files/FWO.Middleware.Client/MiddlewareClient.cs
@@ -48,6 +48,13 @@ namespace FWO.Middleware.Client
             return await restClient.ExecuteAsync<string>(request);
         }
 
+        public async Task<RestResponse<bool>> TestConnection(LdapGetUpdateParameters parameters)
+        {
+            RestRequest request = new RestRequest("AuthenticationServer/TestConnection", Method.Get);
+            request.AddJsonBody(parameters);
+            return await restClient.ExecuteAsync<bool>(request);
+        }
+
         public async Task<RestResponse<List<LdapGetUpdateParameters>>> GetLdaps()
         {
             RestRequest request = new RestRequest("AuthenticationServer", Method.Get);

--- a/roles/lib/files/FWO.Middleware/RequestParameters/AuthenticationServerParameters.cs
+++ b/roles/lib/files/FWO.Middleware/RequestParameters/AuthenticationServerParameters.cs
@@ -18,6 +18,7 @@
         public string? WriteUserPwd { get; set; }
         public int? TenantId { get; set; }
         public string? GlobalTenantName { get; set; }
+        public bool Active { get; set; }
 
         public LdapAddParameters()
         {}
@@ -40,6 +41,7 @@
             WriteUserPwd = ldapAddParameters.WriteUserPwd;
             TenantId = ldapAddParameters.TenantId;
             GlobalTenantName = ldapAddParameters.GlobalTenantName;
+            Active = ldapAddParameters.Active;
         }
     }
 

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationServerController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationServerController.cs
@@ -25,12 +25,21 @@ namespace FWO.Middleware.Controllers
             this.ldaps = ldaps;
         }
 
+        // GET: api/<LdapController>/TestConnection/5
+        [HttpGet("TestConnection")]
+        [Authorize(Roles = "admin, auditor")]
+        public bool TestConnection([FromBody] LdapGetUpdateParameters parameters)
+        {
+            FWO.Middleware.Server.Ldap ldapToTest = new FWO.Middleware.Server.Ldap(parameters);
+            return ldapToTest.TestConnection();
+        }
+
         // GET: api/<LdapController>
         [HttpGet]
         [Authorize(Roles = "admin, auditor")]
         public async Task<List<LdapGetUpdateParameters>> Get()
         {
-            UiLdapConnection[] ldapConnections = (await apiConnection.SendQueryAsync<UiLdapConnection[]>(FWO.ApiClient.Queries.AuthQueries.getLdapConnections));
+            UiLdapConnection[] ldapConnections = (await apiConnection.SendQueryAsync<UiLdapConnection[]>(FWO.ApiClient.Queries.AuthQueries.getAllLdapConnections));
             List<LdapGetUpdateParameters> ldapList = new List<LdapGetUpdateParameters>();
             foreach (UiLdapConnection conn in ldapConnections)
             {

--- a/roles/middleware/files/FWO.Middleware.Server/DailyCheckScheduler.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/DailyCheckScheduler.cs
@@ -239,12 +239,16 @@ namespace FWO.Middleware.Server
                 {
                     Log.WriteError("Write Alert", "Log could not be written to database");
                 }
-                string mgmtIdString = ""; 
+                string? mgmtIdString = ""; 
                 if (mgmtId != null)
+                {
                     mgmtIdString = mgmtId.ToString();
-                string devIdString = ""; 
+                }
+                string? devIdString = ""; 
                 if (devId != null)
+                {
                     devIdString = devId.ToString();
+                }
                 string jsonString = ""; 
                 if (JsonData != null)
                     jsonString = JsonSerializer.Serialize(JsonData);

--- a/roles/middleware/files/FWO.Middleware.Server/Ldap.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Ldap.cs
@@ -42,6 +42,19 @@ namespace FWO.Middleware.Server
             }
         }
 
+        public bool TestConnection()
+        {
+            try
+            {
+                Connect();
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
         private string getUserSearchFilter(string searchPattern)
         {
             string userFilter;

--- a/roles/middleware/files/FWO.Middleware.Server/Program.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Program.cs
@@ -35,7 +35,7 @@ while (true)
     // Repeat first api call in case graphql api is not started yet
     try
     {
-        connectedLdaps = apiConnection.SendQueryAsync<List<Ldap>>(AuthQueries.getLdapConnections).Result;
+        connectedLdaps = apiConnection.SendQueryAsync<List<Ldap>>(AuthQueries.getAllLdapConnections).Result;
         break;
     }
     catch (Exception ex)

--- a/roles/ui/files/FWO.UI/Pages/Help/HelpSettingsLdap.cshtml
+++ b/roles/ui/files/FWO.UI/Pages/Help/HelpSettingsLdap.cshtml
@@ -33,5 +33,6 @@
         <li>@(Html.Raw(userConfig.GetText("H5223")))</li>
         <li>@(Html.Raw(userConfig.GetText("H5224")))</li>
         <li>@(Html.Raw(userConfig.GetText("H5225")))</li>
+        <li>@(Html.Raw(userConfig.GetText("H5226")))</li>
     </ul>
 </div>

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitoringMain.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitoringMain.razor
@@ -262,11 +262,7 @@
 
             int deletedSampleGroups = 0;
             RestResponse<List<GroupGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetInternalGroups();
-            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
-            {
-                DisplayMessageInUi!(null, userConfig.GetText("fetch_groups"), userConfig.GetText("E5231"), true);
-            }
-            else
+            if (middlewareServerResponse.StatusCode == HttpStatusCode.OK && middlewareServerResponse.Data != null)
             {
                 foreach (var ldapUserGroup in middlewareServerResponse.Data)
                 {

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsGroups.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsGroups.razor
@@ -269,7 +269,7 @@
         try
         { 
             RestResponse<List<GroupGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetInternalGroups();
-            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("fetch_groups"), userConfig.GetText("E5231"), true);
             }
@@ -322,7 +322,7 @@
         try
         {
             RestResponse<List<RoleGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetAllRoles();
-            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("fetch_roles"), userConfig.GetText("E5251"), true);
             }
@@ -401,7 +401,7 @@
                     GroupAddDeleteParameters addGroupParameters = new GroupAddDeleteParameters { GroupName = newGroupName };
                     RestResponse<string> middlewareServerResponse = await middlewareClient.AddGroup(addGroupParameters);
                     
-                    if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == "")
+                    if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null || middlewareServerResponse.Data == "")
                     {
                         DisplayMessageInUi!(null, userConfig.GetText("add_new_group"), userConfig.GetText("E5236"), true);
                     }
@@ -421,7 +421,7 @@
                     GroupEditParameters groupEditParameters = new GroupEditParameters { OldGroupName = actGroup.Name, NewGroupName = newGroupName };
                     RestResponse<string> middlewareServerResponse = await middlewareClient.UpdateGroup(groupEditParameters);
 
-                    if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == "")
+                    if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null || middlewareServerResponse.Data == "")
                     {
                         DisplayMessageInUi!(null, userConfig.GetText("edit_group"), userConfig.GetText("E5237"), true);
                     }

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsLdap.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsLdap.razor
@@ -32,6 +32,11 @@
                 </div>
             </Template>
         </Column>
+        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("active"))" Field="@(x => x.Active)" Sortable="true" Filterable="true">
+            <Template>
+                @(GlobalConfig.ShowBool(context.Active))
+            </Template>
+        </Column>
         <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Sortable="true" Filterable="true" />
         <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("host"))" Field="@(x => x.Address)" Sortable="true" Filterable="true">
             <Template>
@@ -178,6 +183,12 @@
                         <input id="ldapGlobTenName" type="text" class="form-control form-control-sm" @bind="actLdapConnection.GlobalTenantName" />
                     </div>
                 </div>
+                <div class="form-group row">
+                    <label for="ldapActive" class="col-sm-3 col-form-label col-form-label-sm">@(userConfig.GetText("active")):</label>
+                    <div class="col-sm-8">
+                        <input id="ldapActive" type="checkbox" @bind="actLdapConnection.Active">
+                    </div>
+                </div>
             </form>
         }
     </Body>
@@ -185,9 +196,11 @@
         <div class="btn-group">
             <AuthorizeView Roles="admin">
                 <Authorized>
+                    <button class="btn btn-sm btn-dark" @onclick="TestConnection">@(userConfig.GetText("test_connection"))</button>
                     <button class="btn btn-sm btn-primary" @onclick="Save">@(userConfig.GetText("save"))</button>
                 </Authorized>
                 <NotAuthorized>
+                    <button class="btn btn-sm btn-dark" disabled>@(userConfig.GetText("test_connection"))</button>
                     <button class="btn btn-sm btn-primary" disabled>@(userConfig.GetText("save"))</button>
                 </NotAuthorized> 
             </AuthorizeView>
@@ -235,13 +248,14 @@
     private UiLdapConnection actLdapConnection = new UiLdapConnection();
 
     private string deleteMessage = "";
+    private bool wasActive = true;
 
     protected override async Task OnInitializedAsync()
     {
         try
         {
             RestResponse<List<LdapGetUpdateParameters>> ldapMiddlewareServerResponse = await middlewareClient.GetLdaps();
-            if (ldapMiddlewareServerResponse.StatusCode != HttpStatusCode.OK)
+            if (ldapMiddlewareServerResponse.StatusCode != HttpStatusCode.OK || ldapMiddlewareServerResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("fetch_ldap_conn"), userConfig.GetText("E5204"), true);
             }
@@ -265,6 +279,7 @@
     private void Edit(UiLdapConnection ldapConnection)
     {
         actLdapConnection = new UiLdapConnection(ldapConnection);
+        wasActive = ldapConnection.Active;
         EditMode = true;
     }
 
@@ -326,6 +341,31 @@
         newLdapConnection = new UiLdapConnection(ldapConnection);
         newLdapConnection.Id = 0;
         Edit(newLdapConnection);
+    }
+
+    private async Task TestConnection()
+    {
+        try
+        {
+            LdapGetUpdateParameters ldapParams = new LdapGetUpdateParameters()
+            {
+                Address = actLdapConnection.Address,
+                Port = actLdapConnection.Port
+            };
+            RestResponse<bool> middlewareServerResponse = await middlewareClient.TestConnection(ldapParams);
+            if (middlewareServerResponse.StatusCode == HttpStatusCode.OK && middlewareServerResponse.Data == true)
+            {
+                DisplayMessageInUi!(null, userConfig.GetText("test_connection"), userConfig.GetText("E5266"), false);
+            }
+            else
+            {
+                DisplayMessageInUi!(null, userConfig.GetText("test_connection"), userConfig.GetText("E5267"), true);
+            }
+        }
+        catch (System.Exception exception)
+        {
+            DisplayMessageInUi!(exception, userConfig.GetText("test_connection"), "", true);
+        }
     }
 
     private async Task Save()
@@ -401,6 +441,11 @@
         if (actLdapConnection.HasRoleHandling() && !actLdapConnection.IsInternal())
         {
             DisplayMessageInUi!(null, userConfig.GetText("save_ldap_conn"), userConfig.GetText("E5265"), true);
+            return false;
+        }
+        if (!AddMode && wasActive && !actLdapConnection.Active && connectedLdaps.Where(x => x.Active).Count() == 1)
+        {
+            DisplayMessageInUi!(null, userConfig.GetText("save_ldap_conn"), userConfig.GetText("E5260"), true);
             return false;
         }
         return true;

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsRoles.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsRoles.razor
@@ -241,7 +241,7 @@
         {
             // get roles from LDAP
             RestResponse<List<RoleGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetAllRoles();
-            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("fetch_roles"), userConfig.GetText("E5251"), true);
             }
@@ -275,7 +275,7 @@
 
             // get groups from internal LDAP
             RestResponse<List<GroupGetReturnParameters>> middlewareServerGroupsResponse = await middlewareClient.GetInternalGroups();
-            if (middlewareServerGroupsResponse.StatusCode != HttpStatusCode.OK)
+            if (middlewareServerGroupsResponse.StatusCode != HttpStatusCode.OK || middlewareServerGroupsResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("fetch_groups"), userConfig.GetText("E5231"), true);
             }
@@ -334,7 +334,7 @@
                 searchedGroupList.Clear();
                 LdapUserGetParameters userGetParameters = new LdapUserGetParameters { LdapId = selectedLdap.Id, SearchPattern = searchPattern };
                 RestResponse<List<LdapUserGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetLdapUsers(userGetParameters);
-                if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+                if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
                 {
                     DisplayMessageInUi!(null, userConfig.GetText("fetch_users"), userConfig.GetText("E5208"), true);
                 }
@@ -351,7 +351,7 @@
                 {
                     GroupGetParameters groupGetParameters = new GroupGetParameters { LdapId = selectedLdap.Id, SearchPattern = searchPattern };
                     RestResponse<List<string>> groupMiddlewareServerResponse = await middlewareClient.GetGroups(groupGetParameters);
-                    if (groupMiddlewareServerResponse.StatusCode != HttpStatusCode.OK)
+                    if (groupMiddlewareServerResponse.StatusCode != HttpStatusCode.OK || groupMiddlewareServerResponse.Data == null)
                     {
                         DisplayMessageInUi!(null, userConfig.GetText("fetch_groups"), userConfig.GetText("E5231"), true);
                     }

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsTenants.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsTenants.razor
@@ -292,7 +292,7 @@
         try
         {
             RestResponse<List<TenantGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetTenants();
-            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("get_tenant_data"), userConfig.GetText("E5284"), true);
             }

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsUsers.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsUsers.razor
@@ -352,7 +352,7 @@
 
             // Get users from uiusers table
             RestResponse<List<UserGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetUsers();
-            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("fetch_users_local"), userConfig.GetText("E5209"), true);
             }
@@ -495,7 +495,7 @@
             // get users from Ldap
             LdapUserGetParameters userGetParameters = new LdapUserGetParameters { LdapId = internalLdap.Id, SearchPattern = "" };
             RestResponse<List<LdapUserGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetLdapUsers(userGetParameters);
-            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("get_user_from_ldap"), userConfig.GetText("E5208"), true);
             }
@@ -532,7 +532,7 @@
         try
         {
             RestResponse<List<GroupGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetInternalGroups();
-            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("fetch_groups"), userConfig.GetText("E5231"), true);
             }
@@ -561,7 +561,7 @@
         try
         {
             RestResponse<List<RoleGetReturnParameters>> middlewareServerResponse = await middlewareClient.GetAllRoles();
-            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+            if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
             {
                 DisplayMessageInUi!(null, userConfig.GetText("fetch_roles"), userConfig.GetText("E5251"), true);
             }
@@ -974,7 +974,7 @@
     {
         try
         {
-            string errorMsg;
+            string errorMsg = "";
             if (actUser.Password == null || actUser.Password == "")
             {
                 DisplayMessageInUi!(null, userConfig.GetText("reset_password"), userConfig.GetText("E5218"), true);
@@ -998,7 +998,10 @@
                 }
                 else
                 {
-                    errorMsg = middlewareServerResponse.Data;
+                    if (middlewareServerResponse.Data != null)
+                    {
+                        errorMsg = middlewareServerResponse.Data;
+                    }
                     if(errorMsg != "")
                     {
                         DisplayMessageInUi!(null, userConfig.GetText("reset_password"), errorMsg, true);

--- a/roles/ui/files/FWO.UI/Services/PasswordChanger.cs
+++ b/roles/ui/files/FWO.UI/Services/PasswordChanger.cs
@@ -27,7 +27,7 @@ namespace FWO.Ui.Services
                     // Ldap call
                     UserChangePasswordParameters parameters = new UserChangePasswordParameters { LdapId = userConfig.User.LdapConnection.Id, NewPassword = newPassword1, OldPassword = oldPassword, UserId = userConfig.User.DbId };
                     RestResponse<string> middlewareServerResponse = await middlewareClient.ChangePassword(parameters);
-                    if (middlewareServerResponse.StatusCode != HttpStatusCode.OK)
+                    if (middlewareServerResponse.StatusCode != HttpStatusCode.OK || middlewareServerResponse.Data == null)
                     {
                         errorMsg = "internal error";
                     }


### PR DESCRIPTION
- deactivation of Ldap connections -> #1346 
- test connection button in ldap edit mode: currently tests only connection itself, no search (-> #1329)
- some more help texts
- fix for autodiscovery: identify disabled gateways in existing managements 
- fix for monitoring: extend hasura access rights for reporter etc for alert (subscription)
- eliminate some warnings