### PR TITLE
Merge: Some more Nuget Updates

### DIFF
--- a/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
+++ b/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="GraphQL.Client" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Data/FWO.Data.csproj
+++ b/roles/lib/files/FWO.Data/FWO.Data.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Mail/FWO.Mail.csproj
+++ b/roles/lib/files/FWO.Mail/FWO.Mail.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="MailKit" Version="4.11.0" />
     <PackageReference Include="MimeKit" Version="4.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Services/FWO.Services.csproj
+++ b/roles/lib/files/FWO.Services/FWO.Services.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.14" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.15" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
     <PackageReference Include="PuppeteerSharp" Version="20.1.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />


### PR DESCRIPTION
Updated Microsoft.AspNetCore.Components to 8.0.15
Updated Microsoft.AspNetCore.Components.Authorization to 8.0.15
Updated Microsoft.AspNetCore.Authentication.JwtBearer to 8.0.15

!> Updated System.Text.Encodings.Web to 9.0.4 <! 
I saw that we are using 9.0.4 already in a transitive package so i figured it's not depending on .Net 9 and we can use this, or am i missing something?


Closing #3139
Closing #3140
Closing #3141