### PR TITLE
PR for bugfix on develop - fix sorting app servers results in duplicates

### DIFF
--- a/roles/lib/files/FWO.Data/Modelling/ModellingAppServer.cs
+++ b/roles/lib/files/FWO.Data/Modelling/ModellingAppServer.cs
@@ -107,5 +107,16 @@ namespace FWO.Data.Modelling
         {
             return Array.ConvertAll(wrappedList.ToArray(), wrapper => wrapper.Content);
         }
+
+        /// <summary>
+        /// Converts an array of ModellingAppServer objects to a list of ModellingAppServerWrapper objects
+        /// </summary>
+        /// <param name="appServers"></param>
+        /// <returns></returns>
+        public static List<ModellingAppServerWrapper> Wrap(ModellingAppServer[] appServers)
+        {
+            ModellingAppServerWrapper[] wrappedArray = Array.ConvertAll(appServers, appServer => new ModellingAppServerWrapper(){Content = appServer});
+            return wrappedArray.ToList();
+        }
     }
 }

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/EditAppRole.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/EditAppRole.razor
@@ -1,5 +1,7 @@
+@using FWO.Basics.Comparer
 @using FWO.Services.EventMediator.Events
 @using FWO.Services.EventMediator.Interfaces
+@using FWO.Ui.Data
 @using FWO.Ui.Display
 
 @inject ApiConnection apiConnection
@@ -93,7 +95,7 @@
                             }
                             else
                             {
-                                <OrderByDropdown CssClass="bg-secondary" @ref="orderByDropdown" TCollectionItem="ModellingAppServer" Collection="ModellingAppServerWrapper.Resolve(AppRoleHandler.ActAppRole.AppServers).Concat(AppRoleHandler.AppServerToAdd).ToList()" CollectionReordered="OnCollectionReordered" ElementProperties="orderByDropdownProperties" />
+                                <OrderByDropdown CssClass="bg-secondary" @ref="orderByDropdown" TCollectionItem="ModellingAppServer" CollectionReordered="OnCollectionReordered" ElementProperties="orderByDropdownProperties" CustomSort="true"/>
                                 <div class="dropzone-scrollable dropzone bg-secondary"
                                 ondragover="event.preventDefault();"
                                 ondragstart="event.dataTransfer.setData('', event.target.id);"
@@ -321,13 +323,39 @@
     }
 
     /// <summary>
-    /// Updates the app server's visual elements after reordering the collection.
+    /// Implements a custom way to reorder the relevant collections.
     /// </summary>
     private void OnCollectionReordered(List<ModellingAppServer> orderedCollection)
     {
-        if (AppRoleHandler != null && orderedCollection != null)
+        if (AppRoleHandler != null && orderByDropdown != null)
         {
-            AppRoleHandler.AppServerToAdd = orderedCollection;
+            ModellingAppServer[]? resolved = ModellingAppServerWrapper.Resolve(AppRoleHandler.ActAppRole.AppServers);
+            ModellingAppServer[]? ordered;
+            List<ModellingAppServer> appServersToAdd = AppRoleHandler.AppServerToAdd; 
+
+            if(orderByDropdown.SelectedProperty.Equals("Ip"))
+            {
+                
+                ordered = resolved.OrderBy(OrderByDropdown<ModellingAppServer>.GetIPAddressRange, new IPAddressRangeComparer()).ToArray<ModellingAppServer>();
+                appServersToAdd = appServersToAdd.OrderBy(OrderByDropdown<ModellingAppServer>.GetIPAddressRange, new IPAddressRangeComparer()).ToList<ModellingAppServer>();
+
+            }
+            else
+            {
+                Func<ModellingAppServer, object> keySelector = orderByDropdown.GetGenericOrderByExpression<ModellingAppServer>(orderByDropdown.SelectedProperty);
+                ordered = resolved.OrderBy(keySelector).ToArray(); 
+                appServersToAdd = appServersToAdd.OrderBy(keySelector).ToList();
+            }
+
+            if (orderByDropdown.SelectedOrderMode == OrderMode.Desc)
+            {
+                Array.Reverse(ordered);   
+                appServersToAdd.Reverse();
+            }
+
+            List<ModellingAppServerWrapper> wrapped = ModellingAppServerWrapper.Wrap(ordered);
+            AppRoleHandler.ActAppRole.AppServers = wrapped; 
+            AppRoleHandler.AppServerToAdd = appServersToAdd;
         }
 
         InvokeAsync(StateHasChanged);

--- a/roles/ui/files/FWO.UI/Shared/OrderByDropdown.razor
+++ b/roles/ui/files/FWO.UI/Shared/OrderByDropdown.razor
@@ -40,13 +40,18 @@
     /// <summary>
     /// Collection of items, that the user can order by the selected property and order mode.
     /// </summary>
-    [Parameter, EditorRequired]
+    [Parameter]
     public List<TCollectionItem>? Collection { get; set; }
     /// <summary>
     /// Callback to communicate that the reordering process has been completed.
     /// </summary>
     [Parameter, EditorRequired]
     public EventCallback<List<TCollectionItem>> CollectionReordered { get; set; }
+    /// <summary>
+    /// Bool if a custom sorting will be implemented.
+    /// </summary>
+    [Parameter, EditorRequired]
+    public bool CustomSort { get; set; }   
 
     [Parameter]
     public string? CssClass { get; set; } = "";
@@ -67,7 +72,7 @@
             if(!selectedProperty.Equals(value))
             {
                 selectedProperty = value;
-                ReorderCollection();
+                ReorderCollection(CustomSort);
             }
         }
     }
@@ -87,7 +92,7 @@
             if(!selectedOrderMode.Equals(value))
             {
                 selectedOrderMode = value;
-                ReorderCollection();
+                ReorderCollection(CustomSort);
             }
         }
     }
@@ -119,7 +124,7 @@
                 CssClass = "";
             }
 
-            EventMediator.Subscribe<CollectionChangedEvent>(nameof(Pages.NetworkModelling.EditAppRole), _ => ReorderCollection());
+            EventMediator.Subscribe<CollectionChangedEvent>(nameof(Pages.NetworkModelling.EditAppRole), _ => ReorderCollection(CustomSort));
 
             initialized = true;
         }
@@ -128,8 +133,16 @@
     /// <summary>
     /// Reordering the collection by the selected property and in the selected mode.
     /// </summary>
-    private void ReorderCollection()
+    private void ReorderCollection(bool customSort)
     {
+        // Skip default way if custom sort, because the sorting will be done in the method that subscribed to the event callback.
+
+        if(customSort)
+        {
+            CollectionReordered.InvokeAsync(Collection);
+            return;
+        }
+
         if(Collection != null && !string.IsNullOrEmpty(SelectedProperty))
         {
             if(SelectedProperty.Equals("Ip") && typeof(TCollectionItem) == typeof(ModellingAppServer))
@@ -163,7 +176,7 @@
     /// <summary>
     /// Creates an IPAddressRange Object.
     /// </summary>
-    private IPAddressRange GetIPAddressRange(TCollectionItem item)
+    public static IPAddressRange GetIPAddressRange(TCollectionItem item)
     {
         if (item is ModellingAppServer server)
         {
@@ -181,7 +194,7 @@
     /// <summary>
     /// Creates lamba function that works as a key selector for OrderBy.
     /// </summary>
-    private Func<T, object> GetGenericOrderByExpression<T>(string propertyName)
+    public Func<T, object> GetGenericOrderByExpression<T>(string propertyName)
     {
         ParameterExpression param = Expression.Parameter(typeof(T), "x");
 


### PR DESCRIPTION
Implemented custom sorting.

Works, with one flaw:

Case : Edit an app role that has already saved servers. Add more servers, but dont save.

Behaviour: the already saved servers and the unsaved ones are two different lists. If you sort them now each list will get sorted on its own. Because they look alike it appears as if the order would be wrong.

We could either give them different colors, so that it is clear that these are different elements (saved vs. unsaved), or we have to work on the EditList component and change the logic that renders the elements. But EditList is a component that is used in many places, so that should be done with enough time to test if it has any unwanted side effects somewhere else.

Closing #3179