### PR TITLE
Fix #2722

### DIFF
--- a/roles/lib/files/FWO.Api.Client/Data/FwoOwner.cs
+++ b/roles/lib/files/FWO.Api.Client/Data/FwoOwner.cs
@@ -49,7 +49,18 @@ namespace FWO.Api.Data
         {
             string comSvcAppendix = CommSvcPossible && comSvcTxt != "" ? $", {comSvcTxt}" : "";
             string appIdPart = ExtAppId != "" ? $" ({ExtAppId}{comSvcAppendix})" : "";
+
             return $"{Name}{appIdPart}";
+        }
+        
+        public string DisplayWithoutAppId(string comSvcTxt)
+        {
+            if (CommSvcPossible)
+            {
+                return $"{Name} ({comSvcTxt})";
+            }
+
+            return $"{Name}";
         }
 
         public override bool Sanitize()

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/SearchInterface.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/SearchInterface.razor
@@ -11,7 +11,7 @@
         @if (Display && InitComplete)
         {
             <div class="min-height me-5">               
-                <ConnectionTable Connections="@selectableInterfaces" SelectInterfaceView="true" ShowAppName="true" @bind-SelectedConns="SelectedInterfaces" />
+                <ConnectionTable Selectable="true" Connections="@selectableInterfaces" SelectInterfaceView="true" ShowAppName="true" @bind-SelectedConns="SelectedInterfaces" />
             </div>
         }
     </Body>

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/SearchInterface.razor.css
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/SearchInterface.razor.css
@@ -1,3 +1,3 @@
 .min-height {
-    min-height: 290px;
+    height: 530px;
 }

--- a/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
+++ b/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
@@ -10,7 +10,7 @@
 
 <Table class="table table-bordered th-bg-secondary sticky-header show-scrollbar table-responsive" TableItem="ModellingConnection"
        Items="Connections" PageSize="8" ColumnReorder="true" TableRowClass="@(con => getTableRowClass(con))"
-       SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">   
+       SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
     @if (!Readonly && !SelectInterfaceView && AppHandler != null)
     {
         <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("actions"))" Field="(x => x.Id)" Sortable="false" Filterable="false">
@@ -38,6 +38,11 @@
             </Template>
         </Column>
     }
+    <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("select"))" Sortable="false" Filterable="false">
+        <Template>
+            <input type="radio" checked="@(SelectedConns.Contains(context))" />
+        </Template>
+    </Column>
     <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true" />
     @if (!SelectInterfaceView)
     {

--- a/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
+++ b/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
@@ -9,8 +9,8 @@
 
 
 <Table class="table table-bordered th-bg-secondary sticky-header show-scrollbar table-responsive" TableItem="ModellingConnection"
-       Items="Connections" PageSize="10" ColumnReorder="true" TableRowClass="@(con => getTableRowClass(con))"
-       SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
+Items="Connections" PageSize="10" ColumnReorder="true" TableRowClass="@(con => getTableRowClass(con))"
+SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
     @if (!Readonly && !SelectInterfaceView && AppHandler != null)
     {
         <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("actions"))" Field="(x => x.Id)" Sortable="false" Filterable="false">
@@ -38,11 +38,13 @@
             </Template>
         </Column>
     }
-    @* <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("select"))" Sortable="false" Filterable="false">
-        <Template>
-            <input type="radio" checked="@(SelectedConns.Contains(context))" />
-        </Template>
-    </Column> *@
+    @if(Selectable){
+        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("select"))" Sortable="false" Filterable="false">
+            <Template>
+                <input type="radio" checked="@(SelectedConns.Contains(context))" />
+            </Template>
+        </Column>
+    }
     <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true" />
     @if (!SelectInterfaceView)
     {
@@ -74,7 +76,7 @@
         </Template>
     </Column>
     <Column TableItem="ModellingConnection" Title="@(Connections.Count > 0 && Connections.First().IsInterface ? userConfig.GetText("interface_description") : userConfig.GetText("func_reason"))"
-            Field="@(x => x.Reason)" Sortable="true" Filterable="true">
+    Field="@(x => x.Reason)" Sortable="true" Filterable="true">
         <Template>
             @((MarkupString)DisplayConditional(context, context.Reason ?? ""))
         </Template>
@@ -138,6 +140,9 @@
 
     [Parameter]
     public EventCallback<List<ModellingConnection>> SelectedConnsChanged { get; set; }
+
+    [Parameter]
+    public bool Selectable { get; set; } = false;
 
     private void ToggleSelection(ModellingConnection conn)
     {

--- a/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
+++ b/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
@@ -9,7 +9,7 @@
 
 
 <Table class="table table-bordered th-bg-secondary sticky-header show-scrollbar table-responsive" TableItem="ModellingConnection"
-       Items="Connections" PageSize="8" ColumnReorder="true" TableRowClass="@(con => getTableRowClass(con))"
+       Items="Connections" PageSize="10" ColumnReorder="true" TableRowClass="@(con => getTableRowClass(con))"
        SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
     @if (!Readonly && !SelectInterfaceView && AppHandler != null)
     {
@@ -38,11 +38,11 @@
             </Template>
         </Column>
     }
-    <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("select"))" Sortable="false" Filterable="false">
+    @* <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("select"))" Sortable="false" Filterable="false">
         <Template>
             <input type="radio" checked="@(SelectedConns.Contains(context))" />
         </Template>
-    </Column>
+    </Column> *@
     <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true" />
     @if (!SelectInterfaceView)
     {

--- a/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
+++ b/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
@@ -66,7 +66,7 @@ SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
     {
         <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("owner"))" Field="@(x => x.App.Name)" Sortable="true" Filterable="true">
             <Template>
-                @(context.App?.Name)
+                @(context.App?.DisplayWithoutAppId(userConfig.GetText("common_service")))
             </Template>
         </Column>
     }

--- a/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
+++ b/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
@@ -66,10 +66,15 @@ SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
     {
         <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("owner"))" Field="@(x => x.App.Name)" Sortable="true" Filterable="true">
             <Template>
-                @(context.App?.Display(userConfig.GetText("common_service")))
+                @(context.App?.Name)
             </Template>
         </Column>
     }
+    <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("ext_app_id"))" Field="@(x => x.App.Name)" Sortable="true" Filterable="true">
+        <Template>
+            @(context.App.ExtAppId)
+        </Template>
+    </Column>
     <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Sortable="true" Filterable="true">
         <Template>
             @((MarkupString)DisplayConditional(context, context.Name ?? ""))


### PR DESCRIPTION
Fixes:  once filtering leads to empty result, the filter is not usable anymore
Fixes: currently it is not obvious that a table row is selectable - add optical help in form of radio buttons?
Fixes:  separate owner name and owner external app id to allow for filtering and sorting for both values (currently the ID is not filterable)