### PR TITLE
Update config.ldif.j2

### DIFF
--- a/roles/openldap-server/templates/config.ldif.j2
+++ b/roles/openldap-server/templates/config.ldif.j2
@@ -16,7 +16,6 @@ olcModulePath: /usr/lib/ldap
 olcModuleLoad: {0}back_mdb.la
 olcModuleLoad: {1}memberof.la
 olcModuleLoad: {2}refint.la
-olcModuleLoad: {3}ppolicy.la
 
 # internal schema
 dn: cn=schema,cn=config
@@ -28,9 +27,6 @@ include: file:///etc/ldap/schema/core.ldif
 include: file:///etc/ldap/schema/cosine.ldif
 include: file:///etc/ldap/schema/inetorgperson.ldif
 include: file:///etc/ldap/schema/nis.ldif
-{% if not ((ansible_facts['distribution_release']|lower == 'bookworm') or (ansible_distribution|lower == 'ubuntu' and ansible_distribution_version is version ('22', '>='))) %}
-include: file:///etc/ldap/schema/ppolicy.ldif
-{% endif %}
 
 # configure config database
 dn: olcDatabase=config,cn=config
@@ -107,12 +103,3 @@ objectClass: top
 olcOverlay: refint
 olcRefintAttribute: memberOf
 olcRefintAttribute: uniqueMember
-
-# Password policy overlay
-dn: olcOverlay=ppolicy,olcDatabase={1}mdb,cn=config
-objectClass: olcConfig
-objectClass: top
-objectClass: olcOverlayConfig
-objectClass: olcPPolicyConfig
-olcOverlay: ppolicy
-olcPPolicyHashCleartext: TRUE


### PR DESCRIPTION
remove ppolicy for ubuntu 22 upgrade

install works on ubuntu 20

creation of user still requests 10 digit password due to GUI restriction

Newly created password is still hashed in LDAP

Upgrade to ubuntu 20 works for LDAP, fails with .NET