### PR TITLE
Cactus develop fix #3114

### DIFF
--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -5285,8 +5285,8 @@ INSERT INTO txt VALUES ('H5639', 'German',  'Hier wird der Meldungstext f&uuml;r
 INSERT INTO txt VALUES ('H5639', 'English', 'Insert customized text for errors in requests to external ticket system.');
 INSERT INTO txt VALUES ('H5640', 'German',  'Auswahl des LDAP-Systems, in dem die Eigent&uuml;mergruppen gepflegt werden.');
 INSERT INTO txt VALUES ('H5640', 'English', 'Select LDAP system for storing owner groups.');
-INSERT INTO txt VALUES ('H5641', 'German',  'Festlegen des Namensschemas f&uuml;r Eigent&uuml;mergruppen. Dient zur eindeutigen Identifizierung der LDAP Gruppen. Der Platzhalter wird als @@ExternalAppId@@ definiert.');
-INSERT INTO txt VALUES ('H5641', 'English', 'Define naming convention in order to identify the LDAP group belonging to an owner. The variable is specified as @@ExternalAppId@@.');
+INSERT INTO txt VALUES ('H5641', 'German',  'Definieren Sie eine Namenskonvention, um die LDAP-Gruppe (nicht der volle DN) zu identifizieren, die zu einem Eigentümer gehört. Mindestens eine der Variablen @@AppId@@ oder @@ExternalAppId@@ muss enthalten sein. Optional können Sie auch @@AppPrefix@@ verwenden.');
+INSERT INTO txt VALUES ('H5641', 'English', 'Define naming convention in order to identify the LDAP group (not the full DN) belonging to an owner. At least one of the variables @@AppId@@ or @@ExternalAppId@@ must be included. Optionally you may also use @@AppPrefix@@.');
 INSERT INTO txt VALUES ('H5642', 'German',  'Sollen die LDAP-Gruppen aktiv von FWO gepflegt werden (anlegen/&auml;ndern von Gruppenmitgliedern)? Ein Schreibzugriff auf den jeweiligen LDAP-Server ist notwendig.');
 INSERT INTO txt VALUES ('H5642', 'English', 'Shall FWO manage LDAP groups for owners? Write access to the respective LDAP is needed if you choose this option.');
 INSERT INTO txt VALUES ('H5643', 'German',  'DNS-Suche: Wenn gesetzt, werden App-Server-Namen aus dem DNS erg&auml;nzt und sind nicht manuell editierbar. Falls kein Name aufgel&ouml;st werden kann, wird er aus Pr&auml;fix und IP-Adresse konstruiert.');

--- a/roles/lib/files/FWO.Basics/GlobalConstants.cs
+++ b/roles/lib/files/FWO.Basics/GlobalConstants.cs
@@ -33,8 +33,11 @@ namespace FWO.Basics
         public const string kImportAreaSubnetData = "importAreaSubnetData";
         public const string kManual = "manual";
         public const string kCSV_ = "CSV_";
+        public const char kAppIdSeparator = '-';
         public const string kModellerGroup = "ModellerGroup_";
-        public const string kAppIdPlaceholder = "@@ExternalAppId@@";
+        public const string kFullAppIdPlaceholder = "@@ExternalAppId@@";
+        public const string kAppIdPlaceholder = "@@AppId@@";
+        public const string kAppPrefixPlaceholder = "@@AppPrefix@@";
         public const string kLdapGroupPattern = kModellerGroup + kAppIdPlaceholder;
         public const string kImportChangeNotify = "importChangeNotify";
 		public const string kExternalRequest = "externalRequest";

--- a/roles/lib/files/FWO.Basics/GlobalConstants.cs
+++ b/roles/lib/files/FWO.Basics/GlobalConstants.cs
@@ -33,7 +33,7 @@ namespace FWO.Basics
         public const string kImportAreaSubnetData = "importAreaSubnetData";
         public const string kManual = "manual";
         public const string kCSV_ = "CSV_";
-        public const char kAppIdSeparator = '-';
+        public const char kAppIdSeparator = '-'; // hard-coded could be moved to settings
         public const string kModellerGroup = "ModellerGroup_";
         public const string kFullAppIdPlaceholder = "@@ExternalAppId@@";
         public const string kAppIdPlaceholder = "@@AppId@@";

--- a/roles/middleware/files/FWO.Middleware.Server/AppDataImport.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/AppDataImport.cs
@@ -10,7 +10,6 @@ using FWO.Services;
 using Novell.Directory.Ldap;
 using System.Data;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 
 namespace FWO.Middleware.Server
 {


### PR DESCRIPTION
closes #3114
These enhanced settings allow for more flexible definition of ldap owner group naming conventions