### PR TITLE
Fix missing user name

### DIFF
--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
@@ -170,6 +170,9 @@ namespace FWO.Middleware.Controllers
             // Get tenant of user
             user.Tenant = await GetTenantAsync(ldapUser, ldap);
 
+            // Remember the hosting ldap
+            user.LdapConnection.Id = ldap.Id;
+
             // Create JWT for validated user with roles and tenant
             return await jwtWriter.CreateJWT(user, lifetime);
         }


### PR DESCRIPTION
user was not created automatically at login in uiusers because of missing ldap id (#1853 No 2).