### PR TITLE
Fortimanager Importer Enhancement

### DIFF
--- a/roles/importer/files/importer/fortiadom5ff/fmgr_getter.py
+++ b/roles/importer/files/importer/fortiadom5ff/fmgr_getter.py
@@ -131,7 +131,7 @@ def fortinet_api_call(sid, api_base_url, api_path, payload={}, show_progress=Fal
     if "data" in plain_result:
         result = plain_result["data"]
         if isinstance(result, dict):
-            result = []
+            result = [result]
     else:
         result = []
     return result

--- a/roles/importer/files/importer/fortiadom5ff/fmgr_getter.py
+++ b/roles/importer/files/importer/fortiadom5ff/fmgr_getter.py
@@ -130,7 +130,7 @@ def fortinet_api_call(sid, api_base_url, api_path, payload={}, show_progress=Fal
     plain_result = result["result"][0]
     if "data" in plain_result:
         result = plain_result["data"]
-        if isinstance(result, dict):
+        if isinstance(result, dict):  # code implicitly expects result to be a list, but some fmgr results are dicts
             result = [result]
     else:
         result = []

--- a/roles/importer/files/importer/fortiadom5ff/fmgr_getter.py
+++ b/roles/importer/files/importer/fortiadom5ff/fmgr_getter.py
@@ -130,6 +130,8 @@ def fortinet_api_call(sid, api_base_url, api_path, payload={}, show_progress=Fal
     plain_result = result["result"][0]
     if "data" in plain_result:
         result = plain_result["data"]
+        if isinstance(result, dict):
+            result = []
     else:
-        result = {}
+        result = []
     return result

--- a/roles/importer/files/importer/fortiadom5ff/fmgr_getter.py
+++ b/roles/importer/files/importer/fortiadom5ff/fmgr_getter.py
@@ -130,7 +130,7 @@ def fortinet_api_call(sid, api_base_url, api_path, payload={}, show_progress=Fal
     plain_result = result["result"][0]
     if "data" in plain_result:
         result = plain_result["data"]
-        if isinstance(result, dict):  # code implicitly expects result to be a list, but some fmgr results are dicts
+        if isinstance(result, dict):  # code implicitly expects result to be a list, but some fmgr data results are dicts
             result = [result]
     else:
         result = []

--- a/roles/importer/files/importer/fortiadom5ff/fmgr_rule.py
+++ b/roles/importer/files/importer/fortiadom5ff/fmgr_rule.py
@@ -149,7 +149,7 @@ def normalize_access_rules(full_config, config2import, import_id, mgm_details={}
                     rule.update({ 'rule_num': rule_number})
                     if 'name' in rule_orig:
                         rule.update({ 'rule_name': rule_orig['name']})
-                    if 'scope member' in rule:
+                    if 'scope member' in rule_orig:
                         installon_target = []
                         for vdom in rule['scope member']:
                             installon_target.append(vdom['name'] + '_' + vdom['vdom'])
@@ -211,18 +211,16 @@ def normalize_access_rules(full_config, config2import, import_id, mgm_details={}
                     if '_last-modified-by' in rule_orig:
                         rule.update({ 'rule_last_change_admin': rule_orig['_last-modified-by']})
 
-                    if rule_table in rule_access_scope_v4:
+                    if rule_table in rule_access_scope_v4 and len(full_config['rules_hitcount'][localPkgName])>0:
                         for hitcount_config in full_config['rules_hitcount'][localPkgName][0]['firewall policy']:
                             if rule_orig['policyid'] == hitcount_config['policyid']:
                                 rule.update({ 'last_hit': time.strftime("%Y-%m-%d", time.localtime(rule_orig['_last_hit']))})
-                            else:
-                                rule.update({ 'last_hit': None})
-                    elif rule_table in rule_access_scope_v6:
+                    elif rule_table in rule_access_scope_v6 and len(full_config['rules_hitcount'][localPkgName])>0:
                         for hitcount_config in full_config['rules_hitcount'][localPkgName][0]['firewall policy6']:
                             if rule_orig['policyid'] == hitcount_config['policyid']:
                                 rule.update({ 'last_hit': time.strftime("%Y-%m-%d", time.localtime(rule_orig['_last_hit']))})
-                            else:
-                                rule.update({ 'last_hit': None})
+                    else:
+                        rule.update({ 'last_hit': None})
 
                     xlate_rule = handle_combined_nat_rule(rule, rule_orig, config2import, nat_rule_number, import_id, localPkgName, dev_id)
                     rules.append(rule)

--- a/roles/importer/files/importer/fortiadom5ff/fmgr_rule.py
+++ b/roles/importer/files/importer/fortiadom5ff/fmgr_rule.py
@@ -68,6 +68,7 @@ def getAccessPolicy(sid, fm_api_url, raw_config, adom_name, device, limit):
     }
     hitcount_task = fmgr_getter.fortinet_api_call(
         sid, fm_api_url, "/sys/hitcount", payload=hitcount_payload, method="get")
+    time.sleep(2)
 
     # get global header rulebase:
     if device['global_rulebase_name'] is None or device['global_rulebase_name'] == '':
@@ -151,9 +152,9 @@ def normalize_access_rules(full_config, config2import, import_id, mgm_details={}
                         rule.update({ 'rule_name': rule_orig['name']})
                     if 'scope member' in rule_orig:
                         installon_target = []
-                        for vdom in rule['scope member']:
+                        for vdom in rule_orig['scope member']:
                             installon_target.append(vdom['name'] + '_' + vdom['vdom'])
-                            rule.update({ 'rule_installon': '|'.join(installon_target)})
+                        rule.update({ 'rule_installon': '|'.join(installon_target)})
                     else:
                         rule.update({ 'rule_installon': localPkgName })
                     rule.update({ 'rule_implied': False })
@@ -213,12 +214,12 @@ def normalize_access_rules(full_config, config2import, import_id, mgm_details={}
 
                     if rule_table in rule_access_scope_v4 and len(full_config['rules_hitcount'][localPkgName])>0:
                         for hitcount_config in full_config['rules_hitcount'][localPkgName][0]['firewall policy']:
-                            if rule_orig['policyid'] == hitcount_config['policyid']:
-                                rule.update({ 'last_hit': time.strftime("%Y-%m-%d", time.localtime(rule_orig['_last_hit']))})
+                            if rule_orig['policyid'] == hitcount_config['last_hit']:
+                                rule.update({ 'last_hit': time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime(hitcount_config['policyid']))})
                     elif rule_table in rule_access_scope_v6 and len(full_config['rules_hitcount'][localPkgName])>0:
                         for hitcount_config in full_config['rules_hitcount'][localPkgName][0]['firewall policy6']:
-                            if rule_orig['policyid'] == hitcount_config['policyid']:
-                                rule.update({ 'last_hit': time.strftime("%Y-%m-%d", time.localtime(rule_orig['_last_hit']))})
+                            if rule_orig['policyid'] == hitcount_config['last_hit']:
+                                rule.update({ 'last_hit': time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime(hitcount_config['policyid']))})
                     else:
                         rule.update({ 'last_hit': None})
 

--- a/roles/importer/files/importer/fortiadom5ff/fmgr_rule.py
+++ b/roles/importer/files/importer/fortiadom5ff/fmgr_rule.py
@@ -74,7 +74,7 @@ def getAccessPolicy(sid, fm_api_url, raw_config, adom_name, device, limit):
         "params": [
             {
                 "data": {
-                    "taskid": hitcount_task['task']
+                    "taskid": hitcount_task[0]['task']
                 }
             }
         ]


### PR DESCRIPTION
closes #1004
- hitcounts: last_hit in rule_meta. Possible further enhancement: If rule had no hit, last hit is in 1970
- custom fields: rule_custom_field in rule is a string in form of a dict
- installon: If rule defines dedicated install on targets, these are stored in rule_installon in rule, seperated by "|"
- last changer: last_change_admin in rule is still NULL (also for checkpoint). But value is passed on by python importer as rule.rule_last_change_admin

Details
- Output of fmgr_getter.fortinet_api_call is now always a list. That was implicitly expected before
- hitcount task needs a short time to gather results, introduced time.sleep(2) (2 Seconds) for each Fortinet policy package