### PR TITLE
hotfix for FWO.Recert installation

### DIFF
--- a/roles/lib/tasks/main.yml
+++ b/roles/lib/tasks/main.yml
@@ -53,6 +53,7 @@
         - FWO.Logging
         - FWO.Config.Api
         - FWO.Config.File
+        - FWO.Recert
         - FWO.Report
         - FWO.Report.Filter
         - FWO.DeviceAutoDiscovery


### PR DESCRIPTION
copy missing dir during install/upgrade