### PR TITLE
feat(ui rsb): intuitive link to rsb in report and recert

### DIFF
--- a/roles/ui/files/FWO.UI/Data/CollapseState.cs
+++ b/roles/ui/files/FWO.UI/Data/CollapseState.cs
@@ -5,20 +5,20 @@ using System.Threading.Tasks;
 
 namespace FWO.Ui.Data
 {
-    public delegate void NotifyCollapse();
+    public delegate void NotifyCollapse(string? location); // optional location in rsb {tab}-{mgm/rule id}-{objtype} e.g. "report-m2-nwobj"
     public class CollapseState
     {
-        public event NotifyCollapse? OnCollapseAll;
-        public event NotifyCollapse? OnExpandAll;
+        public event NotifyCollapse? OnCollapse;
+        public event NotifyCollapse? OnExpand;
 
-        public void CollapseAll()
+        public void Collapse(string? location = null)
         {
-            OnCollapseAll?.Invoke();
+            OnCollapse?.Invoke(location);
         }
 
-        public void ExpandAll()
+        public void Expand(string? location = null)
         {
-            OnExpandAll?.Invoke();
+            OnExpand?.Invoke(location);
         }
     }
 }

--- a/roles/ui/files/FWO.UI/Pages/Certification.razor
+++ b/roles/ui/files/FWO.UI/Pages/Certification.razor
@@ -120,7 +120,7 @@
 </PopUp>
 
 @*==== RIGHT SIDEBAR ====*@
-<RightSidebar @bind-Width="sidebarRightWidth" CurrentReport="currentReport" @bind-SelectedRules="selectedRules"/>
+<RightSidebar @bind-Width="sidebarRightWidth" CurrentReport="currentReport" @bind-SelectedRules="selectedRules" Recert="true" />
 
 @code
 {

--- a/roles/ui/files/FWO.UI/Pages/Certification.razor
+++ b/roles/ui/files/FWO.UI/Pages/Certification.razor
@@ -120,8 +120,7 @@
 </PopUp>
 
 @*==== RIGHT SIDEBAR ====*@
-<RightSidebar @bind-Width="sidebarRightWidth" Tabset="rsbTabset" AnchorNavToRSB="anchorNavToRSB" CurrentReport="currentReport" @bind-SelectedRules="selectedRules"/>
-<AnchorNavToRSB @ref="anchorNavToRSB" TabSet="rsbTabset" />
+<RightSidebar @bind-Width="sidebarRightWidth" CurrentReport="currentReport" @bind-SelectedRules="selectedRules"/>
 
 @code
 {
@@ -130,9 +129,6 @@
 
     [CascadingParameter]
     private Task<AuthenticationState>? authenticationStateTask { get; set; }
-
-    private FWO.Ui.Shared.TabSet rsbTabset;
-    private FWO.Ui.Shared.AnchorNavToRSB anchorNavToRSB;
 
     private const int rulesPerPage = 0;
 

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Report.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Report.razor
@@ -155,7 +155,7 @@
     </div>
 
     @* ==== RIGHT SIDEBAR ==== *@
-    <RightSidebar @bind-Width="sidebarRightWidth" currentReport"
+    <RightSidebar @bind-Width="sidebarRightWidth" CurrentReport="currentReport"
         @bind-SelectedRules="selectedItemsRuleReportTable" 
         AllTabVisible="(tenantFilteringAllowed && actReportFilters.SelectedTenant == null)"
         SelectedReportType = "actReportFilters.ReportType"/>

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Report.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Report.razor
@@ -155,11 +155,10 @@
     </div>
 
     @* ==== RIGHT SIDEBAR ==== *@
-    <RightSidebar @bind-Width="sidebarRightWidth" Tabset="rsbTabset" AnchorNavToRSB="anchorNavToRSB" CurrentReport="currentReport"
+    <RightSidebar @bind-Width="sidebarRightWidth" currentReport"
         @bind-SelectedRules="selectedItemsRuleReportTable" 
         AllTabVisible="(tenantFilteringAllowed && actReportFilters.SelectedTenant == null)"
         SelectedReportType = "actReportFilters.ReportType"/>
-    <AnchorNavToRSB @ref="anchorNavToRSB" TabSet="rsbTabset" />
 }
 
 @* ==== POPUPS ==== *@
@@ -207,9 +206,7 @@
 
     private ReportBase? currentReport;
 
-    private FWO.Ui.Shared.TabSet rsbTabset;
     private Sidebar? deviceSelectionSidebar;
-    private FWO.Ui.Shared.AnchorNavToRSB anchorNavToRSB;
 
     private string filterFeedbackStart = "";
     private string filterFeedbackError = "";

--- a/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
+++ b/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
@@ -85,9 +85,7 @@
             if (foundObj)
             {
                 // remove #goto-{obj-link} fragment from uri
-                UriBuilder ub = new(uri);
-                ub.Fragment = "";
-                NavigationManager.NavigateTo(ub.Uri.AbsoluteUri);
+                await JSRuntime.InvokeVoidAsync("removeUrlFragment");
             }
         }
     }

--- a/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
+++ b/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
@@ -2,7 +2,10 @@
 @using System.Text.RegularExpressions
 @inject IJSRuntime JSRuntime
 @inject NavigationManager NavigationManager
+@inject UserConfig userConfig
+
 @implements IDisposable
+
 @code {
     [Parameter]
     public FWO.Ui.Shared.TabSet TabSet { get; set; } = default!;
@@ -35,9 +38,10 @@
     /// <summary>
     /// Expects the URI to contain link to rsb object in form of #goto-{obj-link}. Example URI: localhost/report#goto-report-m8-nwobj31473
     /// </summary>
-    private string GetIdFromURI()
+    private async Task<string> GetIdFromURI()
     {
-        var uri = new Uri(NavigationManager.Uri, UriKind.Absolute);
+        var currentUrl = await JSRuntime.InvokeAsync<string>("getCurrentUrl");
+        var uri = new Uri(currentUrl, UriKind.Absolute);
         var fragment = uri.Fragment;
         if (fragment.StartsWith("#goto-"))
         {
@@ -52,11 +56,13 @@
             return elementId.Substring(5);
         }
         return "";
+        //NOTE: cannot use NavigationManager.GetUri() since it does not reflect change made by JS (removing the fragment)
+        //      cannot remove fragment in URI with NavigationManager since it will result in a scroll to top
     }
 
     public async Task ScrollToFragment()
     {
-        string elementId = GetIdFromURI();
+        string elementId = await GetIdFromURI();
 
         if (!string.IsNullOrEmpty(elementId))
         {
@@ -66,11 +72,11 @@
             bool recertPage = uri.AbsolutePath == $"/{PageName.Certification}";
 
             if (elementId.StartsWith("all"))
-                TabSet?.SetActiveTab(0);
+                TabSet?.SetActiveTab(TabSet.Tabs.Where(t => t.Title == userConfig.GetText("all")).FirstOrDefault());
             else if (elementId.StartsWith("report"))
-                TabSet?.SetActiveTab(recertPage ? 0 : 1);
+                TabSet?.SetActiveTab(TabSet.Tabs.Where(t => t.Title == userConfig.GetText("report")).FirstOrDefault());
             else if (elementId.StartsWith("rule"))
-                TabSet?.SetActiveTab(recertPage ? 1 : 2);
+                TabSet?.SetActiveTab(TabSet.Tabs.Where(t => t.Title == userConfig.GetText("rule")).FirstOrDefault());
             else
                 return;
 

--- a/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
+++ b/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
@@ -18,7 +18,7 @@
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
-            await ScrollToFragment(GetIdFromURI());
+            await ScrollToFragment();
     }
 
     public void Dispose()
@@ -28,7 +28,7 @@
 
     private async void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
-        await ScrollToFragment(GetIdFromURI());
+        await ScrollToFragment();
     }
 
     /// <returns>The html element id to an object in the right side bar.</returns>
@@ -54,8 +54,10 @@
         return "";
     }
 
-    private async Task ScrollToFragment(string elementId)
+    public async Task ScrollToFragment()
     {
+        string elementId = GetIdFromURI();
+
         if (!string.IsNullOrEmpty(elementId))
         {
             var uri = new Uri(NavigationManager.Uri, UriKind.Absolute);
@@ -87,16 +89,6 @@
                 ub.Fragment = "";
                 NavigationManager.NavigateTo(ub.Uri.AbsoluteUri);
             }
-        }
-    }
-
-    public async Task ScrollToFragmentIfMatch(string idPrefixMatch)
-    {
-        string elementId = GetIdFromURI();
-
-        if (elementId.StartsWith(idPrefixMatch))
-        {
-            await ScrollToFragment(elementId);
         }
     }
 }

--- a/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
+++ b/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
@@ -6,6 +6,9 @@
     [Parameter]
     public FWO.Ui.Shared.TabSet TabSet { get; set; } = default!;
 
+    [Parameter]
+    public FWO.Ui.Data.CollapseState CollapseState { get; set; } = default!;
+
     protected override void OnInitialized()
     {
         NavigationManager.LocationChanged += OnLocationChanged;
@@ -67,6 +70,8 @@
                 TabSet?.SetActiveTab(recertPage ? 1 : 2);
             else
                 return;
+
+            CollapseState.Collapse(elementId);
             
             bool foundObj = await JSRuntime.InvokeAsync<bool>("scrollIntoRSBView", elementId);
 

--- a/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
+++ b/roles/ui/files/FWO.UI/Shared/AnchorNavToRSB.razor
@@ -1,4 +1,5 @@
 @using FWO.Basics
+@using System.Text.RegularExpressions
 @inject IJSRuntime JSRuntime
 @inject NavigationManager NavigationManager
 @implements IDisposable
@@ -59,7 +60,7 @@
         {
             var uri = new Uri(NavigationManager.Uri, UriKind.Absolute);
 
-            // check if current page is certification page
+            // need to check if recert page since tabs are different
             bool recertPage = uri.AbsolutePath == $"/{PageName.Certification}";
 
             if (elementId.StartsWith("all"))
@@ -71,7 +72,11 @@
             else
                 return;
 
-            CollapseState.Collapse(elementId);
+            // remove chapternum from #goto-report-{reportId}-{type}{chapterNumber}x{id} in report html export
+            if (elementId.StartsWith("report"))
+                elementId = Regex.Replace(elementId, @"(nwobj|svc|user)\d+x(\d+)", "$1$2");
+
+            CollapseState.Expand(elementId);
             
             bool foundObj = await JSRuntime.InvokeAsync<bool>("scrollIntoRSBView", elementId);
 

--- a/roles/ui/files/FWO.UI/Shared/Collapse.razor
+++ b/roles/ui/files/FWO.UI/Shared/Collapse.razor
@@ -22,7 +22,7 @@
 @code
 {
     [CascadingParameter]
-    public CollapseState collapseState { get; set; } = new CollapseState();
+    public CollapseState? collapseState { get; set; }
 
     [Parameter]
     public string Title { get; set; } = "";
@@ -48,6 +48,9 @@
     [Parameter]
     public EventCallback<bool> OnOpen { get; set; }
 
+    [Parameter]
+    public string? RSBLocation { get; set; }
+
     private bool show;
     private bool invokeOnOpenAfterRender;
 
@@ -61,8 +64,8 @@
                 invokeOnOpenAfterRender = true;
             if (collapseState != null)
             {
-                collapseState.OnCollapseAll += ForceCollapse;
-                collapseState.OnExpandAll += ForceExpand;
+                collapseState.OnCollapse += onCollapse;
+                collapseState.OnExpand += onExpand;
             }
             StateHasChanged();
         }
@@ -92,9 +95,25 @@
             invokeOnOpenAfterRender = true;
     }
 
+    private void onCollapse(string? location)
+    {
+        if (RSBLocation == null || location != null && location.StartsWith(RSBLocation))
+            ForceCollapse();
+    }
+
+    private void onExpand(string? location)
+    {
+        if (RSBLocation == null || location != null && location.StartsWith(RSBLocation))
+            ForceExpand();
+    }
+
     void IDisposable.Dispose()
     {
-        if (collapseState != null)
-            collapseState.OnCollapseAll -= ForceCollapse;
+        if (collapseState != null && RSBLocation != null)
+        {
+            collapseState.OnExpand -= onExpand;
+            collapseState.OnCollapse -= onCollapse;
+        }
+
     }
 }

--- a/roles/ui/files/FWO.UI/Shared/Collapse.razor
+++ b/roles/ui/files/FWO.UI/Shared/Collapse.razor
@@ -1,4 +1,4 @@
-@using FWO.Ui.Data
+﻿@using FWO.Ui.Data
 @using FWO.Basics
 @using FWO.Api.Data
 
@@ -98,13 +98,13 @@
 
     private void onCollapse(string? location)
     {
-        if (RSBLocation == null || location != null && location.StartsWith(RSBLocation))
+        if (RSBLocation == null || location != null && (location.StartsWith(RSBLocation) || RSBLocation.StartsWith(location)))
             ForceCollapse();
     }
 
     private void onExpand(string? location)
     {
-        if (RSBLocation == null || location != null && location.StartsWith(RSBLocation))
+        if (RSBLocation == null || location != null && (location.StartsWith(RSBLocation) || RSBLocation.StartsWith(location)))
             ForceExpand();
     }
 

--- a/roles/ui/files/FWO.UI/Shared/Collapse.razor
+++ b/roles/ui/files/FWO.UI/Shared/Collapse.razor
@@ -1,4 +1,4 @@
-﻿@using FWO.Ui.Data
+@using FWO.Ui.Data
 @using FWO.Basics
 @using FWO.Api.Data
 
@@ -66,7 +66,6 @@
             {
                 CollapseState.OnCollapse += onCollapse;
                 CollapseState.OnExpand += onExpand;
-                Log.WriteDebug($"Collapse {Title}", $"Subscribed to collapseState {CollapseState.GetHashCode()}");
             }
             StateHasChanged();
         }

--- a/roles/ui/files/FWO.UI/Shared/Collapse.razor
+++ b/roles/ui/files/FWO.UI/Shared/Collapse.razor
@@ -1,4 +1,4 @@
-﻿@using FWO.Ui.Data
+@using FWO.Ui.Data
 @using FWO.Basics
 @using FWO.Api.Data
 
@@ -22,7 +22,7 @@
 @code
 {
     [CascadingParameter]
-    public CollapseState? collapseState { get; set; }
+    public CollapseState? CollapseState { get; set; }
 
     [Parameter]
     public string Title { get; set; } = "";
@@ -62,10 +62,11 @@
             invokeOnOpenAfterRender = false;
             if (!StartToggled)
                 invokeOnOpenAfterRender = true;
-            if (collapseState != null)
+            if (CollapseState != null)
             {
-                collapseState.OnCollapse += onCollapse;
-                collapseState.OnExpand += onExpand;
+                CollapseState.OnCollapse += onCollapse;
+                CollapseState.OnExpand += onExpand;
+                Log.WriteDebug($"Collapse {Title}", $"Subscribed to collapseState {CollapseState.GetHashCode()}");
             }
             StateHasChanged();
         }
@@ -109,10 +110,10 @@
 
     void IDisposable.Dispose()
     {
-        if (collapseState != null && RSBLocation != null)
+        if (CollapseState != null && RSBLocation != null)
         {
-            collapseState.OnExpand -= onExpand;
-            collapseState.OnCollapse -= onCollapse;
+            CollapseState.OnExpand -= onExpand;
+            CollapseState.OnCollapse -= onCollapse;
         }
 
     }

--- a/roles/ui/files/FWO.UI/Shared/DeviceSelection.razor
+++ b/roles/ui/files/FWO.UI/Shared/DeviceSelection.razor
@@ -149,11 +149,11 @@
         CollapseAll = !CollapseAll;
         if(CollapseAll)
         {
-            collapseDevices.CollapseAll();
+            collapseDevices.Collapse();
         }
         else
         {
-            collapseDevices.ExpandAll();
+            collapseDevices.Expand();
         }
         await InvokeAsync(StateHasChanged);
     }

--- a/roles/ui/files/FWO.UI/Shared/DeviceSelectionTenants.razor
+++ b/roles/ui/files/FWO.UI/Shared/DeviceSelectionTenants.razor
@@ -169,11 +169,11 @@
         CollapseAll = !CollapseAll;
         if(CollapseAll)
         {
-            collapseDevices.CollapseAll();
+            collapseDevices.Collapse();
         }
         else
         {
-            collapseDevices.ExpandAll();
+            collapseDevices.Expand();
         }
         await InvokeAsync(StateHasChanged);
     }

--- a/roles/ui/files/FWO.UI/Shared/NavigationMenu.razor
+++ b/roles/ui/files/FWO.UI/Shared/NavigationMenu.razor
@@ -13,7 +13,7 @@
 
 @if(InitComplete)
 {
-    <nav class="navbar navbar-expand-xl navbar-dark bg-blue shadow w-100">
+    <nav class="navbar navbar-expand-xl navbar-dark bg-blue shadow w-100 navbar-height">
         <a class="navbar-brand pad-10" href="#">
             <img src="/images/FWO_logo_navbar.png">&nbsp;@userConfig.GetText("fworch_long")&nbsp;v@(globalConfig.ProductVersion)
         </a>

--- a/roles/ui/files/FWO.UI/Shared/ObjectGroup.razor
+++ b/roles/ui/files/FWO.UI/Shared/ObjectGroup.razor
@@ -19,7 +19,7 @@
     {
         Content = InitialContent;
     }
-    <Collapse Title="@(NameExtractor != null ? NameExtractor(Content) : "")" UseHtmlTitle="@(Tab == RsbTab.rule)" Style="@("primary")" StartToggled="StartCollapsed">
+    <Collapse Title="@(NameExtractor != null ? NameExtractor(Content) : "")" UseHtmlTitle="@(Tab == RsbTab.rule)" Style="@("primary")" StartToggled="StartCollapsed" RSBLocation="@GetRSBLocation()">
         <TitleWithHtml>
             @if (typeof(InputDataType) == typeof(Rule))
             {
@@ -43,7 +43,7 @@
         <ChildContent>
             @if(NetworkObjectExtractor != null)
             {
-                <Collapse Title="@(userConfig.GetText("network_objects"))" StartToggled="StartCollapsed"  OnOpen="() => HandleUncollapse(ObjCategory.nobj)">
+                <Collapse Title="@(userConfig.GetText("network_objects"))" StartToggled="StartCollapsed"  OnOpen="() => HandleUncollapse(ObjCategory.nobj)" RSBLocation=@($"{GetIDPrefix(ObjCategory.nobj)}")>
                     <Table style="font-size:small" class="table table-bordered table-sm th-bg-secondary table-responsive" TableItem="NetworkObject"
                             Items="@NetworkObjectExtractor(Content)" PageSize="PageSize" ColumnReorder="true">
                         <Column TableItem="NetworkObject" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Class="word-break">
@@ -113,7 +113,7 @@
             }
             @if(NetworkServiceExtractor != null)
             {
-                <Collapse Title="@(userConfig.GetText("services"))" StartToggled="StartCollapsed" OnOpen="() => HandleUncollapse(ObjCategory.nsrv)">
+                <Collapse Title="@(userConfig.GetText("services"))" StartToggled="StartCollapsed" OnOpen="() => HandleUncollapse(ObjCategory.nsrv)" RSBLocation=@($"{GetIDPrefix(ObjCategory.nsrv)}")>
                     <Table style="font-size:small" class="table table-bordered table-sm th-bg-secondary table-responsive" TableItem="NetworkService"
                             Items="@NetworkServiceExtractor(Content)" PageSize="PageSize" ColumnReorder="true">
                         <Column TableItem="NetworkService" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Class="word-break">
@@ -189,7 +189,7 @@
             }
             @if(NetworkUserExtractor != null)
             {
-                <Collapse Title="@(userConfig.GetText("users"))" StartToggled="StartCollapsed" OnOpen="() => HandleUncollapse(ObjCategory.user)">
+                <Collapse Title="@(userConfig.GetText("users"))" StartToggled="StartCollapsed" OnOpen="() => HandleUncollapse(ObjCategory.user)" RSBLocation=@($"{GetIDPrefix(ObjCategory.user)}")>
                     <Table style="font-size:small" class="table table-bordered table-sm th-bg-secondary table-responsive"
                             TableItem="NetworkUser" Items="@NetworkUserExtractor(Content)" PageSize="PageSize" ColumnReorder="true">
                         <Column TableItem="NetworkUser" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Class="word-break">
@@ -246,9 +246,6 @@
 {
     [CascadingParameter]
     Action<Exception?, string, string, bool> DisplayMessageInUi { get; set; } = DefaultInit.DoNothing;
-
-    [CascadingParameter]
-    AnchorNavToRSB? anchorNavToRSB { get; set; }
 
     [Parameter]
     public Func<RsbTab, ObjCategory, Func<ReportData, Task>, long, bool, Task>? FetchObjects { get; set; }
@@ -311,33 +308,42 @@
         }
     }
 
-    private string GetIDPrefix(ObjCategory objCategory, RsbTab? tab = null, bool toMgmtObj = false)
+    private string GetRSBLocation(RsbTab? tab = null, bool toMgmtObj = false)
     {
-        string idPref = "";
+        string location = "";
         switch (tab ?? Tab)
         {
             case RsbTab.all:
-                idPref += "all-";
+                location += "all-";
                 break;
             case RsbTab.report:
-                idPref += "report-";
+                location += "report-";
                 break;
             case RsbTab.rule:
-                idPref += "rule-";
+                location += "rule-";
                 break;
         }
         switch (Content)
         {
             case ManagementReport m:
-                idPref += "m" + m.Id + "-";
+                location += "m" + m.Id;
                 break;
             case Rule r:
                 if (!toMgmtObj)
-                    idPref += "r" + r.Id + "-";
+                    location += "r" + r.Id;
                 else
-                    idPref += "m" + r.MgmtId + "-";
+                    location += "m" + r.MgmtId;
                 break;
         }
+        return location;
+    }
+
+    private string GetIDPrefix(ObjCategory objCategory, RsbTab? tab = null, bool toMgmtObj = false)
+    {
+        string idPref = "";
+
+        idPref += GetRSBLocation(tab, toMgmtObj) + "-";
+
         switch (objCategory)
         {
             case ObjCategory.nobj:
@@ -377,7 +383,6 @@
     {
         if (Tab != RsbTab.rule)
             await FetchContent(objCategory);
-        anchorNavToRSB?.ScrollToFragmentIfMatch(GetIDPrefix(objCategory));
     }
 
     private async Task FetchContent(ObjCategory objCategory)

--- a/roles/ui/files/FWO.UI/Shared/ObjectGroup.razor
+++ b/roles/ui/files/FWO.UI/Shared/ObjectGroup.razor
@@ -247,6 +247,9 @@
     [CascadingParameter]
     Action<Exception?, string, string, bool> DisplayMessageInUi { get; set; } = DefaultInit.DoNothing;
 
+    [CascadingParameter]
+    AnchorNavToRSB? AnchorNavToRSB { get; set; }
+
     [Parameter]
     public Func<RsbTab, ObjCategory, Func<ReportData, Task>, long, bool, Task>? FetchObjects { get; set; }
 
@@ -426,6 +429,7 @@
                                         }
                                         Content = (InputDataType)(Object)mgt;
                                     }
+                                    AnchorNavToRSB?.ScrollToFragment();
                                     return InvokeAsync(StateHasChanged);
                                 }, mgt.Id, false);
                             break;
@@ -440,6 +444,7 @@
                                         ruleUpdated.DeviceName = rule.DeviceName;
                                         Content = (InputDataType)(Object)ruleUpdated;
                                     }
+                                    AnchorNavToRSB?.ScrollToFragment();
                                     return InvokeAsync(StateHasChanged);
                                  }, rule.Id, !string.IsNullOrEmpty(rule.NatData?.TranslatedSource));
                             break;

--- a/roles/ui/files/FWO.UI/Shared/ObjectGroup.razor
+++ b/roles/ui/files/FWO.UI/Shared/ObjectGroup.razor
@@ -118,8 +118,10 @@
                             Items="@NetworkServiceExtractor(Content)" PageSize="PageSize" ColumnReorder="true">
                         <Column TableItem="NetworkService" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Class="word-break">
                             <Template>
-                                <span class="@ReportBase.GetIconClass(ObjCategory.nsrv, context.Type.Name)">&nbsp;</span>
-                                <b id="@(GetID(ObjCategory.nsrv, context.Id))">@(context.Name)</b>
+                                <div> @* need same offset to parent html for link highlight *@
+                                    <span class="@ReportBase.GetIconClass(ObjCategory.nsrv, context.Type.Name)">&nbsp;</span>
+                                    <b id="@(GetID(ObjCategory.nsrv, context.Id))">@(context.Name)</b>
+                                </div>
                             </Template>
                         </Column>
                         <DetailTemplate TableItem="NetworkService">
@@ -194,8 +196,10 @@
                             TableItem="NetworkUser" Items="@NetworkUserExtractor(Content)" PageSize="PageSize" ColumnReorder="true">
                         <Column TableItem="NetworkUser" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Class="word-break">
                             <Template>
-                                <span class="@ReportBase.GetIconClass(ObjCategory.user, context.Type.Name)">&nbsp;</span>
-                                <b id="@(GetID(ObjCategory.user, context.Id))">@(context.Name)</b>
+                                <div> @* need same offset to parent html for link highlight *@
+                                    <span class="@ReportBase.GetIconClass(ObjCategory.user, context.Type.Name)">&nbsp;</span>
+                                    <b id="@(GetID(ObjCategory.user, context.Id))">@(context.Name)</b>
+                                </div>
                             </Template>
                         </Column>
                         <DetailTemplate TableItem="NetworkUser">

--- a/roles/ui/files/FWO.UI/Shared/ObjectGroupCollection.razor
+++ b/roles/ui/files/FWO.UI/Shared/ObjectGroupCollection.razor
@@ -17,6 +17,19 @@
 
 @code
 {
+    private ObjectGroup<InputDataType>? objectGroupRef;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender && objectGroupRef != null && !ObjectGroups.Contains(objectGroupRef))
+        {
+            ObjectGroups.Add(objectGroupRef);
+        }
+    }
+
+    public List<ObjectGroup<InputDataType>> ObjectGroups { get; set; } = new List<ObjectGroup<InputDataType>>();
+
+
     [Parameter]
     public Func<RsbTab, ObjCategory, Func<ReportData, Task>, long, bool, Task>? FetchObjects { get; set; }
 
@@ -52,4 +65,5 @@
     
     [Parameter]
     public bool Reload { get; set; } = false;
+
 }

--- a/roles/ui/files/FWO.UI/Shared/ObjectGroupCollection.razor
+++ b/roles/ui/files/FWO.UI/Shared/ObjectGroupCollection.razor
@@ -17,19 +17,6 @@
 
 @code
 {
-    private ObjectGroup<InputDataType>? objectGroupRef;
-
-    protected override void OnAfterRender(bool firstRender)
-    {
-        if (firstRender && objectGroupRef != null && !ObjectGroups.Contains(objectGroupRef))
-        {
-            ObjectGroups.Add(objectGroupRef);
-        }
-    }
-
-    public List<ObjectGroup<InputDataType>> ObjectGroups { get; set; } = new List<ObjectGroup<InputDataType>>();
-
-
     [Parameter]
     public Func<RsbTab, ObjCategory, Func<ReportData, Task>, long, bool, Task>? FetchObjects { get; set; }
 

--- a/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
+++ b/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
@@ -26,7 +26,7 @@
                                 <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("all"))">@(userConfig.GetText("collapse_all"))</div>
                             </div>
                             <div class="mt-2">
-                                    <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.all" InputDataType="ManagementReport" Data="managementsAllObjects"
+                                    <ObjectGroupCollection FetchObjects="FetchContent" Recert="Recert" Tab="RsbTab.all" InputDataType="ManagementReport" Data="managementsAllObjects"
                                         NameExtractor="man => man.Name" NetworkObjectExtractor="man => man.Objects"
                                         NetworkServiceExtractor="man => man.Services" NetworkUserExtractor="man => man.Users" />
                             </div>
@@ -39,7 +39,7 @@
                                 <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
                             </div>
                             <div class="mt-2">
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.report" InputDataType="ManagementReport" 
+                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="Recert" Tab="RsbTab.report" InputDataType="ManagementReport" 
                                     Data="CurrentReport.ReportData.ManagementData.Where(m => (m.Devices.Where(d => d.Rules != null && d.Rules.Count() > 0).Count() > 0))"
                                     NameExtractor="man => man.Name"
                                     NetworkObjectExtractor="man => man.ReportObjects"
@@ -54,7 +54,7 @@
                                 <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("rule"))">@(userConfig.GetText("collapse_all"))</div>
                             </div>
                             <div class="mt-2">
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.rule" StartContentDetailed="true" StartCollapsed="false" InputDataType="Rule" Data="SelectedRules"
+                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="Recert" Tab="RsbTab.rule" StartContentDetailed="true" StartCollapsed="false" InputDataType="Rule" Data="SelectedRules"
                                     NameExtractor=@(rule => $"{rule.DeviceName} - Rule {rule.Id} {rule.Name}")
                                     NetworkObjectExtractor="rule => rule.Froms.Select(nl => nl.Object)
                                         .Union(rule.Tos.Select(nl => nl.Object))
@@ -73,13 +73,13 @@
                                 <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
                             </div>
                             <div class="mt-2">
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="OwnerReport" 
+                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="Recert" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="OwnerReport" 
                                     Data="CurrentReport.ReportData.OwnerData"
                                     NameExtractor="own => own.Name" 
                                     NetworkObjectExtractor="own => own.GetAllNetworkObjects(true)"
                                     NetworkServiceExtractor="own => own.GetAllServices(true)"
                                     Reload="true"/>
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="GlobalCommonSvcReport" 
+                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="Recert" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="GlobalCommonSvcReport" 
                                     Data="CurrentReport.ReportData.GlobalComSvc"
                                     NameExtractor="glbComSvc => glbComSvc.Name"
                                     NetworkObjectExtractor="glbComSvc => glbComSvc.GetAllNetworkObjects(true)"
@@ -120,6 +120,9 @@
 
     [Parameter]
     public ReportType SelectedReportType  { get; set; } = ReportType.Rules;
+
+    [Parameter]
+    public bool Recert { get; set; } = false;
         
     private FWO.Ui.Shared.TabSet tabset = new ();
     private FWO.Ui.Shared.AnchorNavToRSB anchorNavToRSB = new ();

--- a/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
+++ b/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
@@ -17,75 +17,77 @@
         <h5 class="text-center">@(userConfig.GetText("objects"))</h5>
         <AnchorNavToRSB @ref="anchorNavToRSB" TabSet="tabset" CollapseState="collapseInRSB" />
         <TabSet DarkMode="true" KeepPanelsAlive="true" @ref="tabset">
-            @if(SelectedReportType.IsDeviceRelatedReport() && AllTabVisible)
-            {
-                <Tab Title="@(userConfig.GetText("all"))" Position=0>
-                    <div class="d-md-flex justify-content-md-end sticky-marker-45">
-                        <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("all"))">@(userConfig.GetText("collapse_all"))</div>
-                    </div>
-                    <div class="mt-2">
-                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.all" InputDataType="ManagementReport" Data="managementsAllObjects"
-                                NameExtractor="man => man.Name" NetworkObjectExtractor="man => man.Objects"
-                                NetworkServiceExtractor="man => man.Services" NetworkUserExtractor="man => man.Users" />
-                    </div>
-                </Tab>
-            }
-            @if(CurrentReport?.ReportData.ManagementData.Count > 0 && (CurrentReport?.ReportType.IsRuleReport() ?? false))
-            {
-                <Tab Title="@(userConfig.GetText("report"))">
-                    <div class="d-md-flex justify-content-md-end sticky-marker-45">
-                        <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
-                    </div>
-                    <div class="mt-2">
-                        <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.report" InputDataType="ManagementReport" 
-                            Data="CurrentReport.ReportData.ManagementData.Where(m => (m.Devices.Where(d => d.Rules != null && d.Rules.Count() > 0).Count() > 0))"
-                            NameExtractor="man => man.Name"
-                            NetworkObjectExtractor="man => man.ReportObjects"
-                            NetworkServiceExtractor="man => man.ReportServices"
-                            NetworkUserExtractor="man => man.ReportUsers" 
-                            Reload="CurrentReport.ReportType.IsModellingReport()"/>
-                    </div>
-                </Tab>
-                <Tab Title="@(userConfig.GetText("rule"))">
-                    <div class="btn-group btn-group-sm d-md-flex justify-content-md-between sticky-marker-45">
-                        <div class="btn btn-dark btn-sm w-50" @onclick="@(async () => {SelectedRules.Clear(); await SelectedRulesChanged.InvokeAsync(SelectedRules);})">@(userConfig.GetText("clear_all"))</div>
-                        <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("rule"))">@(userConfig.GetText("collapse_all"))</div>
-                    </div>
-                    <div class="mt-2">
-                        <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.rule" StartContentDetailed="true" StartCollapsed="false" InputDataType="Rule" Data="SelectedRules"
-                            NameExtractor=@(rule => $"{rule.DeviceName} - Rule {rule.Id} {rule.Name}")
-                            NetworkObjectExtractor="rule => rule.Froms.Select(nl => nl.Object)
-                                .Union(rule.Tos.Select(nl => nl.Object))
-                                .Union(rule.NatData.TranslatedFroms.Select(nl => nl.Object))
-                                .Union(rule.NatData.TranslatedTos.Select(nl => nl.Object)).OrderBy(o => o.Name).ToArray()"
-                            NetworkServiceExtractor="rule => rule.Services.Select(sw => sw.Content)
-                                .Union(rule.NatData.TranslatedServices.Select(sw => sw.Content)).OrderBy(s => s.Name).ToArray()"
-                            NetworkUserExtractor="rule => rule.Froms.Select(nl => nl.User).Distinct().Where(u => u != null).OrderBy(u => u.Name).ToArray()" />
-                    </div>
-                </Tab>
-            }
-            @if(CurrentReport?.ReportData.OwnerData.Count > 0 && CurrentReport?.ReportType == ReportType.Connections)
-            {
-                <Tab Title="@(userConfig.GetText("used_objects"))">
-                    <div class="d-md-flex justify-content-md-end sticky-marker-45">
-                        <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
-                    </div>
-                    <div class="mt-2">
-                        <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="OwnerReport" 
-                            Data="CurrentReport.ReportData.OwnerData"
-                            NameExtractor="own => own.Name" 
-                            NetworkObjectExtractor="own => own.GetAllNetworkObjects(true)"
-                            NetworkServiceExtractor="own => own.GetAllServices(true)"
-                            Reload="true"/>
-                        <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="GlobalCommonSvcReport" 
-                            Data="CurrentReport.ReportData.GlobalComSvc"
-                            NameExtractor="glbComSvc => glbComSvc.Name"
-                            NetworkObjectExtractor="glbComSvc => glbComSvc.GetAllNetworkObjects(true)"
-                            NetworkServiceExtractor="glbComSvc => glbComSvc.GetAllServices(true)"
-                            Reload="true"/>
-                    </div>
-                </Tab>
-            }
+            <CascadingValue Value="collapseInRSB">
+                @if(SelectedReportType.IsDeviceRelatedReport() && AllTabVisible)
+                {
+                    <Tab Title="@(userConfig.GetText("all"))" Position=0>
+                        <div class="d-md-flex justify-content-md-end sticky-marker-45">
+                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("all"))">@(userConfig.GetText("collapse_all"))</div>
+                        </div>
+                        <div class="mt-2">
+                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.all" InputDataType="ManagementReport" Data="managementsAllObjects"
+                                    NameExtractor="man => man.Name" NetworkObjectExtractor="man => man.Objects"
+                                    NetworkServiceExtractor="man => man.Services" NetworkUserExtractor="man => man.Users" />
+                        </div>
+                    </Tab>
+                }
+                @if(CurrentReport?.ReportData.ManagementData.Count > 0 && (CurrentReport?.ReportType.IsRuleReport() ?? false))
+                {
+                    <Tab Title="@(userConfig.GetText("report"))">
+                        <div class="d-md-flex justify-content-md-end sticky-marker-45">
+                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
+                        </div>
+                        <div class="mt-2">
+                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.report" InputDataType="ManagementReport" 
+                                Data="CurrentReport.ReportData.ManagementData.Where(m => (m.Devices.Where(d => d.Rules != null && d.Rules.Count() > 0).Count() > 0))"
+                                NameExtractor="man => man.Name"
+                                NetworkObjectExtractor="man => man.ReportObjects"
+                                NetworkServiceExtractor="man => man.ReportServices"
+                                NetworkUserExtractor="man => man.ReportUsers" 
+                                Reload="CurrentReport.ReportType.IsModellingReport()"/>
+                        </div>
+                    </Tab>
+                    <Tab Title="@(userConfig.GetText("rule"))">
+                        <div class="btn-group btn-group-sm d-md-flex justify-content-md-between sticky-marker-45">
+                            <div class="btn btn-dark btn-sm w-50" @onclick="@(async () => {SelectedRules.Clear(); await SelectedRulesChanged.InvokeAsync(SelectedRules);})">@(userConfig.GetText("clear_all"))</div>
+                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("rule"))">@(userConfig.GetText("collapse_all"))</div>
+                        </div>
+                        <div class="mt-2">
+                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.rule" StartContentDetailed="true" StartCollapsed="false" InputDataType="Rule" Data="SelectedRules"
+                                NameExtractor=@(rule => $"{rule.DeviceName} - Rule {rule.Id} {rule.Name}")
+                                NetworkObjectExtractor="rule => rule.Froms.Select(nl => nl.Object)
+                                    .Union(rule.Tos.Select(nl => nl.Object))
+                                    .Union(rule.NatData.TranslatedFroms.Select(nl => nl.Object))
+                                    .Union(rule.NatData.TranslatedTos.Select(nl => nl.Object)).OrderBy(o => o.Name).ToArray()"
+                                NetworkServiceExtractor="rule => rule.Services.Select(sw => sw.Content)
+                                    .Union(rule.NatData.TranslatedServices.Select(sw => sw.Content)).OrderBy(s => s.Name).ToArray()"
+                                NetworkUserExtractor="rule => rule.Froms.Select(nl => nl.User).Distinct().Where(u => u != null).OrderBy(u => u.Name).ToArray()" />
+                        </div>
+                    </Tab>
+                }
+                @if(CurrentReport?.ReportData.OwnerData.Count > 0 && CurrentReport?.ReportType == ReportType.Connections)
+                {
+                    <Tab Title="@(userConfig.GetText("used_objects"))">
+                        <div class="d-md-flex justify-content-md-end sticky-marker-45">
+                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
+                        </div>
+                        <div class="mt-2">
+                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="OwnerReport" 
+                                Data="CurrentReport.ReportData.OwnerData"
+                                NameExtractor="own => own.Name" 
+                                NetworkObjectExtractor="own => own.GetAllNetworkObjects(true)"
+                                NetworkServiceExtractor="own => own.GetAllServices(true)"
+                                Reload="true"/>
+                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="GlobalCommonSvcReport" 
+                                Data="CurrentReport.ReportData.GlobalComSvc"
+                                NameExtractor="glbComSvc => glbComSvc.Name"
+                                NetworkObjectExtractor="glbComSvc => glbComSvc.GetAllNetworkObjects(true)"
+                                NetworkServiceExtractor="glbComSvc => glbComSvc.GetAllServices(true)"
+                                Reload="true"/>
+                        </div>
+                    </Tab>
+                }
+            </CascadingValue>
         </TabSet>
     </div>
 </Sidebar>

--- a/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
+++ b/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
@@ -15,87 +15,78 @@
 <Sidebar Collapsible="true" Resizeable="true" PositionLeft="false" @bind-Width="intWidth">
     <div class="p-3 mt-2">
         <h5 class="text-center">@(userConfig.GetText("objects"))</h5>
-        <CascadingValue Value="AnchorNavToRSB">
-            <TabSet DarkMode="true" KeepPanelsAlive="true" @ref="Tabset">
-                @if(SelectedReportType.IsDeviceRelatedReport() && AllTabVisible)
-                {
-                    <Tab Title="@(userConfig.GetText("all"))" Position=0>
-                        <div class="d-md-flex justify-content-md-end sticky-marker-45">
-                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseSidebarAll.CollapseAll())">@(userConfig.GetText("collapse_all"))</div>
-                        </div>
-                        <div class="mt-2">
-                            <CascadingValue Value="collapseSidebarAll">
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.all" InputDataType="ManagementReport" Data="managementsAllObjects"
-                                    NameExtractor="man => man.Name" NetworkObjectExtractor="man => man.Objects"
-                                    NetworkServiceExtractor="man => man.Services" NetworkUserExtractor="man => man.Users" />
-                            </CascadingValue>
-                        </div>
-                    </Tab>
-                }
-                @if(CurrentReport?.ReportData.ManagementData.Count > 0 && (CurrentReport?.ReportType.IsRuleReport() ?? false))
-                {
-                    <Tab Title="@(userConfig.GetText("report"))">
-                        <div class="d-md-flex justify-content-md-end sticky-marker-45">
-                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseSidebarReport.CollapseAll())">@(userConfig.GetText("collapse_all"))</div>
-                        </div>
-                        <div class="mt-2">
-                            <CascadingValue Value="collapseSidebarReport">
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.report" InputDataType="ManagementReport" 
-                                    Data="CurrentReport.ReportData.ManagementData.Where(m => (m.Devices.Where(d => d.Rules != null && d.Rules.Count() > 0).Count() > 0))"
-                                    NameExtractor="man => man.Name"
-                                    NetworkObjectExtractor="man => man.ReportObjects"
-                                    NetworkServiceExtractor="man => man.ReportServices"
-                                    NetworkUserExtractor="man => man.ReportUsers" 
-                                    Reload="CurrentReport.ReportType.IsModellingReport()"/>
-                            </CascadingValue>
-                        </div>
-                    </Tab>
-                    <Tab Title="@(userConfig.GetText("rule"))">
-                        <div class="btn-group btn-group-sm d-md-flex justify-content-md-between sticky-marker-45">
-                            <div class="btn btn-dark btn-sm w-50" @onclick="@(async () => {SelectedRules.Clear(); await SelectedRulesChanged.InvokeAsync(SelectedRules);})">@(userConfig.GetText("clear_all"))</div>
-                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseSidebarRule.CollapseAll())">@(userConfig.GetText("collapse_all"))</div>
-                        </div>
-                        <div class="mt-2">
-                            <CascadingValue Value="collapseSidebarRule">
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.rule" StartContentDetailed="true" StartCollapsed="false" InputDataType="Rule" Data="SelectedRules"
-                                    NameExtractor=@(rule => $"{rule.DeviceName} - Rule {rule.Id} {rule.Name}")
-                                    NetworkObjectExtractor="rule => rule.Froms.Select(nl => nl.Object)
-                                        .Union(rule.Tos.Select(nl => nl.Object))
-                                        .Union(rule.NatData.TranslatedFroms.Select(nl => nl.Object))
-                                        .Union(rule.NatData.TranslatedTos.Select(nl => nl.Object)).OrderBy(o => o.Name).ToArray()"
-                                    NetworkServiceExtractor="rule => rule.Services.Select(sw => sw.Content)
-                                        .Union(rule.NatData.TranslatedServices.Select(sw => sw.Content)).OrderBy(s => s.Name).ToArray()"
-                                    NetworkUserExtractor="rule => rule.Froms.Select(nl => nl.User).Distinct().Where(u => u != null).OrderBy(u => u.Name).ToArray()" />
-                            </CascadingValue>
-                        </div>
-                    </Tab>
-                }
-                @if(CurrentReport?.ReportData.OwnerData.Count > 0 && CurrentReport?.ReportType == ReportType.Connections)
-                {
-                    <Tab Title="@(userConfig.GetText("used_objects"))">
-                        <div class="d-md-flex justify-content-md-end sticky-marker-45">
-                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseSidebarReport.CollapseAll())">@(userConfig.GetText("collapse_all"))</div>
-                        </div>
-                        <div class="mt-2">
-                            <CascadingValue Value="collapseSidebarReport">
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="OwnerReport" 
-                                    Data="CurrentReport.ReportData.OwnerData"
-                                    NameExtractor="own => own.Name" 
-                                    NetworkObjectExtractor="own => own.GetAllNetworkObjects(true)"
-                                    NetworkServiceExtractor="own => own.GetAllServices(true)"
-                                    Reload="true"/>
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="GlobalCommonSvcReport" 
-                                    Data="CurrentReport.ReportData.GlobalComSvc"
-                                    NameExtractor="glbComSvc => glbComSvc.Name"
-                                    NetworkObjectExtractor="glbComSvc => glbComSvc.GetAllNetworkObjects(true)"
-                                    NetworkServiceExtractor="glbComSvc => glbComSvc.GetAllServices(true)"
-                                    Reload="true"/>
-                            </CascadingValue>
-                        </div>
-                    </Tab>
-                }
-            </TabSet>
-        </CascadingValue>
+        <AnchorNavToRSB @ref="anchorNavToRSB" TabSet="tabset" CollapseState="collapseInRSB" />
+        <TabSet DarkMode="true" KeepPanelsAlive="true" @ref="tabset">
+            @if(SelectedReportType.IsDeviceRelatedReport() && AllTabVisible)
+            {
+                <Tab Title="@(userConfig.GetText("all"))" Position=0>
+                    <div class="d-md-flex justify-content-md-end sticky-marker-45">
+                        <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("all"))">@(userConfig.GetText("collapse_all"))</div>
+                    </div>
+                    <div class="mt-2">
+                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.all" InputDataType="ManagementReport" Data="managementsAllObjects"
+                                NameExtractor="man => man.Name" NetworkObjectExtractor="man => man.Objects"
+                                NetworkServiceExtractor="man => man.Services" NetworkUserExtractor="man => man.Users" />
+                    </div>
+                </Tab>
+            }
+            @if(CurrentReport?.ReportData.ManagementData.Count > 0 && (CurrentReport?.ReportType.IsRuleReport() ?? false))
+            {
+                <Tab Title="@(userConfig.GetText("report"))">
+                    <div class="d-md-flex justify-content-md-end sticky-marker-45">
+                        <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
+                    </div>
+                    <div class="mt-2">
+                        <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.report" InputDataType="ManagementReport" 
+                            Data="CurrentReport.ReportData.ManagementData.Where(m => (m.Devices.Where(d => d.Rules != null && d.Rules.Count() > 0).Count() > 0))"
+                            NameExtractor="man => man.Name"
+                            NetworkObjectExtractor="man => man.ReportObjects"
+                            NetworkServiceExtractor="man => man.ReportServices"
+                            NetworkUserExtractor="man => man.ReportUsers" 
+                            Reload="CurrentReport.ReportType.IsModellingReport()"/>
+                    </div>
+                </Tab>
+                <Tab Title="@(userConfig.GetText("rule"))">
+                    <div class="btn-group btn-group-sm d-md-flex justify-content-md-between sticky-marker-45">
+                        <div class="btn btn-dark btn-sm w-50" @onclick="@(async () => {SelectedRules.Clear(); await SelectedRulesChanged.InvokeAsync(SelectedRules);})">@(userConfig.GetText("clear_all"))</div>
+                        <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("rule"))">@(userConfig.GetText("collapse_all"))</div>
+                    </div>
+                    <div class="mt-2">
+                        <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.rule" StartContentDetailed="true" StartCollapsed="false" InputDataType="Rule" Data="SelectedRules"
+                            NameExtractor=@(rule => $"{rule.DeviceName} - Rule {rule.Id} {rule.Name}")
+                            NetworkObjectExtractor="rule => rule.Froms.Select(nl => nl.Object)
+                                .Union(rule.Tos.Select(nl => nl.Object))
+                                .Union(rule.NatData.TranslatedFroms.Select(nl => nl.Object))
+                                .Union(rule.NatData.TranslatedTos.Select(nl => nl.Object)).OrderBy(o => o.Name).ToArray()"
+                            NetworkServiceExtractor="rule => rule.Services.Select(sw => sw.Content)
+                                .Union(rule.NatData.TranslatedServices.Select(sw => sw.Content)).OrderBy(s => s.Name).ToArray()"
+                            NetworkUserExtractor="rule => rule.Froms.Select(nl => nl.User).Distinct().Where(u => u != null).OrderBy(u => u.Name).ToArray()" />
+                    </div>
+                </Tab>
+            }
+            @if(CurrentReport?.ReportData.OwnerData.Count > 0 && CurrentReport?.ReportType == ReportType.Connections)
+            {
+                <Tab Title="@(userConfig.GetText("used_objects"))">
+                    <div class="d-md-flex justify-content-md-end sticky-marker-45">
+                        <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
+                    </div>
+                    <div class="mt-2">
+                        <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="OwnerReport" 
+                            Data="CurrentReport.ReportData.OwnerData"
+                            NameExtractor="own => own.Name" 
+                            NetworkObjectExtractor="own => own.GetAllNetworkObjects(true)"
+                            NetworkServiceExtractor="own => own.GetAllServices(true)"
+                            Reload="true"/>
+                        <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="GlobalCommonSvcReport" 
+                            Data="CurrentReport.ReportData.GlobalComSvc"
+                            NameExtractor="glbComSvc => glbComSvc.Name"
+                            NetworkObjectExtractor="glbComSvc => glbComSvc.GetAllNetworkObjects(true)"
+                            NetworkServiceExtractor="glbComSvc => glbComSvc.GetAllServices(true)"
+                            Reload="true"/>
+                    </div>
+                </Tab>
+            }
+        </TabSet>
     </div>
 </Sidebar>
 
@@ -110,11 +101,6 @@
     [Parameter]
     public EventCallback<int> WidthChanged { get; set; }
 
-    [Parameter]
-    public FWO.Ui.Shared.TabSet Tabset { get; set; } = default!;
-
-    [Parameter]
-    public FWO.Ui.Shared.AnchorNavToRSB AnchorNavToRSB { get; set; } = default!;
 
     [Parameter]
     public ReportBase? CurrentReport { get; set; }
@@ -131,9 +117,9 @@
     [Parameter]
     public ReportType SelectedReportType  { get; set; } = ReportType.Rules;
         
-    private CollapseState collapseSidebarAll = new ();
-    private CollapseState collapseSidebarReport = new ();
-    private CollapseState collapseSidebarRule = new ();
+    private FWO.Ui.Shared.TabSet tabset = new ();
+    private FWO.Ui.Shared.AnchorNavToRSB anchorNavToRSB = new ();
+    private CollapseState collapseInRSB = new ();
     private List<ManagementReport> managementsAllObjects = new ();
 
     private int intWidth { get { return Width; } set { Width = value; WidthChanged.InvokeAsync(Width);}}

--- a/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
+++ b/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
@@ -15,8 +15,8 @@
 <Sidebar Collapsible="true" Resizeable="true" PositionLeft="false" @bind-Width="intWidth">
     <div class="p-3 mt-2">
         <h5 class="text-center">@(userConfig.GetText("objects"))</h5>
-        <AnchorNavToRSB @ref="anchorNavToRSB" TabSet="tabset" CollapseState="collapseInRSB" />
         <TabSet DarkMode="true" KeepPanelsAlive="true" @ref="tabset">
+        <AnchorNavToRSB @ref="anchorNavToRSB" TabSet="tabset" CollapseState="collapseInRSB" />
             <CascadingValue Value="collapseInRSB">
                 <CascadingValue Value="anchorNavToRSB">
                     @if(SelectedReportType.IsDeviceRelatedReport() && AllTabVisible)

--- a/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
+++ b/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
@@ -15,7 +15,7 @@
 <Sidebar Collapsible="true" Resizeable="true" PositionLeft="false" @bind-Width="intWidth">
     <div class="p-3 mt-2">
         <h5 class="text-center">@(userConfig.GetText("objects"))</h5>
-        <TabSet DarkMode="true" KeepPanelsAlive="true" @ref="tabset">
+        <TabSet @ref="tabset" DarkMode="true" KeepPanelsAlive="true" RsbStyle="true">
         <AnchorNavToRSB @ref="anchorNavToRSB" TabSet="tabset" CollapseState="collapseInRSB" />
             <CascadingValue Value="collapseInRSB">
                 <CascadingValue Value="anchorNavToRSB">

--- a/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
+++ b/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
@@ -18,75 +18,77 @@
         <AnchorNavToRSB @ref="anchorNavToRSB" TabSet="tabset" CollapseState="collapseInRSB" />
         <TabSet DarkMode="true" KeepPanelsAlive="true" @ref="tabset">
             <CascadingValue Value="collapseInRSB">
-                @if(SelectedReportType.IsDeviceRelatedReport() && AllTabVisible)
-                {
-                    <Tab Title="@(userConfig.GetText("all"))" Position=0>
-                        <div class="d-md-flex justify-content-md-end sticky-marker-45">
-                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("all"))">@(userConfig.GetText("collapse_all"))</div>
-                        </div>
-                        <div class="mt-2">
-                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.all" InputDataType="ManagementReport" Data="managementsAllObjects"
-                                    NameExtractor="man => man.Name" NetworkObjectExtractor="man => man.Objects"
-                                    NetworkServiceExtractor="man => man.Services" NetworkUserExtractor="man => man.Users" />
-                        </div>
-                    </Tab>
-                }
-                @if(CurrentReport?.ReportData.ManagementData.Count > 0 && (CurrentReport?.ReportType.IsRuleReport() ?? false))
-                {
-                    <Tab Title="@(userConfig.GetText("report"))">
-                        <div class="d-md-flex justify-content-md-end sticky-marker-45">
-                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
-                        </div>
-                        <div class="mt-2">
-                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.report" InputDataType="ManagementReport" 
-                                Data="CurrentReport.ReportData.ManagementData.Where(m => (m.Devices.Where(d => d.Rules != null && d.Rules.Count() > 0).Count() > 0))"
-                                NameExtractor="man => man.Name"
-                                NetworkObjectExtractor="man => man.ReportObjects"
-                                NetworkServiceExtractor="man => man.ReportServices"
-                                NetworkUserExtractor="man => man.ReportUsers" 
-                                Reload="CurrentReport.ReportType.IsModellingReport()"/>
-                        </div>
-                    </Tab>
-                    <Tab Title="@(userConfig.GetText("rule"))">
-                        <div class="btn-group btn-group-sm d-md-flex justify-content-md-between sticky-marker-45">
-                            <div class="btn btn-dark btn-sm w-50" @onclick="@(async () => {SelectedRules.Clear(); await SelectedRulesChanged.InvokeAsync(SelectedRules);})">@(userConfig.GetText("clear_all"))</div>
-                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("rule"))">@(userConfig.GetText("collapse_all"))</div>
-                        </div>
-                        <div class="mt-2">
-                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.rule" StartContentDetailed="true" StartCollapsed="false" InputDataType="Rule" Data="SelectedRules"
-                                NameExtractor=@(rule => $"{rule.DeviceName} - Rule {rule.Id} {rule.Name}")
-                                NetworkObjectExtractor="rule => rule.Froms.Select(nl => nl.Object)
-                                    .Union(rule.Tos.Select(nl => nl.Object))
-                                    .Union(rule.NatData.TranslatedFroms.Select(nl => nl.Object))
-                                    .Union(rule.NatData.TranslatedTos.Select(nl => nl.Object)).OrderBy(o => o.Name).ToArray()"
-                                NetworkServiceExtractor="rule => rule.Services.Select(sw => sw.Content)
-                                    .Union(rule.NatData.TranslatedServices.Select(sw => sw.Content)).OrderBy(s => s.Name).ToArray()"
-                                NetworkUserExtractor="rule => rule.Froms.Select(nl => nl.User).Distinct().Where(u => u != null).OrderBy(u => u.Name).ToArray()" />
-                        </div>
-                    </Tab>
-                }
-                @if(CurrentReport?.ReportData.OwnerData.Count > 0 && CurrentReport?.ReportType == ReportType.Connections)
-                {
-                    <Tab Title="@(userConfig.GetText("used_objects"))">
-                        <div class="d-md-flex justify-content-md-end sticky-marker-45">
-                            <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
-                        </div>
-                        <div class="mt-2">
-                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="OwnerReport" 
-                                Data="CurrentReport.ReportData.OwnerData"
-                                NameExtractor="own => own.Name" 
-                                NetworkObjectExtractor="own => own.GetAllNetworkObjects(true)"
-                                NetworkServiceExtractor="own => own.GetAllServices(true)"
-                                Reload="true"/>
-                            <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="GlobalCommonSvcReport" 
-                                Data="CurrentReport.ReportData.GlobalComSvc"
-                                NameExtractor="glbComSvc => glbComSvc.Name"
-                                NetworkObjectExtractor="glbComSvc => glbComSvc.GetAllNetworkObjects(true)"
-                                NetworkServiceExtractor="glbComSvc => glbComSvc.GetAllServices(true)"
-                                Reload="true"/>
-                        </div>
-                    </Tab>
-                }
+                <CascadingValue Value="anchorNavToRSB">
+                    @if(SelectedReportType.IsDeviceRelatedReport() && AllTabVisible)
+                    {
+                        <Tab Title="@(userConfig.GetText("all"))" Position=0>
+                            <div class="d-md-flex justify-content-md-end sticky-marker-45">
+                                <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("all"))">@(userConfig.GetText("collapse_all"))</div>
+                            </div>
+                            <div class="mt-2">
+                                    <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.all" InputDataType="ManagementReport" Data="managementsAllObjects"
+                                        NameExtractor="man => man.Name" NetworkObjectExtractor="man => man.Objects"
+                                        NetworkServiceExtractor="man => man.Services" NetworkUserExtractor="man => man.Users" />
+                            </div>
+                        </Tab>
+                    }
+                    @if(CurrentReport?.ReportData.ManagementData.Count > 0 && (CurrentReport?.ReportType.IsRuleReport() ?? false))
+                    {
+                        <Tab Title="@(userConfig.GetText("report"))">
+                            <div class="d-md-flex justify-content-md-end sticky-marker-45">
+                                <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
+                            </div>
+                            <div class="mt-2">
+                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.report" InputDataType="ManagementReport" 
+                                    Data="CurrentReport.ReportData.ManagementData.Where(m => (m.Devices.Where(d => d.Rules != null && d.Rules.Count() > 0).Count() > 0))"
+                                    NameExtractor="man => man.Name"
+                                    NetworkObjectExtractor="man => man.ReportObjects"
+                                    NetworkServiceExtractor="man => man.ReportServices"
+                                    NetworkUserExtractor="man => man.ReportUsers" 
+                                    Reload="CurrentReport.ReportType.IsModellingReport()"/>
+                            </div>
+                        </Tab>
+                        <Tab Title="@(userConfig.GetText("rule"))">
+                            <div class="btn-group btn-group-sm d-md-flex justify-content-md-between sticky-marker-45">
+                                <div class="btn btn-dark btn-sm w-50" @onclick="@(async () => {SelectedRules.Clear(); await SelectedRulesChanged.InvokeAsync(SelectedRules);})">@(userConfig.GetText("clear_all"))</div>
+                                <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("rule"))">@(userConfig.GetText("collapse_all"))</div>
+                            </div>
+                            <div class="mt-2">
+                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.rule" StartContentDetailed="true" StartCollapsed="false" InputDataType="Rule" Data="SelectedRules"
+                                    NameExtractor=@(rule => $"{rule.DeviceName} - Rule {rule.Id} {rule.Name}")
+                                    NetworkObjectExtractor="rule => rule.Froms.Select(nl => nl.Object)
+                                        .Union(rule.Tos.Select(nl => nl.Object))
+                                        .Union(rule.NatData.TranslatedFroms.Select(nl => nl.Object))
+                                        .Union(rule.NatData.TranslatedTos.Select(nl => nl.Object)).OrderBy(o => o.Name).ToArray()"
+                                    NetworkServiceExtractor="rule => rule.Services.Select(sw => sw.Content)
+                                        .Union(rule.NatData.TranslatedServices.Select(sw => sw.Content)).OrderBy(s => s.Name).ToArray()"
+                                    NetworkUserExtractor="rule => rule.Froms.Select(nl => nl.User).Distinct().Where(u => u != null).OrderBy(u => u.Name).ToArray()" />
+                            </div>
+                        </Tab>
+                    }
+                    @if(CurrentReport?.ReportData.OwnerData.Count > 0 && CurrentReport?.ReportType == ReportType.Connections)
+                    {
+                        <Tab Title="@(userConfig.GetText("used_objects"))">
+                            <div class="d-md-flex justify-content-md-end sticky-marker-45">
+                                <div class="btn btn-secondary btn-sm w-50" @onclick="@(() => collapseInRSB.Collapse("report"))">@(userConfig.GetText("collapse_all"))</div>
+                            </div>
+                            <div class="mt-2">
+                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="OwnerReport" 
+                                    Data="CurrentReport.ReportData.OwnerData"
+                                    NameExtractor="own => own.Name" 
+                                    NetworkObjectExtractor="own => own.GetAllNetworkObjects(true)"
+                                    NetworkServiceExtractor="own => own.GetAllServices(true)"
+                                    Reload="true"/>
+                                <ObjectGroupCollection FetchObjects="FetchContent" Recert="false" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="GlobalCommonSvcReport" 
+                                    Data="CurrentReport.ReportData.GlobalComSvc"
+                                    NameExtractor="glbComSvc => glbComSvc.Name"
+                                    NetworkObjectExtractor="glbComSvc => glbComSvc.GetAllNetworkObjects(true)"
+                                    NetworkServiceExtractor="glbComSvc => glbComSvc.GetAllServices(true)"
+                                    Reload="true"/>
+                            </div>
+                        </Tab>
+                    }
+                </CascadingValue>
             </CascadingValue>
         </TabSet>
     </div>

--- a/roles/ui/files/FWO.UI/Shared/TabSet.razor
+++ b/roles/ui/files/FWO.UI/Shared/TabSet.razor
@@ -76,9 +76,12 @@
         StateHasChanged();
     }
 
-    public void SetActiveTab(Tab tab)
+    public void SetActiveTab(Tab? tab)
     {
-        if (ActiveTab == null || ActiveTab != tab)
+        if (tab == null)
+            return;
+
+        if (Tabs.Contains(tab) && (ActiveTab == null || ActiveTab != tab))
         {
             ActiveTab = tab;
             StateHasChanged();
@@ -87,7 +90,7 @@
 
     public void SetActiveTab(int index)
     {
-        if (Tabs.Count > 0 && (ActiveTab == null || ActiveTab != Tabs[index]))
+        if (Tabs.Count > index && (ActiveTab == null || ActiveTab != Tabs[index]))
         {
             ActiveTab = Tabs[index];
             StateHasChanged();

--- a/roles/ui/files/FWO.UI/Shared/TabSet.razor
+++ b/roles/ui/files/FWO.UI/Shared/TabSet.razor
@@ -1,19 +1,12 @@
 ﻿@implements IDisposable
 
 <!-- Display the tab headers -->
-<ul class="nav nav-tabs  @(WholeWidth ? "nav-fill" : "") sticky-marker @(DarkMode ? "bg-transparent" : "")" style="@(DarkMode ? "--bs-nav-tabs-border-color: transparent;" : "")">
+<ul class="@GetNavClasses()">
     @foreach (Tab tab in Tabs)
     {
         <li class="nav-item">
-            <a href="" @onclick="() => SetActiveTab(tab)" @onclick:preventDefault class="nav-link @(DarkMode ? "text-white" : "text-dark")
-                @(ActiveTab == tab ? (DarkMode ? "bg-transparent active" : "active") : "")"
-               style="@(DarkMode ? (ActiveTab == tab ? "border-color: #0d6efd;  border-bottom-style: none;" : "border-color: #0d6efd; border-right-style:none; border-top-style:none; border-left-style: none;") : "")">
-
+            <a href="" @onclick="() => SetActiveTab(tab)" @onclick:preventDefault class="@GetTabLinkClasses(tab)">
                 @tab.Title
-                @*@if (Closeable)
-                    {
-                        <div class="ms-1 @(Icons.Close)"></div>
-                    }*@
             </a>
         </li>
     }
@@ -25,7 +18,6 @@
         @ChildContent
     </div>
 </CascadingValue>
-
 
 @code {
     [Parameter]
@@ -40,11 +32,44 @@
     [Parameter]
     public bool WholeWidth { get; set; } = true;
 
+    [Parameter]
+    public bool RsbStyle { get; set; } = false;
+
     public List<Tab> Tabs = new List<Tab>();
 
     public Tab? ActiveTab { get; private set; }
 
     private bool _isDisposed;
+
+    private string GetNavClasses()
+    {
+        var classes = new List<string> { "nav", "nav-tabs" };
+        if (WholeWidth) classes.Add("nav-fill");
+        classes.Add("sticky-marker");
+        if (DarkMode) classes.Add("nav-tabs-dark");
+        if (DarkMode) classes.Add("nav-tabs-border-transparent");
+        if (RsbStyle) classes.Add("nav-tabs-rsb");
+        return string.Join(" ", classes);
+    }
+
+    private string GetTabLinkClasses(Tab tab)
+    {
+        var classes = new List<string> { "nav-link" };
+        if (DarkMode) classes.Add("text-white");
+        else          classes.Add("text-dark");
+        if (ActiveTab == tab)
+        {
+            classes.Add("nav-link-active");
+            if (RsbStyle) classes.Add("nav-link-active-rsb");
+        }
+        else
+        {
+            classes.Add("nav-link-inactive");
+            if (RsbStyle) classes.Add("nav-link-inactive-rsb");
+        }
+        if (RsbStyle) classes.Add("nav-link-rsb-hover");
+        return string.Join(" ", classes);
+    }
 
     internal void AddTab(Tab tab, int pos = -1)
     {

--- a/roles/ui/files/FWO.UI/Shared/TabSet.razor.css
+++ b/roles/ui/files/FWO.UI/Shared/TabSet.razor.css
@@ -1,0 +1,36 @@
+.nav-tabs-rsb {
+    top: 0 !important;
+    background-color: #054887 !important;
+}
+
+.nav-tabs-dark {
+    background-color: transparent;
+}
+
+.nav-tabs-border-transparent {
+    --bs-nav-tabs-border-color: transparent;
+}
+
+.nav-link-active {
+    border-color: #0d6efd;
+    border-bottom-style: none;
+}
+
+.nav-link-inactive {
+    border-color: #0d6efd;
+    border-right-style: none;
+    border-top-style: none;
+    border-left-style: none;
+}
+
+.nav-link-active-rsb {
+    background-color: #054887;
+}
+
+.nav-link-inactive-rsb {
+    background-color: #03335E;
+}
+
+.nav-link-rsb-hover:hover {
+    background-color: #054887 !important;
+}

--- a/roles/ui/files/FWO.UI/wwwroot/css/site.css
+++ b/roles/ui/files/FWO.UI/wwwroot/css/site.css
@@ -257,6 +257,10 @@ h5 {
     text-overflow: ellipsis;
 }
 
+.navbar-height {
+    height: 56px;
+}
+
 .navbar-brand {
     padding: 8px;
 }

--- a/roles/ui/files/FWO.UI/wwwroot/js/scrollIntoView.js
+++ b/roles/ui/files/FWO.UI/wwwroot/js/scrollIntoView.js
@@ -12,6 +12,10 @@ function scrollIntoRSBView(htmlObjId) {
   return obj.offsetParent !== null; // element visible?
 }
 
+function getCurrentUrl() {
+  return window.location.href;
+}
+
 function removeUrlFragment() {
   history.replaceState(null, document.title, window.location.pathname + window.location.search);
 }

--- a/roles/ui/files/FWO.UI/wwwroot/js/scrollIntoView.js
+++ b/roles/ui/files/FWO.UI/wwwroot/js/scrollIntoView.js
@@ -1,4 +1,4 @@
-﻿
+
 function scrollIntoRSBView(htmlObjId) {
   let obj =  document.getElementById(htmlObjId)?.parentElement?.parentElement; // gets the tr element containing the obj
   if (!obj)
@@ -10,4 +10,8 @@ function scrollIntoRSBView(htmlObjId) {
   // Remove highlight after 800ms
   setTimeout(() => obj.style.backgroundColor = "", 800);
   return obj.offsetParent !== null; // element visible?
+}
+
+function removeUrlFragment() {
+  history.replaceState(null, document.title, window.location.pathname + window.location.search);
 }


### PR DESCRIPTION
Clicking on a link in report or rsb now automatically opens the necessary collapses to scroll to the object in rsb
Also fixes some bugs where the links did not work in general

closes #2261 
closes #2263 