### PR TITLE
stop deleting test user

### DIFF
--- a/roles/sample-auth-data/tasks/main.yml
+++ b/roles/sample-auth-data/tasks/main.yml
@@ -2,15 +2,15 @@
 
 - name: add auth test data to database
   include_tasks: auth_sample_data.yml
-  when: installation_mode is not match('upgrade') or sample_role_purpose is match('test')
+  when: installation_mode is match('new') or sample_role_purpose is match('test')
 
 - name: include ldif driven changes
   import_tasks: modify_ldap_tree.yml
-  when: installation_mode is not match('upgrade') or sample_role_purpose is match('test')
+  when: installation_mode is match('new') or sample_role_purpose is match('test')
 
 - name: include owner sample data
   import_tasks: sample_owner_data.yml
-  when: installation_mode is not match('upgrade') or sample_role_purpose is match('test')
+  when: installation_mode is match('new') or sample_role_purpose is match('test')
 
 - name: restart middleware server in case any changes to ldap_connections were made
   systemd:

--- a/roles/test/handlers/main.yml
+++ b/roles/test/handlers/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: delete test user and dir
-  user:
-    name: test
-    state: absent
-    remove: true
-  become: true
-  listen: "test importer handler"
-
 - name: delete test user cred config file
   file:
     path: "{{ fworch_secrets_dir }}/TestUserCreds.json"


### PR DESCRIPTION
closes #2520
I can't find creation of user test. After removing the deletion statement he is not in /etc/passwd
Reduced logic complexity of sample-auth-data, which is never called for uninstall