### PR TITLE
fix(ui): ip filtering in app report

### DIFF
--- a/roles/lib/files/FWO.Api.Client/APIcalls/owner/newNetworkOwnership.graphql
+++ b/roles/lib/files/FWO.Api.Client/APIcalls/owner/newNetworkOwnership.graphql
@@ -7,6 +7,8 @@ mutation newNetworkOwnership(
     owner_id: $ownerId
     ip: $ip
     ip_end: $ip_end
+    is_deleted: false
+    nw_type: 10
   }) {
     returning {
       newIdLong: id


### PR DESCRIPTION
- IP filtering did not work in general for IP filters set during creation of new owner
- IP filtering now observes negation in rule source/destination

closes #2574 