### PR TITLE
Nuget bumps

### DIFF
--- a/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
+++ b/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="GraphQL.Client" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
+++ b/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IPAddressRange" Version="6.0.0" />
+    <PackageReference Include="IPAddressRange" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />

--- a/roles/lib/files/FWO.Basics/FWO.Basics.csproj
+++ b/roles/lib/files/FWO.Basics/FWO.Basics.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IPAddressRange" Version="6.0.0" />
+    <PackageReference Include="IPAddressRange" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/roles/lib/files/FWO.Report.Filter/FWO.Report.Filter.csproj
+++ b/roles/lib/files/FWO.Report.Filter/FWO.Report.Filter.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IPAddressRange" Version="6.0.0" />
+    <PackageReference Include="IPAddressRange" Version="6.1.0" />
   </ItemGroup>
   <ItemGroup>
       <ProjectReference Include="..\..\..\lib\files\FWO.Api.Client\FWO.Api.Client.csproj" />

--- a/roles/lib/files/FWO.Services/FWO.Services.csproj
+++ b/roles/lib/files/FWO.Services/FWO.Services.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/ui/files/FWO.UI/FWO.Ui.csproj
+++ b/roles/ui/files/FWO.UI/FWO.Ui.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IPAddressRange" Version="6.0.0" />
+    <PackageReference Include="IPAddressRange" Version="6.1.0" />
     <PackageReference Include="BlazorTable" Version="1.17.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Bump Microsoft.AspNetCore.Authentication.JwtBearer from 8.0.10 to 8.0.11
Bump Swashbuckle.AspNetCore from 6.9.0 to 7.0.0
Bump Microsoft.AspNetCore.Components.Authorization from 8.0.10 to 8.0.11
Bump Microsoft.AspNetCore.Components from 8.0.10 to 8.0.11
Bump IPAddressRange from 6.0.0 to 6.1.0

**This will be the last update we get with .Net 8. If we want to update further we need .Net 9**