### PR TITLE
libssl-dev instead of libssl1.1

### DIFF
--- a/documentation/operations.md
+++ b/documentation/operations.md
@@ -1,6 +1,14 @@
 # Tips on Firewall Orchestrator Operations
 
 
+## Backup / Restore
+
+We recommend to backup the following data:
+
+- PostgreSQL database fworchdb using a tool like pg_dump
+- directory /etc/fworch (which is a link to /usr/local/fworch/etc)
+- optionally any customized settings like /etc/syslog-ng.conf etc. which were not automatically created during the installation process
+
 ## Monitoring and alerting
 
 Use /var/log/fworch/alert.log to generate alerts with the SIEM tool of your choice.

--- a/roles/lib/tasks/main.yml
+++ b/roles/lib/tasks/main.yml
@@ -23,7 +23,7 @@
         - libc6-dev
         - libjpeg62
         - xfonts-75dpi
-        - libssl1.1
+        - libssl-dev
 
     - name: backup lib dir
       synchronize:

--- a/roles/middleware/tasks/main.yml
+++ b/roles/middleware/tasks/main.yml
@@ -57,7 +57,7 @@
       - libc6-dev
       - libjpeg62
       - xfonts-75dpi
-      - libssl1.1
+      - libssl-dev
   
   become: yes
 

--- a/roles/ui/tasks/main.yml
+++ b/roles/ui/tasks/main.yml
@@ -35,7 +35,7 @@
         - libc6-dev
         - libjpeg62
         - xfonts-75dpi
-        - libssl1.1
+        - libssl-dev
       
     - name: create ui dir
       file:


### PR DESCRIPTION
to avoid errors with libssl1.1 installation on ubuntu 22.04