### PR TITLE
fixed total rollback

### DIFF
--- a/roles/ui/files/FWO.UI/Shared/ImportRollback.razor
+++ b/roles/ui/files/FWO.UI/Shared/ImportRollback.razor
@@ -146,7 +146,8 @@
                         while (managementImportsStillExists)
                         {
                             var variablesGetManagement = new { mgmId = ManagementId };
-                            lastImportId = await apiConnection.SendQueryAsync<long?>(FWO.Api.Client.Queries.ImportQueries.getLastImport, variablesGetManagement);
+                            List<ImportControl>? getLastImportResponse = await apiConnection.SendQueryAsync<List<ImportControl>>(FWO.Api.Client.Queries.ImportQueries.getLastImport, variablesGetManagement);
+                            lastImportId = getLastImportResponse.FirstOrDefault()?.ControlId;
                             if (lastImportId == null)
                             {
                                 managementImportsStillExists = false;


### PR DESCRIPTION
The query responds with an array. To get the control id I made it similar to the calls right before the breaking call.