### PR TITLE
enrich schedule + archive page, review column filters

### DIFF
--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -10247,6 +10247,28 @@
                   }
                 },
                 {
+                  "role": "middleware-server",
+                  "permission": {
+                    "columns": [
+                      "id",
+                      "language",
+                      "txt"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
+                  "role": "recertifier",
+                  "permission": {
+                    "columns": [
+                      "id",
+                      "language",
+                      "txt"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
                   "role": "reporter",
                   "permission": {
                     "columns": [

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -2,7 +2,6 @@
   "type": "replace_metadata",
   "version": 2,
   "args": {
-
     "metadata": {
       "version": 3,
       "sources": [
@@ -4747,16 +4746,18 @@
                     "check": {},
                     "columns": [
                       "report_id",
-                      "report_template_id",
-                      "report_start_time",
-                      "report_end_time",
-                      "report_json",
-                      "report_pdf",
-                      "report_csv",
-                      "report_html",
+                      "description",
                       "report_name",
                       "report_owner_id",
-                      "tenant_wide_visible"
+                      "report_template_id",
+                      "report_type",
+                      "tenant_wide_visible",
+                      "report_json",
+                      "report_csv",
+                      "report_html",
+                      "report_pdf",
+                      "report_end_time",
+                      "report_start_time"
                     ],
                     "backend_only": false
                   }
@@ -4767,9 +4768,11 @@
                     "check": {},
                     "columns": [
                       "report_id",
+                      "description",
                       "report_name",
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
                       "tenant_wide_visible",
                       "report_json",
                       "report_csv",
@@ -4787,16 +4790,18 @@
                     "check": {},
                     "columns": [
                       "report_id",
-                      "report_template_id",
-                      "report_start_time",
-                      "report_end_time",
-                      "report_json",
-                      "report_pdf",
-                      "report_csv",
-                      "report_html",
+                      "description",
                       "report_name",
                       "report_owner_id",
-                      "tenant_wide_visible"
+                      "report_template_id",
+                      "report_type",
+                      "tenant_wide_visible",
+                      "report_json",
+                      "report_csv",
+                      "report_html",
+                      "report_pdf",
+                      "report_end_time",
+                      "report_start_time"
                     ],
                     "backend_only": false
                   }
@@ -4807,16 +4812,18 @@
                     "check": {},
                     "columns": [
                       "report_id",
-                      "report_template_id",
-                      "report_start_time",
-                      "report_end_time",
-                      "report_json",
-                      "report_pdf",
-                      "report_csv",
-                      "report_html",
+                      "description",
                       "report_name",
                       "report_owner_id",
-                      "tenant_wide_visible"
+                      "report_template_id",
+                      "report_type",
+                      "tenant_wide_visible",
+                      "report_json",
+                      "report_csv",
+                      "report_html",
+                      "report_pdf",
+                      "report_end_time",
+                      "report_start_time"
                     ],
                     "backend_only": false
                   }
@@ -4827,16 +4834,18 @@
                     "check": {},
                     "columns": [
                       "report_id",
-                      "report_template_id",
-                      "report_start_time",
-                      "report_end_time",
-                      "report_json",
-                      "report_pdf",
-                      "report_csv",
-                      "report_html",
+                      "description",
                       "report_name",
                       "report_owner_id",
-                      "tenant_wide_visible"
+                      "report_template_id",
+                      "report_type",
+                      "tenant_wide_visible",
+                      "report_json",
+                      "report_csv",
+                      "report_html",
+                      "report_pdf",
+                      "report_end_time",
+                      "report_start_time"
                     ],
                     "backend_only": false
                   }
@@ -4847,16 +4856,18 @@
                     "check": {},
                     "columns": [
                       "report_id",
-                      "report_template_id",
-                      "report_start_time",
-                      "report_end_time",
-                      "report_json",
-                      "report_pdf",
-                      "report_csv",
-                      "report_html",
+                      "description",
                       "report_name",
                       "report_owner_id",
-                      "tenant_wide_visible"
+                      "report_template_id",
+                      "report_type",
+                      "tenant_wide_visible",
+                      "report_json",
+                      "report_csv",
+                      "report_html",
+                      "report_pdf",
+                      "report_end_time",
+                      "report_start_time"
                     ],
                     "backend_only": false
                   }
@@ -4868,16 +4879,18 @@
                   "permission": {
                     "columns": [
                       "report_id",
-                      "report_template_id",
-                      "report_start_time",
-                      "report_end_time",
-                      "report_json",
-                      "report_pdf",
-                      "report_csv",
-                      "report_html",
+                      "description",
                       "report_name",
                       "report_owner_id",
-                      "tenant_wide_visible"
+                      "report_template_id",
+                      "report_type",
+                      "tenant_wide_visible",
+                      "report_json",
+                      "report_csv",
+                      "report_html",
+                      "report_pdf",
+                      "report_end_time",
+                      "report_start_time"
                     ],
                     "filter": {}
                   }
@@ -4886,17 +4899,19 @@
                   "role": "fw-admin",
                   "permission": {
                     "columns": [
-                      "report_pdf",
+                      "report_id",
+                      "description",
+                      "report_name",
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
                       "tenant_wide_visible",
-                      "report_id",
                       "report_json",
                       "report_csv",
                       "report_html",
+                      "report_pdf",
                       "report_end_time",
-                      "report_start_time",
-                      "report_name"
+                      "report_start_time"
                     ],
                     "filter": {
                       "report_owner_id": {
@@ -4910,17 +4925,19 @@
                   "role": "recertifier",
                   "permission": {
                     "columns": [
-                      "report_pdf",
+                      "report_id",
+                      "description",
+                      "report_name",
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
                       "tenant_wide_visible",
-                      "report_id",
                       "report_json",
                       "report_csv",
                       "report_html",
+                      "report_pdf",
                       "report_end_time",
-                      "report_start_time",
-                      "report_name"
+                      "report_start_time"
                     ],
                     "filter": {
                       "report_owner_id": {
@@ -4934,17 +4951,19 @@
                   "role": "reporter",
                   "permission": {
                     "columns": [
-                      "report_pdf",
+                      "report_id",
+                      "description",
+                      "report_name",
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
                       "tenant_wide_visible",
-                      "report_id",
                       "report_json",
                       "report_csv",
                       "report_html",
+                      "report_pdf",
                       "report_end_time",
-                      "report_start_time",
-                      "report_name"
+                      "report_start_time"
                     ],
                     "filter": {
                       "report_owner_id": {
@@ -4958,17 +4977,19 @@
                   "role": "reporter-viewall",
                   "permission": {
                     "columns": [
-                      "report_pdf",
+                      "report_id",
+                      "description",
+                      "report_name",
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
                       "tenant_wide_visible",
-                      "report_id",
                       "report_json",
                       "report_csv",
                       "report_html",
+                      "report_pdf",
                       "report_end_time",
-                      "report_start_time",
-                      "report_name"
+                      "report_start_time"
                     ],
                     "filter": {
                       "report_owner_id": {
@@ -4986,6 +5007,8 @@
                     "columns": [
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
+                      "description",
                       "tenant_wide_visible",
                       "report_id",
                       "report_json",
@@ -5011,6 +5034,8 @@
                       "report_pdf",
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
+                      "description",
                       "tenant_wide_visible",
                       "report_id",
                       "report_json",
@@ -5035,6 +5060,8 @@
                       "report_pdf",
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
+                      "description",
                       "tenant_wide_visible",
                       "report_id",
                       "report_json",
@@ -5059,6 +5086,8 @@
                       "report_pdf",
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
+                      "description",
                       "tenant_wide_visible",
                       "report_id",
                       "report_json",
@@ -5083,6 +5112,8 @@
                       "report_pdf",
                       "report_owner_id",
                       "report_template_id",
+                      "report_type",
+                      "description",
                       "tenant_wide_visible",
                       "report_id",
                       "report_json",
@@ -11688,6 +11719,6 @@
           "comment": null
         }
       ]
-    }  
+    }
   }
 }

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -8238,7 +8238,13 @@
                 {
                   "role": "reporter",
                   "permission": {
-                    "columns": [],
+                    "columns": [
+                      "mgm_id",
+                      "rule_id",
+                      "user_id",
+                      "created",
+                      "removed"
+                    ],
                     "filter": {
                       "mgm_id": {
                         "_in": "X-Hasura-visible-managements"

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -2986,6 +2986,36 @@
                   }
                 },
                 {
+                  "role": "middleware-server",
+                  "permission": {
+                    "columns": [
+                      "culture_info",
+                      "name"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
+                  "role": "recertifier",
+                  "permission": {
+                    "columns": [
+                      "culture_info",
+                      "name"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
+                  "role": "reporter",
+                  "permission": {
+                    "columns": [
+                      "culture_info",
+                      "name"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
                   "role": "reporter-viewall",
                   "permission": {
                     "columns": [
@@ -3081,6 +3111,16 @@
                   }
                 },
                 {
+                  "role": "fw-admin",
+                  "permission": {
+                    "columns": [
+                      "ldap_connection_id",
+                      "ldap_tenant_level"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
                   "role": "middleware-server",
                   "permission": {
                     "columns": [
@@ -3102,6 +3142,36 @@
                       "ldap_write_user",
                       "ldap_write_user_pwd",
                       "tenant_id"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
+                  "role": "recertifier",
+                  "permission": {
+                    "columns": [
+                      "ldap_connection_id",
+                      "ldap_tenant_level"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
+                  "role": "reporter",
+                  "permission": {
+                    "columns": [
+                      "ldap_connection_id",
+                      "ldap_tenant_level"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
+                  "role": "reporter-viewall",
+                  "permission": {
+                    "columns": [
+                      "ldap_connection_id",
+                      "ldap_tenant_level"
                     ],
                     "filter": {}
                   }

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -5307,6 +5307,7 @@
                       "report_schedule_owner",
                       "report_schedule_repeat",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "backend_only": false
@@ -5325,6 +5326,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "backend_only": false
@@ -5343,6 +5345,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "backend_only": false
@@ -5361,6 +5364,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "backend_only": false
@@ -5379,6 +5383,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "backend_only": false
@@ -5398,6 +5403,7 @@
                       "report_schedule_repeat",
                       "report_schedule_every",
                       "report_schedule_active",
+                      "report_schedule_counter",
                       "report_schedule_repetitions"
                     ],
                     "filter": {}
@@ -5415,6 +5421,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "filter": {
@@ -5466,6 +5473,7 @@
                       "report_schedule_repeat",
                       "report_schedule_every",
                       "report_schedule_active",
+                      "report_schedule_counter",
                       "report_schedule_repetitions"
                     ],
                     "filter": {},
@@ -5484,6 +5492,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "filter": {
@@ -5505,6 +5514,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "filter": {
@@ -5526,6 +5536,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "filter": {
@@ -5578,6 +5589,7 @@
                       "report_schedule_owner",
                       "report_schedule_repeat",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "filter": {
@@ -5600,6 +5612,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "filter": {
@@ -5622,6 +5635,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "filter": {
@@ -5644,6 +5658,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "filter": {
@@ -5666,6 +5681,7 @@
                       "report_schedule_repeat",
                       "report_schedule_repetitions",
                       "report_schedule_start_time",
+                      "report_schedule_counter",
                       "report_template_id"
                     ],
                     "filter": {

--- a/roles/database/files/sql/creation/fworch-create-tables.sql
+++ b/roles/database/files/sql/creation/fworch-create-tables.sql
@@ -1009,6 +1009,8 @@ Create table "report"
 	"report_name" varchar NOT NULL,
 	"report_owner_id" Integer NOT NULL, --FK to uiuser
 	"tenant_wide_visible" Integer,
+	"report_type" Integer,
+	"description" varchar,
  	primary key ("report_id")
 );
 
@@ -1023,6 +1025,7 @@ Create table if not exists "report_schedule"
 	"report_schedule_every" Integer Not NULL Default 1, -- x - every x days/weeks/months/years
 	"report_schedule_active" Boolean Default TRUE,
 	"report_schedule_repetitions" Integer,
+	"report_schedule_counter" Integer Not NULL Default 0,
  	primary key ("report_schedule_id")
 );
 

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -1668,13 +1668,19 @@ INSERT INTO txt VALUES ('H2016', 'German',  'Aktiv-Kennzeichen: Nur als aktiv ge
 INSERT INTO txt VALUES ('H2016', 'English', 'Active Flag: Only schedules with this flag set will be executed.
     So report schedules for future use can be prepared, resp. schedules currently not needed do not have to be deleted.
 ');
+INSERT INTO txt VALUES ('H2017', 'German',  'Eigent&uuml;mer: Ersteller dieses Termins.');
+INSERT INTO txt VALUES ('H2017', 'English', 'Owner: Creator of this schedule.');
+INSERT INTO txt VALUES ('H2018', 'German',  'Z&auml;hler: Z&auml;hlt, wie viele Reports mit diesem Terminauftrag bereits erstellt wurden.');
+INSERT INTO txt VALUES ('H2018', 'English', 'Count: Counts how many reports have already been created with this schedule.');
 
-INSERT INTO txt VALUES ('H3001', 'German',  'Hier sind die archivierten Reports mit Name sowie Informationen zum Erzeugungsdatum und Eigent&uuml;mer zu finden.
+INSERT INTO txt VALUES ('H3001', 'German',  'Hier sind die archivierten Reports mit Name sowie Informationen zu Erzeugungsdatum, Typ, Vorlage (nur bei termingesteuerten Reports), 
+    Eigent&uuml;mer sowie eine kurze Beschreibung des Inhalts zu finden.
     Sie k&ouml;nnen zum einen durch Export manuell erzeugter Reports durch Setzen des "Archiv"-Kennzeichens in <a href="/help/reporting/export">Export Report</a> erzeugt werden.
     Zum anderen finden sich hier auch die durch das <a href="/help/scheduling">Scheduling</a> erzeugten Reports.
     Die archivierten Reports k&ouml;nnen von hier heruntergeladen oder gel&ouml;scht werden.
 ');
-INSERT INTO txt VALUES ('H3001', 'English', 'Here the archived reports can be found with name and information about creation date and owner. 
+INSERT INTO txt VALUES ('H3001', 'English', 'Here the archived reports can be found with name and information about creation date, type, template (only at scheduled reports),
+    owner and a short description about the content. 
     They may be created on the one hand by exporting manually created reports with setting the flag "Archive" in <a href="/help/reporting/export">Export Report</a>.
     On the other hand here also the reports created by the <a href="/help/scheduling">Scheduling</a> can be found.
     It is possible to download or delete these archived reports.

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -118,12 +118,12 @@ INSERT INTO txt VALUES ('whats_new_facts',	    'German', 	'
     <li>GraphQL API f&uuml;r Automatisierungen</li>
     <li>Firewall-Regel Rezertifizierungsworkflow - beseitigen Sie ihre Altlasten und erf&uuml;llen Sie aktuelle regulatorische Anforderungen.</li>
     <li>F&uuml;r FortiManager und CheckPoint (Stand-Alone & MDS Manager) ist eine Auto Discovery Funktion enthalten, die ausgehend 
-    vom Mnagement-System alle definierten Domains/SubManager sowie Devices automatisch anlegt sowie &Auml;nderungen erkennt 
+    vom Management-System alle definierten Domains/SubManager sowie Devices automatisch anlegt sowie &Auml;nderungen erkennt 
     und diese zur automatischen Konfigurations&auml;nderung anbietet.</li>
-    <li>Einf&uuml;rung Monitoring und Alerting Modul - folgende Ereignisse werden protokolliert, in eine Log-Datei geschrieben (zur ggf. weiteren Auswertung per SIEM)
+    <li>Einf&uuml;hrung Monitoring und Alerting Modul - folgende Ereignisse werden protokolliert, in eine Log-Datei geschrieben (zur ggf. weiteren Auswertung per SIEM)
      und dem Nutzer in der Oberfl&auml;che zur Erinnerung angezeigt:
      <ul>
-        <li>&Auml;nderungen an angebundenen Firewall-Systemen, die im regelm&auml;&szlig; laufenden Hintergrund-Auto-Discovery-Prozess erkannt werden</li>
+        <li>&Auml;nderungen an angebundenen Firewall-Systemen, die im regelm&auml;&szlig;ig laufenden Hintergrund-Auto-Discovery-Prozess erkannt werden</li>
         <li>Beim Import auftretende Fehler</li>
         <li>Warnungen & Fehler, die in der Nutzeroberfl&auml;che angezeigt werden</li>
      </ul>
@@ -447,6 +447,8 @@ INSERT INTO txt VALUES ('owner',				'German', 	'Eigent&uuml;mer');
 INSERT INTO txt VALUES ('owner',				'English', 	'Owner');
 INSERT INTO txt VALUES ('active', 			    'German',	'Aktiv');
 INSERT INTO txt VALUES ('active', 			    'English',	'Active');
+INSERT INTO txt VALUES ('count', 			    'German',	'Z&auml;hler');
+INSERT INTO txt VALUES ('count', 			    'English',	'Count');
 INSERT INTO txt VALUES ('output_format', 		'German',	'Ausgabeformat');
 INSERT INTO txt VALUES ('output_format', 		'English',	'Output Format');
 INSERT INTO txt VALUES ('report_schedule', 		'German',	'Reporttermin');

--- a/roles/database/files/upgrade/5.6.7.sql
+++ b/roles/database/files/upgrade/5.6.7.sql
@@ -1,2 +1,7 @@
 
 ALTER TABLE "ldap_connection" ADD column IF NOT EXISTS "active" Boolean NOT NULL Default TRUE;
+
+ALTER TABLE "report" ADD column IF NOT EXISTS "report_type" Integer;
+ALTER TABLE "report" ADD column IF NOT EXISTS "description" varchar;
+
+ALTER TABLE "report_schedule" ADD column IF NOT EXISTS "report_schedule_counter" Integer Not NULL Default 0;

--- a/roles/lib/files/FWO.Api.Client/APIcalls/report/addGeneratedReport.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/report/addGeneratedReport.graphql
@@ -8,6 +8,8 @@
   $report_html: String
   $report_json: json
   $report_template_id: Int
+  $report_type: Int
+  $description: String
 ) {
     insert_report(
       objects: {
@@ -20,6 +22,8 @@
         report_html: $report_html
         report_json: $report_json
         report_template_id : $report_template_id
+        report_type: $report_type
+        description: $description
   }
   ) {
         returning {

--- a/roles/lib/files/FWO.Api.Client/APIcalls/report/countReportSchedule.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/report/countReportSchedule.graphql
@@ -1,0 +1,8 @@
+﻿mutation countReportSchedule($report_schedule_id: bigint!) {
+  update_report_schedule(
+    where: {report_schedule_id: {_eq: $report_schedule_id}},
+    _inc: {report_schedule_counter: 1}
+  ) {
+    affected_rows
+  }   
+}

--- a/roles/lib/files/FWO.Api.Client/APIcalls/report/getGeneratedReports.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/report/getGeneratedReports.graphql
@@ -4,6 +4,8 @@
     report_name
     report_start_time
     report_end_time
+    report_type
+    description
     uiuser {
       uiuser_username
     }

--- a/roles/lib/files/FWO.Api.Client/APIcalls/report/getReportSchedules.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/report/getReportSchedules.graphql
@@ -19,5 +19,6 @@ query getReportSchedules {
     report_schedule_formats{
       report_schedule_format_name
     }
+    report_schedule_counter
   }
 }

--- a/roles/lib/files/FWO.Api.Client/APIcalls/report/getReportSchedules.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/report/getReportSchedules.graphql
@@ -8,6 +8,9 @@ query getReportSchedules {
     report_schedule_owner_user: uiuser {
       uiuser_id
       uiuser_username
+      ldap_connection: ldap_connection {
+        ldap_connection_id
+      }
     }
     report_schedule_active
     report_schedule_template: report_template {

--- a/roles/lib/files/FWO.Api.Client/APIcalls/report/subscribeReportScheduleChanges.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/report/subscribeReportScheduleChanges.graphql
@@ -9,6 +9,9 @@
       uiuser_id
       uiuser_username
       uuid
+      ldap_connection: ldap_connection {
+        ldap_connection_id
+      }
     }
     report_schedule_active
     report_schedule_template: report_template {

--- a/roles/lib/files/FWO.Api.Client/Data/ReportFile.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/ReportFile.cs
@@ -41,6 +41,12 @@ namespace FWO.Api.Data
         [JsonProperty("report_csv"), JsonPropertyName("report_csv")]
         public string? Csv { get; set; }
 
+        [JsonProperty("report_type"), JsonPropertyName("report_type")]
+        public int? Type { get; set; }
+
+        [JsonProperty("description"), JsonPropertyName("description")]
+        public String? Description { get; set; }
+
         public void Sanitize()
         {
             Name = Sanitizer.SanitizeMand(Name);

--- a/roles/lib/files/FWO.Api.Client/Data/ScheduledReport.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/ScheduledReport.cs
@@ -32,6 +32,9 @@ namespace FWO.Api.Data
         [JsonProperty("report_schedule_active"), JsonPropertyName("report_schedule_active")]
         public bool Active { get; set; }
 
+        [JsonProperty("report_schedule_counter"), JsonPropertyName("report_schedule_counter")]
+        public int Counter { get; set; }
+
         public void Sanitize()
         {
             Name = Sanitizer.SanitizeMand(Name);

--- a/roles/lib/files/FWO.Api.Client/Queries/ReportQueries.cs
+++ b/roles/lib/files/FWO.Api.Client/Queries/ReportQueries.cs
@@ -20,6 +20,7 @@ namespace FWO.ApiClient.Queries
         public static readonly string editReportSchedule;
         public static readonly string deleteReportSchedule;
         public static readonly string getReportSchedules;
+        public static readonly string countReportSchedule;
 
         public static readonly string getReportsOverview;
 
@@ -42,6 +43,7 @@ namespace FWO.ApiClient.Queries
                 editReportSchedule = File.ReadAllText(QueryPath + "report/editReportSchedule.graphql");
                 deleteReportSchedule = File.ReadAllText(QueryPath + "report/deleteReportSchedule.graphql");
                 getReportSchedules = File.ReadAllText(QueryPath + "report/getReportSchedules.graphql");
+                countReportSchedule = File.ReadAllText(QueryPath + "report/countReportSchedule.graphql");
                 getReportsOverview = File.ReadAllText(QueryPath + "report/getReportsOverview.graphql");
                 getReportsById = File.ReadAllText(QueryPath + "report/getReportById.graphql");
                 getReportTemplates = File.ReadAllText(QueryPath + "report/getReportTemplates.graphql");

--- a/roles/lib/files/FWO.Report/ReportChanges.cs
+++ b/roles/lib/files/FWO.Report/ReportChanges.cs
@@ -10,7 +10,7 @@ namespace FWO.Report
 {
     public class ReportChanges : ReportBase
     {
-        public ReportChanges(DynGraphqlQuery query, UserConfig userConfig) : base(query, userConfig) { }
+        public ReportChanges(DynGraphqlQuery query, UserConfig userConfig, ReportType reportType) : base(query, userConfig, reportType) { }
 
         public override async Task<bool> GetObjectsInReport(int objectsPerFetch, APIConnection apiConnection, Func<Management[], Task> callback)
         {
@@ -48,6 +48,24 @@ namespace FWO.Report
             }
         }
 
+        public override string SetDescription()
+        {
+            int managementCounter = 0;
+            int deviceCounter = 0;
+            int ruleChangeCounter = 0;
+            foreach (Management management in Managements.Where(mgt => !mgt.Ignore && mgt.Devices != null &&
+                    Array.Exists(mgt.Devices, device => device.RuleChanges != null && device.RuleChanges.Length > 0)))
+            {
+                managementCounter++;
+                foreach (Device device in management.Devices.Where(dev => dev.RuleChanges != null && dev.RuleChanges.Length > 0))
+                {
+                    deviceCounter++;
+                    ruleChangeCounter += device.RuleChanges.Length;
+                }
+            }
+            return $"{managementCounter} {userConfig.GetText("managements")}, {deviceCounter} {userConfig.GetText("gateways")}, {ruleChangeCounter} {userConfig.GetText("changes")}";
+        }
+
         public override string ExportToCsv()
         {
             StringBuilder csvBuilder = new StringBuilder();
@@ -71,7 +89,7 @@ namespace FWO.Report
             RuleChangeDisplay ruleChangeDisplay = new RuleChangeDisplay(userConfig);
 
             foreach (Management management in Managements.Where(mgt => !mgt.Ignore && mgt.Devices != null &&
-            Array.Exists(mgt.Devices, device => device.RuleChanges != null && device.RuleChanges.Length > 0)))
+                    Array.Exists(mgt.Devices, device => device.RuleChanges != null && device.RuleChanges.Length > 0)))
             {
                 report.AppendLine($"<h3>{management.Name}</h3>");
                 report.AppendLine("<hr>");

--- a/roles/lib/files/FWO.Report/ReportNatRules.cs
+++ b/roles/lib/files/FWO.Report/ReportNatRules.cs
@@ -8,7 +8,7 @@ namespace FWO.Report
 {
     public class ReportNatRules : ReportRules
     {
-        public ReportNatRules(DynGraphqlQuery query, UserConfig userConfig) : base(query, userConfig) { }
+        public ReportNatRules(DynGraphqlQuery query, UserConfig userConfig, ReportType reportType) : base(query, userConfig, reportType) { }
 
         private const int ColumnCount = 12;
 

--- a/roles/lib/files/FWO.Report/ReportRules.cs
+++ b/roles/lib/files/FWO.Report/ReportRules.cs
@@ -11,7 +11,7 @@ namespace FWO.Report
 {
     public class ReportRules : ReportBase
     {
-        public ReportRules(DynGraphqlQuery query, UserConfig userConfig) : base(query, userConfig) { }
+        public ReportRules(DynGraphqlQuery query, UserConfig userConfig, ReportType reportType) : base(query, userConfig, reportType) { }
 
         private const byte all = 0, nobj = 1, nsrv = 2, user = 3;
         public bool GotReportedRuleIds { get; protected set; } = false;
@@ -168,6 +168,24 @@ namespace FWO.Report
             }
         }
 
+        public override string SetDescription()
+        {
+            int managementCounter = 0;
+            int deviceCounter = 0;
+            int ruleCounter = 0;
+            foreach (Management management in Managements.Where(mgt => !mgt.Ignore && mgt.Devices != null &&
+                    Array.Exists(mgt.Devices, device => device.Rules != null && device.Rules.Length > 0)))
+            {
+                managementCounter++;
+                foreach (Device device in management.Devices.Where(dev => dev.Rules != null && dev.Rules.Length > 0))
+                {
+                    deviceCounter++;
+                    ruleCounter += device.Rules.Length;
+                }
+            }
+            return $"{managementCounter} {userConfig.GetText("managements")}, {deviceCounter} {userConfig.GetText("gateways")}, {ruleCounter} {userConfig.GetText("rules")}";
+        }
+
         public override string ExportToCsv()
         {
             StringBuilder csvBuilder = new StringBuilder();
@@ -196,7 +214,7 @@ namespace FWO.Report
             RuleDisplay ruleDisplay = new RuleDisplay(userConfig);
 
             foreach (Management management in Managements.Where(mgt => !mgt.Ignore && mgt.Devices != null &&
-            Array.Exists(mgt.Devices, device => device.Rules != null && device.Rules.Length > 0)))
+                    Array.Exists(mgt.Devices, device => device.Rules != null && device.Rules.Length > 0)))
             {
                 management.AssignRuleNumbers();
 

--- a/roles/lib/files/FWO.Report/ReportStatistics.cs
+++ b/roles/lib/files/FWO.Report/ReportStatistics.cs
@@ -14,7 +14,7 @@ namespace FWO.Report
         // TODO: Currently generated in Report.razor as well as here, because of export. Remove dupliacte.
         private Management globalStatisticsManagement = new Management();
 
-        public ReportStatistics(DynGraphqlQuery query, UserConfig userConfig) : base(query, userConfig) { }
+        public ReportStatistics(DynGraphqlQuery query, UserConfig userConfig, ReportType reportType) : base(query, userConfig, reportType) { }
 
         public override async Task<bool> GetObjectsInReport(int objectsPerFetch, APIConnection apiConnection, Func<Management[], Task> callback)
         {

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
@@ -207,6 +207,15 @@ namespace FWO.Middleware.Controllers
         public async Task<Tenant?> GetTenantAsync(UiUser user)
         {
             Tenant tenant = new Tenant();
+            if(loggedInLdap.Id == 0 && user.LdapConnection != null) // user is already assigned to ldap (scheduled reports)
+            {
+                Ldap? existingLdap = ldaps.FirstOrDefault(x => x.Id == user.LdapConnection.Id);
+                if (existingLdap != null)
+                {
+                    loggedInLdap = existingLdap;
+                }
+            }
+
             if (loggedInLdap.TenantId != null)
             {
                 Log.WriteDebug("Get Tenant", $"This LDAP has the fixed tenant {loggedInLdap.TenantId.Value}");

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
@@ -115,7 +115,7 @@ namespace FWO.Middleware.Controllers
                 List<Task> ldapDnRequests = new List<Task>();
                 object dnLock = new object();
 
-                foreach (Ldap currentLdap in ldaps)
+                foreach (Ldap currentLdap in ldaps.Where(x => x.Active))
                 {
                     ldapDnRequests.Add(Task.Run(() =>
                     {

--- a/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
@@ -122,6 +122,7 @@ namespace FWO.Middleware.Server
                         GenerationDateStart = DateTime.Now,
                         TemplateId = report.Template.Id,
                         OwnerId = report.Owner.DbId,
+                        Type = report.Template.ReportParams.ReportType
                     };
 
                     DateTime reportGenerationStartDate = DateTime.Now;
@@ -136,6 +137,8 @@ namespace FWO.Middleware.Server
                     APIConnection apiConnectionUserContext = new APIConnection(apiServerUri, jwt);
                     GlobalConfig globalConfig = await GlobalConfig.ConstructAsync(jwt);
                     UserConfig userConfig = new UserConfig(globalConfig);
+
+                    await apiConnectionUserContext.SendQueryAsync<object>(ReportQueries.countReportSchedule, new { report_schedule_id = report.Id });
 
                     if(!report.Template.ReportParams.DeviceFilter.isAnyDeviceFilterSet())
                     {
@@ -198,6 +201,8 @@ namespace FWO.Middleware.Server
                         report_csv = reportFile.Csv,
                         report_html = reportFile.Html,
                         report_json = reportFile.Json,
+                        report_type = reportFile.Type,
+                        description = reportRules.SetDescription()
                     };
 
                     await apiConnectionUserContext.SendQueryAsync<object>(ReportQueries.addGeneratedReport, queryVariables);

--- a/roles/ui/files/FWO.UI/Pages/Help/HelpScheduling.cshtml
+++ b/roles/ui/files/FWO.UI/Pages/Help/HelpScheduling.cshtml
@@ -19,7 +19,9 @@
         <li>@(Html.Raw(userConfig.GetText("H2012")))</li>
         <li>@(Html.Raw(userConfig.GetText("H2013")))</li>
         <li>@(Html.Raw(userConfig.GetText("H2014")))</li>
-        <li>@(Html.Raw(userConfig.GetText("H2015")))</li>
+        <li>@(Html.Raw(userConfig.GetText("H2017")))</li>
         <li>@(Html.Raw(userConfig.GetText("H2016")))</li>
+        <li>@(Html.Raw(userConfig.GetText("H2018")))</li>
+        <li>@(Html.Raw(userConfig.GetText("H2015")))</li>
     </ul>
 </div>

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorAlerts.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorAlerts.razor
@@ -10,24 +10,24 @@
 <hr />
 
 <Table TableClass="table table-bordered table-sm table-responsive vheight75 overflow-auto sticky-header" TableItem="Alert" Items="alertEntrys" PageSize="100">
-    <Column TableItem="Alert" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" />
-    <Column TableItem="Alert" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" />
-    <Column TableItem="Alert" Title="@(userConfig.GetText("source"))" Field="@(x => x.Source)" />
-    <Column TableItem="Alert" Title="@(userConfig.GetText("title"))" Field="@(x => x.Title)" />
-    <Column TableItem="Alert" Title="@(userConfig.GetText("code"))" Field="@(x => x.AlertCode)" />
-    <Column TableItem="Alert" Title="@(userConfig.GetText("id"))" Field="@(x => x.ManagementId)" />
-    <Column TableItem="Alert" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" >
+    <Column TableItem="Alert" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)"  Sortable="true" Filterable="true"/>
+    <Column TableItem="Alert" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)"  Sortable="true" Filterable="true"/>
+    <Column TableItem="Alert" Title="@(userConfig.GetText("source"))" Field="@(x => x.Source)" Sortable="true" Filterable="true"/>
+    <Column TableItem="Alert" Title="@(userConfig.GetText("title"))" Field="@(x => x.Title)" Sortable="true" Filterable="true"/>
+    <Column TableItem="Alert" Title="@(userConfig.GetText("code"))" Field="@(x => x.AlertCode)" Sortable="true" Filterable="true"/>
+    <Column TableItem="Alert" Title="@(userConfig.GetText("id"))" Field="@(x => x.ManagementId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="Alert" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" Sortable="true">
         <Template>
             @(managements.FirstOrDefault(x => x.Id == context.ManagementId)?.Name)
         </Template>
     </Column>
-    <Column TableItem="Alert" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" />
-    <Column TableItem="Alert" Title="@(userConfig.GetText("acknowledged_by"))" Field="@(x => x.AcknowledgedBy)" >
+    <Column TableItem="Alert" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" Sortable="true" Filterable="true"/>
+    <Column TableItem="Alert" Title="@(userConfig.GetText("acknowledged_by"))" Field="@(x => x.AcknowledgedBy)" Sortable="true">
         <Template>
             @(uiUsers.FirstOrDefault(x => x.DbId == context.AcknowledgedBy)?.Name)
         </Template>
     </Column>
-    <Column TableItem="Alert" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.AckTimestamp)" />
+    <Column TableItem="Alert" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.AckTimestamp)" Sortable="true" Filterable="true"/>
     <Pager ShowPageNumber="true" ShowTotalCount="true" />
 </Table>
 

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorAll.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorAll.razor
@@ -9,21 +9,21 @@
 <h3>@(userConfig.GetText("monitoring"))</h3>
 
 <Table TableClass="table table-bordered table-sm table-responsive vheight75 overflow-auto sticky-header" TableItem="LogEntry" Items="logEntrys" PageSize="100">
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("source"))" Field="@(x => x.Source)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("severity"))" Field="@(x => x.Severity)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("suspected_cause"))" Field="@(x => x.SuspectedCause)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("device"))" Field="@(x => x.DeviceId)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("import_id"))" Field="@(x => x.ImportId)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_type"))" Field="@(x => x.ObjectType)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_name"))" Field="@(x => x.ObjectName)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_uid"))" Field="@(x => x.ObjectUid)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("rule_uid"))" Field="@(x => x.RuleUid)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("rule_id"))" Field="@(x => x.RuleId)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("user"))" Field="@(x => x.UserId)" />
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("source"))" Field="@(x => x.Source)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("severity"))" Field="@(x => x.Severity)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("suspected_cause"))" Field="@(x => x.SuspectedCause)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("device"))" Field="@(x => x.DeviceId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("import_id"))" Field="@(x => x.ImportId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_type"))" Field="@(x => x.ObjectType)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_name"))" Field="@(x => x.ObjectName)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_uid"))" Field="@(x => x.ObjectUid)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("rule_uid"))" Field="@(x => x.RuleUid)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("rule_id"))" Field="@(x => x.RuleId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("user"))" Field="@(x => x.UserId)" Sortable="true" Filterable="true"/>
     <Pager ShowPageNumber="true" ShowTotalCount="true" />
 </Table>
 

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorAutodiscoveryLog.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorAutodiscoveryLog.razor
@@ -10,21 +10,21 @@
 <hr />
 
 <Table TableClass="table table-bordered table-sm table-responsive vheight75 overflow-auto sticky-header" TableItem="LogEntry" Items="logEntrys" PageSize="100">
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("found_by"))" Field="@(x => x.UserId)" >
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("found_by"))" Field="@(x => x.UserId)" Sortable="true">
         <Template>
             @(uiUsers.FirstOrDefault(x => x.DbId == context.UserId)?.Name)
         </Template>
     </Column>
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("title"))" Field="@(x => x.SuspectedCause)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.ManagementId)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" >
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("title"))" Field="@(x => x.SuspectedCause)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.ManagementId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" Sortable="true">
         <Template>
             @(managements.FirstOrDefault(x => x.Id == context.ManagementId)?.Name)
         </Template>
     </Column>
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" />
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" Sortable="true" Filterable="true"/>
     <Pager ShowPageNumber="true" ShowTotalCount="true" />
 </Table>
 

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorDailyChecks.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorDailyChecks.razor
@@ -10,11 +10,11 @@
 <hr />
 
 <Table TableClass="table table-bordered table-sm table-responsive vheight75 overflow-auto sticky-header" TableItem="LogEntry" Items="logEntrys" PageSize="100">
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("severity"))" Field="@(x => x.Severity)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("title"))" Field="@(x => x.SuspectedCause)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" />
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("severity"))" Field="@(x => x.Severity)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("title"))" Field="@(x => x.SuspectedCause)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" Sortable="true" Filterable="true"/>
     <Pager ShowPageNumber="true" ShowTotalCount="true" />
 </Table>
 

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorImportLog.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorImportLog.razor
@@ -10,19 +10,19 @@
 <hr />
 
 <Table TableClass="table table-bordered table-sm table-responsive vheight75 overflow-auto sticky-header" TableItem="LogEntry" Items="logEntrys" PageSize="100">
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("severity"))" Field="@(x => x.Severity)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("import_id"))" Field="@(x => x.ImportId)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("suspected_cause"))" Field="@(x => x.SuspectedCause)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("device"))" Field="@(x => x.DeviceId)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("rule_uid"))" Field="@(x => x.RuleUid)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("rule_id"))" Field="@(x => x.RuleId)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_type"))" Field="@(x => x.ObjectType)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_name"))" Field="@(x => x.ObjectName)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_uid"))" Field="@(x => x.ObjectUid)" />
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("severity"))" Field="@(x => x.Severity)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("import_id"))" Field="@(x => x.ImportId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("suspected_cause"))" Field="@(x => x.SuspectedCause)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("device"))" Field="@(x => x.DeviceId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("rule_uid"))" Field="@(x => x.RuleUid)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("rule_id"))" Field="@(x => x.RuleId)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_type"))" Field="@(x => x.ObjectType)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_name"))" Field="@(x => x.ObjectName)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("object_uid"))" Field="@(x => x.ObjectUid)" Sortable="true" Filterable="true"/>
     <Pager ShowPageNumber="true" ShowTotalCount="true" />
 </Table>
 

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorImportStatus.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorImportStatus.razor
@@ -36,7 +36,7 @@
                 @if (context.LastIncompleteImport != null && context.LastIncompleteImport.Length > 0)
                 {
                     <div class="btn-group">
-                        @if(context.LastIncompleteImport[0].StartTime < DateTime.Now.AddMinutes(0))
+                        @if(context.LastIncompleteImport[0].StartTime < DateTime.Now.AddMinutes(-5))
                         {
                             <button class="btn btn-sm btn-danger" @onclick:preventDefault @onclick="() => RequestRollback(context)">@(userConfig.GetText("rollback"))</button>
                         }

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorImportStatus.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorImportStatus.razor
@@ -26,17 +26,17 @@
         </Column>
         <Column TableItem="ImportStatus" Title="@(userConfig.GetText("id"))" Field="@(x => x.MgmId)" Sortable="true" Filterable="true" />
         <Column TableItem="ImportStatus" Title="@(userConfig.GetText("management"))" Field="@(x => x.MgmName)" Sortable="true" Filterable="true" />
-        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("type"))" Field="@(x => x.DeviceType.Id)" Sortable="true" Filterable="true">
+        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("type"))" Field="@(x => x.DeviceType.Id)" Sortable="true">
             <Template>
                 @(context.DeviceType.NameVersion())
             </Template>
         </Column>
-        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("last_incomplete"))" Field="@(x => x.LastIncompleteImport)" Sortable="true" Filterable="true">
+        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("last_incomplete"))" Field="@(x => x.LastIncompleteImport)">
             <Template>
                 @if (context.LastIncompleteImport != null && context.LastIncompleteImport.Length > 0)
                 {
                     <div class="btn-group">
-                        @if(context.LastIncompleteImport[0].StartTime < DateTime.Now.AddMinutes(-5))
+                        @if(context.LastIncompleteImport[0].StartTime < DateTime.Now.AddMinutes(0))
                         {
                             <button class="btn btn-sm btn-danger" @onclick:preventDefault @onclick="() => RequestRollback(context)">@(userConfig.GetText("rollback"))</button>
                         }
@@ -45,7 +45,7 @@
                 }
             </Template>
         </Column>
-        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("last_success"))" Field="@(x => x.LastSuccessfulImport)" Sortable="true" Filterable="true">
+        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("last_success"))" Field="@(x => x.LastSuccessfulImport)">
             <Template>
                 @if (context.LastSuccessfulImport != null && context.LastSuccessfulImport.Length > 0)
                 {
@@ -53,7 +53,7 @@
                 }
             </Template>
         </Column>
-        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("last_import"))" Field="@(x => x.LastImport)" Sortable="true" Filterable="true">
+        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("last_import"))" Field="@(x => x.LastImport)">
             <Template>
                 @if (context.LastImport != null && context.LastImport.Length > 0)
                 {
@@ -61,7 +61,7 @@
                 }
             </Template>
         </Column>
-        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("success"))" Field="@(x => x.LastImport)" Sortable="true" Filterable="true">
+        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("success"))" Field="@(x => x.LastImport)">
             <Template>
                 @if (context.LastImport != null && context.LastImport.Length > 0)
                 {
@@ -69,7 +69,7 @@
                 }
             </Template>
         </Column>
-        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("errors"))" Field="@(x => x.LastImport)" Sortable="true" Filterable="true">
+        <Column TableItem="ImportStatus" Title="@(userConfig.GetText("errors"))" Field="@(x => x.LastImport)">
             <Template>
                 @if (context.LastImport != null && context.LastImport.Length > 0)
                 {

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorUiLog.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorUiLog.razor
@@ -10,11 +10,11 @@
 <hr />
 
 <Table TableClass="table table-bordered table-sm table-responsive vheight75 overflow-auto sticky-header" TableItem="LogEntry" Items="logEntrys" PageSize="100">
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("severity"))" Field="@(x => x.Severity)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("title"))" Field="@(x => x.SuspectedCause)" />
-    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" />
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("severity"))" Field="@(x => x.Severity)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("title"))" Field="@(x => x.SuspectedCause)" Sortable="true" Filterable="true"/>
+    <Column TableItem="LogEntry" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" Sortable="true" Filterable="true"/>
     <Pager ShowPageNumber="true" ShowTotalCount="true" />
 </Table>
 

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitoringMain.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitoringMain.razor
@@ -60,18 +60,18 @@
                     </AuthorizeView>
                 </Template>
             </Column>
-            <Column TableItem="Alert" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" />
-            <Column TableItem="Alert" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" />
-            <Column TableItem="Alert" Title="@(userConfig.GetText("source"))" Field="@(x => x.Source)" />
-            <Column TableItem="Alert" Title="@(userConfig.GetText("title"))" Field="@(x => x.Title)" />
-            <Column TableItem="Alert" Title="@(userConfig.GetText("code"))" Field="@(x => x.AlertCode)" />
-            <Column TableItem="Alert" Title="@(userConfig.GetText("id"))" Field="@(x => x.ManagementId)" />
-            <Column Context="alert" TableItem="Alert" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" >
+            <Column TableItem="Alert" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true"/>
+            <Column TableItem="Alert" Title="@(userConfig.GetText("timestamp"))" Field="@(x => x.Timestamp)" Sortable="true" Filterable="true"/>
+            <Column TableItem="Alert" Title="@(userConfig.GetText("source"))" Field="@(x => x.Source)" Sortable="true" Filterable="true"/>
+            <Column TableItem="Alert" Title="@(userConfig.GetText("title"))" Field="@(x => x.Title)" Sortable="true" Filterable="true"/>
+            <Column TableItem="Alert" Title="@(userConfig.GetText("code"))" Field="@(x => x.AlertCode)" Sortable="true" Filterable="true"/>
+            <Column TableItem="Alert" Title="@(userConfig.GetText("id"))" Field="@(x => x.ManagementId)" Sortable="true" Filterable="true"/>
+            <Column Context="alert" TableItem="Alert" Title="@(userConfig.GetText("management"))" Field="@(x => x.ManagementId)" Sortable="true">
                 <Template>
                     @(managements.FirstOrDefault(x => x.Id == alert.ManagementId)?.Name)
                 </Template>
             </Column>
-            <Column TableItem="Alert" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" />
+            <Column TableItem="Alert" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" Sortable="true" Filterable="true"/>
             <Pager ShowPageNumber="true" ShowTotalCount="true" />
         </Table>
     }

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Archive.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Archive.razor
@@ -20,11 +20,11 @@
             </div>
         </Template>
     </Column>
-    <Column TableItem="ReportFile" Title="@(userConfig.GetText("name"))" Field="@(reportFile => reportFile.Name)" />
-    <Column TableItem="ReportFile" Title="@(userConfig.GetText("generation_date"))" Field="@(reportFile => reportFile.GenerationDateStart)" />
+    <Column TableItem="ReportFile" Title="@(userConfig.GetText("name"))" Field="@(reportFile => reportFile.Name)" Sortable="true" Filterable="true"/>
+    <Column TableItem="ReportFile" Title="@(userConfig.GetText("generation_date"))" Field="@(reportFile => reportFile.GenerationDateStart)" Sortable="true" Filterable="true"/>
     @*<Column TableItem="ReportFile" Title="Output Format" Field="@(reportFile => reportFile.Type)" /> TODO: ADD TYPE*@
     @*<Column TableItem="ReportFile" Title="Template" Field="@(reportFile => reportFile.Template.Name)" /> TODO: Template (is not always defined - report export)*@
-    <Column TableItem="ReportFile" Title="@(userConfig.GetText("owner"))" Field="@(reportFile => reportFile.Owner.Name)" />
+    <Column TableItem="ReportFile" Title="@(userConfig.GetText("owner"))" Field="@(reportFile => reportFile.Owner.Name)" Sortable="true" Filterable="true"/>
 </Table>
 
 <PopUp Show="ShowDeleteReportFileDialog" Title="@(userConfig.GetText("generated_report"))">

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Archive.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Archive.razor
@@ -21,10 +21,15 @@
         </Template>
     </Column>
     <Column TableItem="ReportFile" Title="@(userConfig.GetText("name"))" Field="@(reportFile => reportFile.Name)" Sortable="true" Filterable="true"/>
+    <Column TableItem="ReportFile" Title="@(userConfig.GetText("report_type"))" Field="@(reportFile => reportFile.Type)" Sortable="true">
+        <Template>
+            @(userConfig.GetText(((FWO.Report.Filter.ReportType)((int)(context.Type ?? 0))).ToString()?.ToLower() ?? "none"))
+        </Template>
+    </Column>
+    <Column TableItem="ReportFile" Title="@(userConfig.GetText("template"))" Field="@(reportFile => reportFile.Template.Name)" Filterable="true"/>
     <Column TableItem="ReportFile" Title="@(userConfig.GetText("generation_date"))" Field="@(reportFile => reportFile.GenerationDateStart)" Sortable="true" Filterable="true"/>
-    @*<Column TableItem="ReportFile" Title="Output Format" Field="@(reportFile => reportFile.Type)" /> TODO: ADD TYPE*@
-    @*<Column TableItem="ReportFile" Title="Template" Field="@(reportFile => reportFile.Template.Name)" /> TODO: Template (is not always defined - report export)*@
     <Column TableItem="ReportFile" Title="@(userConfig.GetText("owner"))" Field="@(reportFile => reportFile.Owner.Name)" Sortable="true" Filterable="true"/>
+    <Column TableItem="ReportFile" Title="@(userConfig.GetText("description"))" Field="@(reportFile => reportFile.Description)" Sortable="true" Filterable="true"/>
 </Table>
 
 <PopUp Show="ShowDeleteReportFileDialog" Title="@(userConfig.GetText("generated_report"))">

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Report.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Report.razor
@@ -831,13 +831,16 @@
 
     private bool NoRuleFound()
     {
-        foreach(var mgmt in currentReport.Managements)
+        if(currentReport != null)
         {
-            foreach(var dev in mgmt.Devices)
+            foreach(var mgmt in currentReport.Managements)
             {
-                if(dev.Rules != null && dev.Rules.Count() > 0)
+                foreach(var dev in mgmt.Devices)
                 {
-                    return false;
+                    if(dev.Rules != null && dev.Rules.Count() > 0)
+                    {
+                        return false;
+                    }
                 }
             }
         }

--- a/roles/ui/files/FWO.UI/Pages/Reporting/ReportExport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/ReportExport.razor
@@ -157,6 +157,8 @@
                             report_pdf = reportExportFile.Pdf,
                             report_html = reportExportFile.Html,
                             report_json = reportExportFile.Json,
+                            report_type = (int?)ReportToExport.ReportType,
+                            description = ReportToExport.SetDescription()
                         };
 
                         await apiConnection.SendQueryAsync<object>(ReportQueries.addGeneratedReport, queryVariables);

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
@@ -33,7 +33,7 @@
 
                             @if(Recertification)
                             {
-                                <Column TableItem="Rule" Context="rule" Title="@(userConfig.GetText("next_recert"))" Field="@(rule => rule.Metadata.NextRecert)" Sortable="true" Filterable="true" />
+                                <Column TableItem="Rule" Context="rule" Title="@(userConfig.GetText("next_recert"))" Field="@(rule => rule.Metadata.NextRecert)" Sortable="true" Filterable="false" />
                                 <Column TableItem="Rule" Title="@(userConfig.GetText("last_recertifier"))" Field="@(rule => rule.Metadata.LastCertifierName)" Sortable="true" Filterable="true" />
                                 <Column TableItem="Rule" Title="@(userConfig.GetText("action"))" Field="@(rule => rule.OrderNumber)">
                                     <Template>

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
@@ -21,16 +21,16 @@
             }
         </Template>
     </Column>
-    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("name"))" Field="@(scheduledReport => scheduledReport.Name)" />
-    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("start_time"))" Field="@(scheduledReport => scheduledReport.StartTime)" />
+    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("name"))" Field="@(scheduledReport => scheduledReport.Name)" Sortable="true" Filterable="true"/>
+    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("start_time"))" Field="@(scheduledReport => scheduledReport.StartTime)" Sortable="true" Filterable="true"/>
     <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("repeat_interval"))" Field="@(scheduledReport => scheduledReport.RepeatOffset)">
         <Template>
             @(context.RepeatInterval != Interval.Never ? context.RepeatOffset : "") @(userConfig.GetText(context.RepeatInterval.ToString()))
         </Template>
     </Column>
-    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("template"))" Field="@(scheduledReport => scheduledReport.Template.Name)" />
-    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("owner"))" Field="@(scheduledReport => scheduledReport.Owner.Name)" />
-    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("active"))" Field="@(scheduledReport => scheduledReport.Active)" >
+    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("template"))" Field="@(scheduledReport => scheduledReport.Template.Name)" Sortable="true" Filterable="true"/>
+    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("owner"))" Field="@(scheduledReport => scheduledReport.Owner.Name)" Sortable="true" Filterable="true"/>
+    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("active"))" Field="@(scheduledReport => scheduledReport.Active)" Sortable="true" Filterable="true">
             <Template>
                 @(GlobalConfig.ShowBool(context.Active))
             </Template>

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
@@ -35,6 +35,7 @@
                 @(GlobalConfig.ShowBool(context.Active))
             </Template>
     </Column>
+    <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("count"))" Field="@(scheduledReport => scheduledReport.Counter)" Sortable="true" Filterable="true"/>
     <Column TableItem="ScheduledReport" Title="@(userConfig.GetText("output_format"))" Field="@(scheduledReport => scheduledReport.OutputFormat)">
         <Template>
             @String.Join(", ", context.OutputFormat.ConvertAll(format => format.Name.ToUpperInvariant()))

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsGateways.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsGateways.razor
@@ -32,17 +32,17 @@
         </Column>
         <Column TableItem="Device" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true" />
         <Column TableItem="Device" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Sortable="true" Filterable="true" />
-        <Column TableItem="Device" Title="@(userConfig.GetText("type"))" Field="@(x => x.DeviceType.Id)" Sortable="true" Filterable="true">
+        <Column TableItem="Device" Title="@(userConfig.GetText("type"))" Field="@(x => x.DeviceType.Id)" Sortable="true">
             <Template>
                 @context.DeviceType.NameVersion()
             </Template>
         </Column>
-        <Column TableItem="Device" Title="@(userConfig.GetText("management"))" Field="@(x => x.Management.Id)" Sortable="true" Filterable="true">
+        <Column TableItem="Device" Title="@(userConfig.GetText("management"))" Field="@(x => x.Management.Id)" Sortable="true">
             <Template>
                 @context.Management.Name
             </Template>
         </Column>
-        <Column TableItem="Device" Title="@(userConfig.GetText("import_enabled"))" Field="@(x => x.ImportDisabled)" Sortable="true" Filterable="true" >
+        <Column TableItem="Device" Title="@(userConfig.GetText("import_enabled"))" Field="@(x => x.ImportDisabled)" Sortable="true">
             <Template>
                 @(GlobalConfig.ShowBool(!context.ImportDisabled))
             </Template>

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsLdap.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsLdap.razor
@@ -38,42 +38,42 @@
             </Template>
         </Column>
         <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Sortable="true" Filterable="true" />
-        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("host"))" Field="@(x => x.Address)" Sortable="true" Filterable="true">
+        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("host"))" Field="@(x => x.Address)" Sortable="true">
             <Template>
                 @(context.Host())
             </Template>
         </Column>
-        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("type"))" Field="@(x => x.Type)" Sortable="true" Filterable="true">
+        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("type"))" Field="@(x => x.Type)" Sortable="true">
             <Template>
                 @(Enum.GetName(typeof(LdapType), context.Type))
             </Template>
         </Column>
-        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("search_user"))" Field="@(x => x.SearchUser)" Sortable="true" Filterable="true">
+        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("search_user"))" Field="@(x => x.SearchUser)" Sortable="true">
             <Template>
                 @(GlobalConfig.ShowBool(context.SearchUser != null && context.SearchUser != ""))
             </Template>
         </Column>
-        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("write_user"))" Field="@(x => x.WriteUser)" Sortable="true" Filterable="true">
+        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("write_user"))" Field="@(x => x.WriteUser)" Sortable="true">
             <Template>
                 @(GlobalConfig.ShowBool(context.IsWritable()))
             </Template>
         </Column>
-        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("role_handling"))" Field="@(x => x.RoleSearchPath)" Sortable="true" Filterable="true">
+        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("role_handling"))" Field="@(x => x.RoleSearchPath)" Sortable="true">
             <Template>
                 @(GlobalConfig.ShowBool(context.HasRoleHandling()))
             </Template>
         </Column>
-        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("group_handling"))" Field="@(x => (x.GroupSearchPath))" Sortable="true" Filterable="true">
+        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("group_handling"))" Field="@(x => (x.GroupSearchPath))" Sortable="true">
             <Template>
                 @(GlobalConfig.ShowBool(context.HasGroupHandling()))
             </Template>
         </Column>
-        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("tenant"))" Field="@(x => x.TenantId)" Sortable="true" Filterable="true">
+        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("tenant"))" Field="@(x => x.TenantId)" Sortable="true">
             <Template>
                 @(context.TenantId != null ? tenants.FirstOrDefault(x => x.Id == context.TenantId)?.Name ?? "" : "" )
             </Template>
         </Column>
-        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("global_tenant_name"))" Field="@(x => x.GlobalTenantName)" Sortable="true" Filterable="true" />
+        <Column TableItem="UiLdapConnection" Title="@(userConfig.GetText("global_tenant_name"))" Field="@(x => x.GlobalTenantName)" Sortable="true"/>
     </Table>
 </div>
 

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsManagements.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsManagements.razor
@@ -48,25 +48,25 @@
         </Column>
         <Column TableItem="Management" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true" />
         <Column TableItem="Management" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Sortable="true" Filterable="true" />
-        <Column TableItem="Management" Title="@(userConfig.GetText("type"))" Field="@(x => x.DeviceType.Id)" Sortable="true" Filterable="true">
+        <Column TableItem="Management" Title="@(userConfig.GetText("type"))" Field="@(x => x.DeviceType.Id)" Sortable="true">
             <Template>
                 @(context.DeviceType.NameVersion())
             </Template>
         </Column>
-        <Column TableItem="Management" Title="@(userConfig.GetText("host"))" Field="@(x => x.Hostname)" Sortable="true" Filterable="true">
+        <Column TableItem="Management" Title="@(userConfig.GetText("host"))" Field="@(x => x.Hostname)" Sortable="true">
             <Template>
                 @(context.Host())
             </Template>
         </Column>
         <Column TableItem="Management" Title="@(userConfig.GetText("config_path"))" Field="@(x => x.ConfigPath)" Sortable="true" Filterable="true" />
-        <Column TableItem="Management" Title="@(userConfig.GetText("super_manager"))" Field="@(x => x.SuperManagerId)" Sortable="true" Filterable="true">
+        <Column TableItem="Management" Title="@(userConfig.GetText("super_manager"))" Field="@(x => x.SuperManagerId)" Sortable="true">
             <Template>
                 @(((context.SuperManagerId != null) ? managements.Find(x => x.Id == context.SuperManagerId)?.Name : ""))
             </Template>
         </Column>
 
         <Column TableItem="Management" Title="@(userConfig.GetText("importer_host"))" Field="@(x => x.ImporterHostname)" Sortable="true" Filterable="true" />
-        <Column TableItem="Management" Title="@(userConfig.GetText("import_enabled"))" Field="@(x => x.ImportDisabled)" Sortable="true" Filterable="true" >
+        <Column TableItem="Management" Title="@(userConfig.GetText("import_enabled"))" Field="@(x => x.ImportDisabled)" Sortable="true">
             <Template>
                 @(GlobalConfig.ShowBool(!context.ImportDisabled))
             </Template>

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsRoles.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsRoles.razor
@@ -36,12 +36,12 @@
             </Template>
         </Column>
         <Column TableItem="Role" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Sortable="true" Filterable="true" />
-        <Column TableItem="Role" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" Sortable="true" Filterable="true" >
+        <Column TableItem="Role" Title="@(userConfig.GetText("description"))" Field="@(x => x.Description)" Sortable="true">
             <Template>
                 @(userConfig.GetText(context.Description))
             </Template>
         </Column>
-        <Column TableItem="Role" Title="@(userConfig.GetText("users_groups"))" Field="@(x => x.Users)" Sortable="false" Filterable="false">
+        <Column TableItem="Role" Title="@(userConfig.GetText("users_groups"))" Field="@(x => x.Users)" Sortable="false">
             <Template>
                 @(context.UserList())
             </Template>

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsUsers.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsUsers.razor
@@ -55,7 +55,7 @@
         </Column>
         <Column TableItem="UiUser" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Sortable="true" Filterable="true" />
         <Column TableItem="UiUser" Title="@(userConfig.GetText("from_ldap"))" Field="@(x => x.LdapConnection.Name)" Sortable="true" Filterable="true" />
-        <Column TableItem="UiUser" Title="@(userConfig.GetText("tenant"))" Field="@(x => x.Tenant)" Sortable="true" Filterable="true" >
+        <Column TableItem="UiUser" Title="@(userConfig.GetText("tenant"))" Field="@(x => x.Tenant)" Sortable="true">
             <Template>
                 @(context.Tenant != null ? (context.Tenant.Id == 1 && context.LdapConnection.GlobalTenantName != null && context.LdapConnection.GlobalTenantName != "" ? context.LdapConnection.GlobalTenantName : context.Tenant.Name) : "" )
             </Template>       


### PR DESCRIPTION
- archive page shows now report type, template (only for scheduled reports) and a short description of the report content (number of managements) -> #1575
- scheduling has a counter, how many reports have been created -> #1576
- reviewed all blazor tables about filtering and sorting (removed where results may be unexpected for user, added in all monitoring tables) -> #1044 (partially)
- small fixes