### PR TITLE
Issue 2761   rule order issue with moved rules b

### DIFF
--- a/roles/importer/files/importer/fwo_base.py
+++ b/roles/importer/files/importer/fwo_base.py
@@ -299,3 +299,110 @@ def validate_ip_address(address):
     except ValueError:
         return False
         # print("IP address {} is not valid".format(address)) 
+
+
+def lcs_dp(seq1, seq2):
+    """
+    Compute the length and dynamic programming (DP) table for the longest common subsequence (LCS)
+    between seq1 and seq2. Returns (dp, length) where dp is a 2D table and
+    length = dp[len(seq1)][len(seq2)].
+    """
+    m, n = len(seq1), len(seq2)
+    dp = [[0]*(n+1) for _ in range(m+1)]
+   
+    for i in range(m):
+        for j in range(n):
+            if seq1[i] == seq2[j]:
+                dp[i+1][j+1] = dp[i][j] + 1
+            else:
+                dp[i+1][j+1] = max(dp[i+1][j], dp[i][j+1])
+    return dp, dp[m][n]
+
+
+def backtrack_lcs(seq1, seq2, dp):
+    """
+    Backtracks the dynamic programming (DP) table to recover one longest common subsequence (LCS) (as a list of (i, j) index pairs).
+    These index pairs indicate positions in seq1 and seq2 that match in the LCS.
+    """
+    lcs_indices = []
+    i, j = len(seq1), len(seq2)
+    while i > 0 and j > 0:
+        if seq1[i-1] == seq2[j-1]:
+            lcs_indices.append((i-1, j-1))
+            i -= 1
+            j -= 1
+        elif dp[i-1][j] >= dp[i][j-1]:
+            i -= 1
+        else:
+            j -= 1
+    lcs_indices.reverse()
+    return lcs_indices
+
+
+def compute_min_moves(source, target):
+    """
+    Computes the minimal number of operations required to transform the source list into the target list,
+    where allowed operations are:
+       - pop-and-reinsert a common element (to reposition it)
+       - delete (an element in source not present in target)
+       - insert (an element in target not present in source)
+
+    Returns a dictionary with all gathered data (total_moves, operations, deletions, insertions and moves) where operations is a list of suggested human readable operations.
+    """
+    # Build sets (assume uniqueness for membership checks)
+    target_set = set(target)
+    source_set = set(source)
+   
+    # Identify the common elements:
+    S_common = [elem for elem in source if elem in target_set]
+    T_common = [elem for elem in target if elem in source_set]
+   
+    # Calculate deletions and insertions:
+    deletions = [ (i, elem) for i, elem in enumerate(source) if elem not in target_set ]
+    insertions = [ (j, elem) for j, elem in enumerate(target) if elem not in source_set ]
+   
+    # Compute the longest common subsequence (LCS) between S_common and T_common – these are common elements already in correct relative order.
+    dp, lcs_length = lcs_dp(S_common, T_common)
+    lcs_indices = backtrack_lcs(S_common, T_common, dp)
+   
+    # To decide which common elements must be repositioned, mark the indices in S_common which are part of the LCS.
+    in_place = [False] * len(S_common)
+    for i, _ in lcs_indices:
+        in_place[i] = True
+    # Every common element in S_common not in the LCS will need a pop-and-reinsert.
+    reposition_moves = []
+    # To better explain (rough indexing): We traverse the source list and when we get to a common element,
+    # we check if it is “in place”. Note that because S_common is a filtered version of source, we need
+    # to convert back to indices in the original source. We do this by iterating over source and whenever
+    # we encounter an element in target_set, we pop the next value from S_common.
+    s_common_iter = 0
+    for orig_index, elem in enumerate(source):
+        if elem in target_set:
+            # This element is one of the common ones.
+            if not in_place[s_common_iter]:
+                # This element is not in the LCS so it will be repositioned.
+                # We will reinsert it to the position where it should appear in target.
+                reposition_moves.append((orig_index, elem, target.index(elem)))
+            s_common_iter += 1
+
+    total_moves = (len(deletions)
+                   + len(insertions)
+                   + len(reposition_moves))
+
+    # Build a list of human‐readable operations.
+    operations = []
+    for idx, elem in deletions:
+        operations.append(f"Delete element '{elem}' at source index {idx}.")
+    for idx, elem in insertions:
+        operations.append(f"Insert element '{elem}' at target position {idx}.")
+    for idx, elem, target_pos in reposition_moves:
+        operations.append(f"Pop element '{elem}' from source index {idx} and reinsert at target position {target_pos}.")
+   
+    return {
+        "moves": total_moves,
+        "operations": operations,
+        "deletions": deletions,
+        "insertions": insertions,
+        "reposition_moves": reposition_moves
+    }
+

--- a/roles/importer/files/importer/model_controllers/fwconfig_import_ruleorder.py
+++ b/roles/importer/files/importer/model_controllers/fwconfig_import_ruleorder.py
@@ -131,8 +131,12 @@ class RuleOrderService:
                     consecutive_insertions += 1
                 else:
                     next_num_numeric = consecutive_insertions * rule_num_numeric_steps + previous_rule_num_numeric
-            new_rule_num_numeric_step = (next_num_numeric - previous_rule_num_numeric) / consecutive_insertions # divide by zero !!! But if zero occurs here, there data is already corrupted
-            new_rule_num_numeric = previous_rule_num_numeric + new_rule_num_numeric_step
+            new_rule_num_numeric_step = (next_num_numeric - previous_rule_num_numeric)
+            if new_rule_num_numeric_step != 0:
+                new_rule_num_numeric_step /= consecutive_insertions
+                new_rule_num_numeric = previous_rule_num_numeric + new_rule_num_numeric_step
+            else:
+                new_rule_num_numeric = previous_rule_num_numeric
         else:
             new_rule_num_numeric = (previous_rule_num_numeric + next_num_numeric) / 2
 

--- a/roles/importer/files/importer/model_controllers/fwconfig_import_ruleorder.py
+++ b/roles/importer/files/importer/model_controllers/fwconfig_import_ruleorder.py
@@ -1,22 +1,130 @@
 from fwo_const import rule_num_numeric_steps
+from models.fwconfig_normalized import FwConfigNormalized
+from fwo_base import compute_min_moves
 
 class RuleOrderService:
+    """
+        A singleton service that holds data and provides logic to compute rule order values.
+    """
+
     _instance = None
     _current_rule_num_numeric: float
+    _previous_config: FwConfigNormalized
+    _normalized_config: FwConfigNormalized
+
 
     def __new__(cls):
+        """
+            Singleton pattern: Creates instance and sets defaults if constructed first time and sets that object to a protected class variable. 
+            If the constructor is called when there is already an instance returns that instance instead. That way there will only be one instance of this type throudgh the whole runtime.
+        """
+
         if cls._instance is None:
             cls._instance = super(RuleOrderService, cls).__new__(cls)
             cls._instance._current_rule_num_numeric = 0
+            cls._previous_config = None
+            cls._normalized_config = None
+            cls._compute_min_moves_result = None
+            cls._source_rule_uids = []
+            cls._target_rule_uids = []
+            cls._deleted_rule_uids = {}
+            cls._new_rule_uids = {}
+            cls._moved_rule_uids = {}
+            cls._source_rules_flat = []
+            cls._target_rules_flat = []
+            cls._needs_rule_num_numeric_update_rule_uids = []
         return cls._instance
+
 
     @property
     def current_rule_num_numeric(self) -> float:
         return self._current_rule_num_numeric
+    
+    @property
+    def target_rules_flat(self) -> list:
+        return self._target_rules_flat
+    
+    @property
+    def compute_min_moves_result(self):
+        return self._compute_min_moves_result
+    
 
     def get_new_rule_num_numeric(self) -> float:
         self._current_rule_num_numeric += rule_num_numeric_steps
         return self._current_rule_num_numeric
     
+
     def reset_rule_num_numeric(self):
         self._current_rule_num_numeric = 0.0
+
+
+    def initialize(self, previous_config: FwConfigNormalized, normalized_config: FwConfigNormalized):
+        self._previous_config = previous_config
+        self._normalized_config = normalized_config
+
+        self._source_rule_uids = rule_uids = [
+            rule_uid
+            for rulebase in self._previous_config.rulebases
+            for rule_uid in rulebase.Rules.keys()
+        ]
+
+        self._target_rule_uids = rule_uids = [
+            rule_uid
+            for rulebase in self._normalized_config.rulebases
+            for rule_uid in rulebase.Rules.keys()
+        ]
+
+        self._compute_min_moves_result = compute_min_moves(self._source_rule_uids, self._target_rule_uids)
+
+        for rulebase in self._previous_config.rulebases:
+            self._deleted_rule_uids[rulebase.uid] = [
+                deletion_rule_uid
+                for _, deletion_rule_uid in self._compute_min_moves_result["deletions"]
+                if any(deletion_rule_uid == rule_uid for rule_uid in rulebase.Rules.keys())
+            ]
+            self._moved_rule_uids[rulebase.uid] = [
+                move_rule_uid
+                for _, move_rule_uid, target_index in self._compute_min_moves_result["reposition_moves"]
+                if any(move_rule_uid == rule_uid for rule_uid in rulebase.Rules.keys())
+            ]
+            self._needs_rule_num_numeric_update_rule_uids.extend(self._moved_rule_uids[rulebase.uid])
+
+            self._source_rules_flat.extend(rulebase.Rules.values())
+            
+        for rulebase in self._normalized_config.rulebases:
+            self._new_rule_uids[rulebase.uid] = [
+                insertion_rule_uid
+                for target_index, insertion_rule_uid in self._compute_min_moves_result["insertions"]
+                if any(insertion_rule_uid == rule_uid for rule_uid in rulebase.Rules.keys())
+            ]
+
+            self._target_rules_flat.extend(rulebase.Rules.values())
+            self._needs_rule_num_numeric_update_rule_uids.extend(self._new_rule_uids[rulebase.uid])
+        
+        for rule_uid in self._needs_rule_num_numeric_update_rule_uids:
+            self.update_rule_num_numeric(rule_uid)
+
+        return self._deleted_rule_uids, self._new_rule_uids, self._moved_rule_uids
+
+
+    def update_rule_num_numeric(self, rule_uid):
+        index, changed_rule = next(
+            (i, rule) for i, rule in enumerate(self._target_rules_flat) if rule.rule_uid == rule_uid
+        )
+        previous_rule_num_numeric = 0.0
+        new_rule_num_numeric = 0.0
+        next_num_numeric  = 0.0
+
+        if index > 0:
+            previous_rule_num_numeric = self._target_rules_flat[index - 1].rule_num_numeric
+
+        if index < len(self._target_rule_uids) - 1:
+            next_num_numeric = self._target_rules_flat[index + 1].rule_num_numeric
+
+        if next_num_numeric == 0:
+            new_rule_num_numeric = self._target_rules_flat[index].rule_num_numeric
+        else:
+            new_rule_num_numeric = (previous_rule_num_numeric + next_num_numeric) / 2
+
+        changed_rule.rule_num_numeric = new_rule_num_numeric
+

--- a/roles/importer/files/importer/model_controllers/fwconfig_import_ruleorder.py
+++ b/roles/importer/files/importer/model_controllers/fwconfig_import_ruleorder.py
@@ -121,8 +121,18 @@ class RuleOrderService:
         if index < len(self._target_rule_uids) - 1:
             next_num_numeric = self._target_rules_flat[index + 1].rule_num_numeric
 
-        if next_num_numeric == 0:
+        if index == len(self._target_rule_uids) - 1:
             new_rule_num_numeric = self._target_rules_flat[index].rule_num_numeric
+        elif next_num_numeric == 0:
+            consecutive_insertions = 1
+            while next_num_numeric == 0:          
+                if index + consecutive_insertions < len(self._target_rule_uids) - 1:
+                    next_num_numeric = next_num_numeric = self._target_rules_flat[index + consecutive_insertions].rule_num_numeric
+                    consecutive_insertions += 1
+                else:
+                    next_num_numeric = consecutive_insertions * rule_num_numeric_steps + previous_rule_num_numeric
+            new_rule_num_numeric_step = (next_num_numeric - previous_rule_num_numeric) / consecutive_insertions # divide by zero !!! But if zero occurs here, there data is already corrupted
+            new_rule_num_numeric = previous_rule_num_numeric + new_rule_num_numeric_step
         else:
             new_rule_num_numeric = (previous_rule_num_numeric + next_num_numeric) / 2
 

--- a/roles/importer/files/test/mocking/mock_config.py
+++ b/roles/importer/files/test/mocking/mock_config.py
@@ -1,17 +1,115 @@
 import json
 import uuid
-from typing import Union
-from uid_manager import UidManager
-from mock_rulebase import MockRulebase
+from typing import Union, Dict
 
-""" 
+if __name__ == '__main__': # for usage as executable script
+    from uid_manager import UidManager
+    from mock_rulebase import MockRulebase
+else: # for usage in unit tests
+    from . uid_manager import UidManager
+    from . mock_rulebase import MockRulebase
+    from importer.models.fwconfig_normalized import FwConfigNormalized
+    from importer.models.rulebase import Rulebase
+    from importer.models.rule import Rule
+    from pydantic import PrivateAttr
+    from importer.fwo_const import rule_num_numeric_steps
 
-DISCLAIMER
 
-This script does create a config similar to the normalized config we get when we import and transform a config from sting. However, it is not very sophisticated at this point.
-It simply creates an empty config with the bare minimum to import n rules. To make it work you have to deactivate the consistency checks and create only one rulebase. 
+class MockFwConfigNormalized(FwConfigNormalized):
+    """
+    A mock subclass of FwConfigNormalized for testing purposes.
 
-"""
+    This class creates a fake firewall configuration including rulebases
+    and rules, using a UID manager to generate unique identifiers.
+    """
+
+    _uid_manager: UidManager = PrivateAttr()
+
+    def __init__(self, **kwargs):
+        """
+        Initializes the mock configuration with default action and an empty gateway list.
+        """
+        super().__init__(action="INSERT", gateways=[], **kwargs)
+        self._uid_manager = UidManager()
+
+    @property
+    def uid_manager(self) -> UidManager:
+        """
+        Returns the internal UID manager.
+        """
+        return self._uid_manager
+
+    def initialize_config(self, mock_config: Dict):
+        """
+        Initializes the mock configuration with rulebases and rules.
+
+        Args:
+            mock_config (dict): A dictionary with configuration values. Expected keys:
+                - "rule_config": List of integers, each representing the number of rules per rulebase.
+                - "initialize_rule_num_numeric": Optional boolean, if True assigns incremental numeric rule numbers.
+        """
+        mock_mgm_uid = self.uid_manager.create_uid()
+        created_rule_counter = 1
+
+        for number_of_rules in mock_config["rule_config"]:
+            # Create a new rulebase
+            new_rulebase_uid = self.uid_manager.create_uid()
+            new_rulebase = Rulebase(
+                uid=new_rulebase_uid,
+                name=f"Rulebase {new_rulebase_uid}",
+                mgm_uid=mock_mgm_uid
+            )
+            self.rulebases.append(new_rulebase)
+
+            for i in range(number_of_rules):
+                # Add a new rule to the rulebase
+                new_rule = self.add_rule_to_rulebase(new_rulebase_uid)
+
+                if mock_config.get("initialize_rule_num_numeric"):
+                    new_rule.rule_num_numeric = created_rule_counter * rule_num_numeric_steps
+                    created_rule_counter += 1
+
+    def add_rule_to_rulebase(self, rulebase_uid: str) -> Rule:
+        """
+        Adds a new rule to the rulebase identified by the given UID.
+
+        Args:
+            rulebase_uid (str): The UID of the rulebase to which the rule should be added.
+
+        Returns:
+            Rule: The newly created rule.
+        """
+        rulebase = next(rb for rb in self.rulebases if rb.uid == rulebase_uid)
+
+        new_rule = Rule(
+            action_id=0,
+            mgm_id=0,
+            rule_action="accept",
+            rule_create=0,
+            rule_disabled=False,
+            rule_dst="",
+            rule_dst_neg=False,
+            rule_dst_refs="",
+            rule_last_seen=0,
+            rule_num=0,
+            rule_num_numeric=0,
+            rule_src="",
+            rule_src_neg=False,
+            rule_src_refs="",
+            rule_svc="",
+            rule_svc_neg=False,
+            rule_svc_refs="",
+            rule_time="",
+            track_id=0,
+            rule_track="none",
+            rule_uid=self.uid_manager.create_uid(),
+            rule_installon=""
+        )
+        rulebase.Rules[new_rule.rule_uid] = new_rule
+
+        return new_rule
+
+        
 
 class ConfigMocker:
     config_type = "normalized"
@@ -62,6 +160,7 @@ class ConfigMocker:
 
     checkpoint_objects_config = {}
 
+
     def create_checkpoint_config(self):
         self.config["object_tables"] = []
         for object_type in self.checkpoint_object_types:
@@ -71,6 +170,7 @@ class ConfigMocker:
                     "object_chunks": [{"objects":[]}]
                 }
             )
+
 
     def create_checkpoint_config_object(self, uid, name, type, domain_uid = "", domain_name = "", domain_type = "", icon = "", color = ""):
         return {
@@ -86,6 +186,7 @@ class ConfigMocker:
             "color": color
         }
 
+
     def create_checkpoint_config_objects(self):
         for objects_config in self.checkpoint_objects_config.keys():
             object_tables = self.config["object_tables"]
@@ -97,6 +198,7 @@ class ConfigMocker:
                 self.checkpoint_config_objects.append(new_object)
                 table["object_chunks"][0]["objects"].append(new_object) # TODO: Support more than one chunk
                 counter += 1
+
 
     def create_config(self, as_dict: bool = False, file_path: str = "", number_config: list = []) -> Union[dict, None]: 
         if number_config == []:
@@ -126,6 +228,7 @@ class ConfigMocker:
             print(f"Config file saved to {file_path}")
 
             return None
+
 
     def build_normalized_config(self):
         self.config = {
@@ -158,6 +261,7 @@ class ConfigMocker:
                 }
             ]
         }
+
 
     def generate_rules(self, rules_number=0):
         rules = {}
@@ -199,6 +303,7 @@ class ConfigMocker:
 
         return rules
 
+
     def generate_rulebase(self, rules_number=0):
         rulebase = MockRulebase()
         rulebase.uid = self.uid_manager.create_uid()
@@ -207,12 +312,23 @@ class ConfigMocker:
         rulebase.Rules = self.generate_rules(rules_number) or {}
         return rulebase
 
+
     def generate_rulebases(self, rulebase_config):
         for number_of_rules in rulebase_config:
             new_rulebase = self.generate_rulebase(number_of_rules)
             self.rulebases.append(new_rulebase)
 
+
 if __name__ == '__main__':
+    """ 
+
+    DISCLAIMER
+
+    This script does create a config similar to the normalized config we get when we import and transform a config from sting. However, it is not very sophisticated at this point.
+    It simply creates an empty config with the bare minimum to import n rules. To make it work you have to deactivate the consistency checks and create only one rulebase. 
+
+    """
+
     config_mocker = ConfigMocker()
     config_mocker.create_config()
 

--- a/roles/importer/files/test/mocking/mock_fwconfig_import_rule.py
+++ b/roles/importer/files/test/mocking/mock_fwconfig_import_rule.py
@@ -1,0 +1,211 @@
+from typing import List, Dict, Tuple, Any
+
+from importer.model_controllers.fwconfig_import_rule import FwConfigImportRule
+from importer.models.rulebase import Rulebase
+from test.mocking.mock_import_state import MockImportStateController
+
+
+class MockFwConfigImportRule(FwConfigImportRule):
+    """
+        A mock subclass of FwConfigImportRule for testing.
+
+        This class allows selective stubbing of internal methods to control behavior during tests.
+    """
+
+    def __init__(self):
+        """
+            Initializes the mock import rule controller with stubs enabled by default. 
+        """
+
+        self._import_details = MockImportStateController()
+        self._stub_markRulesRemoved = True
+        self._stub_getRules = True
+        self._stub_addNewRuleMetadata = True
+        self._stub_addNewRules = True
+        self._stub_moveRules = True
+
+
+    @property
+    def ImportDetails(self) -> MockImportStateController:
+        """
+            Returns the mock import state controller.
+        """
+
+        return self._import_details
+
+    @property
+    def stub_markRulesRemoved(self) -> bool:
+        """
+            Indicates whether to stub markRulesRemoved.
+        """
+
+        return self._stub_markRulesRemoved
+
+    @stub_markRulesRemoved.setter
+    def stub_markRulesRemoved(self, value: bool):
+        self._stub_markRulesRemoved = value
+
+    @property
+    def stub_getRules(self) -> bool:
+        """
+            Indicates whether to stub getRules.
+        """
+
+        return self._stub_getRules
+
+    @stub_getRules.setter
+    def stub_getRules(self, value: bool):
+        self._stub_getRules = value
+
+    @property
+    def stub_addNewRuleMetadata(self) -> bool:
+        """
+            Indicates whether to stub addNewRuleMetadata.
+        """
+
+        return self._stub_addNewRuleMetadata
+
+    @stub_addNewRuleMetadata.setter
+    def stub_addNewRuleMetadata(self, value: bool):
+        self._stub_addNewRuleMetadata = value
+
+    @property
+    def stub_addNewRules(self) -> bool:
+        """
+            Indicates whether to stub addNewRules.
+        """
+
+        return self._stub_addNewRules
+
+    @stub_addNewRules.setter
+    def stub_addNewRules(self, value: bool):
+        self._stub_addNewRules = value
+
+    @property
+    def stub_moveRules(self) -> bool:
+        """
+            Indicates whether to stub moveRules.
+        """
+
+        return self._stub_moveRules
+
+    @stub_moveRules.setter
+    def stub_moveRules(self, value: bool):
+        self._stub_moveRules = value
+
+
+    def markRulesRemoved(self, removedRuleUids: Dict[str, List[str]]) -> Tuple[int, int, Dict[str, List[str]]]:
+        """
+            Simulates marking rules as removed. Can delegate to the base class if not stubbed.
+
+            Args:
+                removedRuleUids (dict): A dict mapping rulebase identifiers to lists of rule UIDs.
+
+            Returns:
+                tuple: (errors, changes, collectedRemovedRuleIds)
+        """
+        
+        errors = 0
+        changes = 0
+        for rulebase in removedRuleUids.keys():
+            changes += len(removedRuleUids[rulebase])
+        collectedRemovedRuleIds = removedRuleUids
+
+        if not self.stub_markRulesRemoved:
+            errors, changes, collectedRemovedRuleIds = super().markRulesRemoved(removedRuleUids)
+
+        return errors, changes, collectedRemovedRuleIds
+
+
+    def getRules(self, ruleUids: List[str]) -> List[Rulebase]:
+        """
+            Simulates returning rules by UID. Delegates to base if not stubbed.
+
+            Args:
+                ruleUids (list): List of rule UIDs to fetch.
+
+            Returns:
+                list: List of Rulebase instances containing the rules.
+        """
+
+        rulebases: List[Rulebase] = []
+
+        if not self.stub_getRules:
+            rulebases = super().getRules(ruleUids)
+
+        return rulebases
+
+
+    def addNewRuleMetadata(self, newRules: List[Rulebase]) -> Tuple[int, int, List[int]]:
+        """
+            Simulates adding metadata for new rules. Delegates to base if not stubbed.
+
+            Args:
+                newRules (list): List of Rulebase objects with new rules.
+
+            Returns:
+                tuple: (errors, changes, newRuleIds)
+        """
+
+        errors = 0
+        changes = 0
+        newRuleIds: List[int] = []
+
+        if not self.stub_addNewRuleMetadata:
+            errors, changes, newRuleIds = super().addNewRuleMetadata(newRules)
+
+        return errors, changes, newRuleIds
+
+
+    def addNewRules(self, newRules: List[Rulebase]) -> Tuple[int, int, List[int]]:
+        """
+            Simulates adding new rules to db and returning their ids. Delegates to base if not stubbed.
+
+            Args:
+                newRules (list): List of Rulebase objects with new rules.
+
+            Returns:
+                tuple: (errors, changes, newRuleIds)
+        """
+
+        errors = 0
+        changes = 0
+        newRuleIds: List[int] = []
+
+        for rulebase in newRules:
+            for rule in rulebase.Rules:
+                changes += 1
+                newRuleIds.append(changes)
+
+        if not self.stub_addNewRuleMetadata:
+            errors, changes, newRuleIds = super().addNewRules(newRules)
+
+        return errors, changes, newRuleIds
+
+
+    def moveRules(self, movedRuleUids: Dict[str, List[str]], target_rule_uids: List[str]) -> Tuple[int, int, List[int]]:
+        """
+            Simulates moving rules to a new location.  Delegates to base if not stubbed.
+
+            Args:
+                movedRuleUids (dict): Mapping from rulebase to list of rule UIDs to move.
+                target_rule_uids (list): List of target rule UIDs to move to.
+
+            Returns:
+                tuple: (errors, changes, movedRuleIds)
+        """
+
+        errors = 0
+        changes = 0
+        movedRuleIds: List[int] = []
+
+        for rulebase in movedRuleUids.keys():
+            for rule in movedRuleUids[rulebase]:
+                changes += 1
+                movedRuleIds.append(changes)
+
+        if not self.stub_moveRules:
+            errors, changes, movedRuleIds = super().moveRules(movedRuleUids, target_rule_uids)
+
+        return errors, changes, movedRuleIds
+

--- a/roles/importer/files/test/mocking/mock_import_state.py
+++ b/roles/importer/files/test/mocking/mock_import_state.py
@@ -1,6 +1,17 @@
-class MockImportState:
-    previous_calls = []
+from importer.model_controllers.import_state_controller import ImportStateController
+from importer.model_controllers.import_statistics_controller import ImportStatisticsController
 
-    def call(self, query, queryVariables):
-        full_query = {"query": query, "variables": queryVariables}
-        self.previous_calls.append(full_query)
+
+class MockImportStateController(ImportStateController):
+    """
+        Mock class for ImportState.
+    """
+
+    def __init__(self):
+        """
+            Initializes without calling base init. This avoids the necessity to provide JWT and management details.
+        """
+
+        self.DebugLevel = 0
+        self.Stats = ImportStatisticsController()
+

--- a/roles/importer/files/test/test_ruleorder.py
+++ b/roles/importer/files/test/test_ruleorder.py
@@ -40,28 +40,58 @@ class TestRuleOrdering(unittest.TestCase):
         self.assertEqual(compute_min_moves_result["deletions"], expectedResult["deletions"])     
         self.assertEqual(compute_min_moves_result["reposition_moves"], expectedResult["reposition_moves"])      
 
-    def test_compute_min_moves_on_delete(self):
+    def test_compute_rulebase_diffs_delete(self):
         # arrange
-        previousConfigRuleUids = self.mock_previous_config_rule_uids()
-        currentConfigRuleUids = copy.deepcopy(previousConfigRuleUids)
-        del currentConfigRuleUids[4]
-        expectedResult = { 
-            "moves": 1, 
-            "operations": ["Delete element 'e40d5b53-67e0-4ba7-923e-226909fc3c82' at source index 4."],
-            "insertions": [],
-            "deletions": [(4, 'e40d5b53-67e0-4ba7-923e-226909fc3c82')],
-            "reposition_moves": []
-        }
+        previous_config = MockFwConfigNormalized()
+        previous_config.initialize_config(
+            {
+                "rule_config": [10,10,10]
+            }
+        )
+
+        fwconfig_import_rule = MockFwConfigImportRule()
+        fwconfig_import_rule.NormalizedConfig = copy.deepcopy(previous_config)
+        deleted_rule = list(fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules.keys())[0]
+        del fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules[deleted_rule]
 
         # act
-        compute_min_moves_result = compute_min_moves(previousConfigRuleUids, currentConfigRuleUids)
+        deletions, _, _ = fwconfig_import_rule.computeRulebaseDiffs(previous_config)
+        flatted_deletions = [
+            rule_uid
+            for rules_uids in deletions.values()
+            for rule_uid in rules_uids
+        ]
+
 
         # assert
-        self.assertEqual(compute_min_moves_result["moves"], expectedResult["moves"])
-        self.assertEqual(compute_min_moves_result["operations"], expectedResult["operations"])
-        self.assertEqual(compute_min_moves_result["insertions"], expectedResult["insertions"])
-        self.assertEqual(compute_min_moves_result["deletions"], expectedResult["deletions"])     
-        self.assertEqual(compute_min_moves_result["reposition_moves"], expectedResult["reposition_moves"])      
+        self.assertEqual(len(flatted_deletions), 1)
+        self.assertEqual(flatted_deletions[0], deleted_rule)
+
+
+    # def test_update_rulebase_diffs_recognize_delete(self):
+    #     # arrange
+    #     previous_config = MockFwConfigNormalized()
+    #     previous_config.initialize_config(
+    #         {
+    #             "rule_config": [10,10,10]
+    #         }
+    #     )
+
+    #     fwconfig_import_rule = MockFwConfigImportRule()
+    #     fwconfig_import_rule.NormalizedConfig = copy.deepcopy(previous_config)
+    #     deleted_rule = list(fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules.keys())[0]
+    #     del fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules[deleted_rule]
+
+
+    #     # act
+    #     fwconfig_import_rule.updateRulebaseDiffs(previous_config)
+
+    #     # assert
+    #     self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleAddCount, 0)
+    #     self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleDeleteCount, 1)
+    #     self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleChangeCount, 0)
+    #     self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleMoveCount, 0)
+
 
 
 

--- a/roles/importer/files/test/test_ruleorder.py
+++ b/roles/importer/files/test/test_ruleorder.py
@@ -2,50 +2,319 @@ import asyncio
 import unittest
 import sys
 import os
+import copy
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../importer'))
 
-from importer.model_controllers.fwconfig_import_rule import resetOrderNumbersAsync
-from test.mocking.mock_config import ConfigMocker
-from test.mocking.mock_import_state import MockImportState
+from importer.models.rule import Rule
+from test.mocking.mock_fwconfig_import_rule import MockFwConfigImportRule
+from importer.fwo_base import compute_min_moves
+from importer.models.fwconfig_normalized import FwConfigNormalized
+from test.mocking.mock_config import ConfigMocker, MockFwConfigNormalized
 
 class TestRuleOrdering(unittest.TestCase):
     config_mocker = ConfigMocker()
 
-    async def test_rule_ordering_new_import_creates_correct_mutation(self):
+
+    def test_compute_min_moves_on_insert(self):
         # arrange
-        number_config = [10] # one rulebase with ten rules
-        config, rules_uids = self.config_mocker.create_config(True, number_config=number_config)
-        rules_uids_with_order_number = {}
-        count = 1
-        for rule_uid in rules_uids:
-            rules_uids_with_order_number[rule_uid] = count
-            count += 1
-        mock_import_state = MockImportState() # instead of a real request this mock gathers the arguments that fwo_api_oo.call would get in a real scenario
-        batch_size = 2
-        expected_query = '\n        mutation UpdateRuleOrder($updates: [rule_updates!]!) {\n            update_rule_many(updates: $updates) {\n                affected_rows\n            }\n        }\n    '
+        previousConfigRuleUids = self.mock_previous_config_rule_uids()
+        currentConfigRuleUids = copy.deepcopy(previousConfigRuleUids)
+        new_uid = "500d884f-be27-4db4-9dd8-ec2b87ece474"
+        currentConfigRuleUids.insert(4, new_uid)
+        expectedResult = { 
+            "moves": 1, 
+            "operations": ["Insert element '500d884f-be27-4db4-9dd8-ec2b87ece474' at target position 4."],
+            "insertions": [(4, '500d884f-be27-4db4-9dd8-ec2b87ece474')],
+            "deletions": [],
+            "reposition_moves": []
+        }
 
         # act
-        await resetOrderNumbersAsync(config.rulebases, batch_size, 2, mock_import_state)
+        compute_min_moves_result = compute_min_moves(previousConfigRuleUids, currentConfigRuleUids)
 
         # assert
-        self.assertTrue(len(mock_import_state.previous_calls) == batch_size) # one call per batch should be sent
-        count_asserts = 1
-        for mocked_call in mock_import_state.previous_calls:
-            self.assertTrue(mocked_call["query"]==expected_query) # the query is always the same
-            for update in mocked_call["variables"]["updates"]:
-                # check rule_uid
-                expected_rule_uid = rules_uids[count_asserts -1]
-                actual_rule_uid = update["where"]["rule_uid"]["_eq"]
-                self.assertEqual(expected_rule_uid, actual_rule_uid)
+        self.assertEqual(compute_min_moves_result["moves"], expectedResult["moves"])
+        self.assertEqual(compute_min_moves_result["operations"], expectedResult["operations"])
+        self.assertEqual(compute_min_moves_result["insertions"], expectedResult["insertions"])
+        self.assertEqual(compute_min_moves_result["deletions"], expectedResult["deletions"])     
+        self.assertEqual(compute_min_moves_result["reposition_moves"], expectedResult["reposition_moves"])      
 
-                # check rule_num_numeric
-                expected_rule_num_numeric = rules_uids_with_order_number[actual_rule_uid]
-                actual_rule_num_numeric = update["_set"]["rule_num_numeric"]
-                self.assertEqual(expected_rule_num_numeric, actual_rule_num_numeric)
+    def test_compute_min_moves_on_delete(self):
+        # arrange
+        previousConfigRuleUids = self.mock_previous_config_rule_uids()
+        currentConfigRuleUids = copy.deepcopy(previousConfigRuleUids)
+        del currentConfigRuleUids[4]
+        expectedResult = { 
+            "moves": 1, 
+            "operations": ["Delete element 'e40d5b53-67e0-4ba7-923e-226909fc3c82' at source index 4."],
+            "insertions": [],
+            "deletions": [(4, 'e40d5b53-67e0-4ba7-923e-226909fc3c82')],
+            "reposition_moves": []
+        }
 
-                count_asserts += 1
+        # act
+        compute_min_moves_result = compute_min_moves(previousConfigRuleUids, currentConfigRuleUids)
 
+        # assert
+        self.assertEqual(compute_min_moves_result["moves"], expectedResult["moves"])
+        self.assertEqual(compute_min_moves_result["operations"], expectedResult["operations"])
+        self.assertEqual(compute_min_moves_result["insertions"], expectedResult["insertions"])
+        self.assertEqual(compute_min_moves_result["deletions"], expectedResult["deletions"])     
+        self.assertEqual(compute_min_moves_result["reposition_moves"], expectedResult["reposition_moves"])      
+
+
+
+    def test_compute_min_moves_on_move(self):
+        # arrange
+        previousConfigRuleUids = self.mock_previous_config_rule_uids()
+        currentConfigRuleUids = copy.deepcopy(previousConfigRuleUids)
+        moving_element = currentConfigRuleUids.pop(8)
+        currentConfigRuleUids.insert(4, moving_element)
+        expectedResult = { "moves": 1, "operations": ["Pop element 'a5d42650-43d5-4cab-9bc8-48cbf902fa34' from source index 8 and reinsert at target position 4."]}
+        expectedResult = { 
+            "moves": 1, 
+            "operations": ["Pop element 'a5d42650-43d5-4cab-9bc8-48cbf902fa34' from source index 8 and reinsert at target position 4."],
+            "insertions": [],
+            "deletions": [],
+            "reposition_moves": [(8, 'a5d42650-43d5-4cab-9bc8-48cbf902fa34', 4)]
+        }
+        # act
+        compute_min_moves_result = compute_min_moves(previousConfigRuleUids, currentConfigRuleUids)
+
+        # assert
+        self.assertEqual(compute_min_moves_result["moves"], expectedResult["moves"])
+        self.assertEqual(compute_min_moves_result["operations"], expectedResult["operations"])
+        self.assertEqual(compute_min_moves_result["insertions"], expectedResult["insertions"])
+        self.assertEqual(compute_min_moves_result["deletions"], expectedResult["deletions"])     
+        self.assertEqual(compute_min_moves_result["reposition_moves"], expectedResult["reposition_moves"])      
+
+    def test_compute_min_moves_all_cases(self):
+        # arrange
+        previousConfigRuleUids = self.mock_previous_config_rule_uids()
+        currentConfigRuleUids = copy.deepcopy(previousConfigRuleUids)
+
+        del currentConfigRuleUids[2]
+
+        new_uid = "500d884f-be27-4db4-9dd8-ec2b87ece474"
+        currentConfigRuleUids.insert(3, new_uid)
+
+        moving_element = currentConfigRuleUids.pop(8)
+        currentConfigRuleUids.insert(4, moving_element)
+
+        expectedResult = { 
+            "moves": 3, 
+            "operations": [
+                "Delete element 'f31d21f5-2b5d-47e8-9011-cd16695f5644' at source index 2.", 
+                "Insert element '500d884f-be27-4db4-9dd8-ec2b87ece474' at target position 3.",
+                "Pop element 'a5d42650-43d5-4cab-9bc8-48cbf902fa34' from source index 8 and reinsert at target position 4."
+            ],
+            "insertions": [(3, '500d884f-be27-4db4-9dd8-ec2b87ece474')],
+            "deletions": [(2, 'f31d21f5-2b5d-47e8-9011-cd16695f5644')],
+            "reposition_moves": [(8, 'a5d42650-43d5-4cab-9bc8-48cbf902fa34', 4)]
+        }
+
+
+        # act
+        compute_min_moves_result = compute_min_moves(previousConfigRuleUids, currentConfigRuleUids)
+
+        # assert
+        self.assertEqual(compute_min_moves_result["moves"], expectedResult["moves"])
+        self.assertEqual(compute_min_moves_result["operations"], expectedResult["operations"])
+        self.assertEqual(compute_min_moves_result["insertions"], expectedResult["insertions"])
+        self.assertEqual(compute_min_moves_result["deletions"], expectedResult["deletions"])     
+        self.assertEqual(compute_min_moves_result["reposition_moves"], expectedResult["reposition_moves"])       
+
+    def test_compute_min_moves_complex_case(self):
+        # arrange
+        previousConfigRuleUids = self.mock_previous_config_rule_uids(longer_version=True)
+        currentConfigRuleUids = copy.deepcopy(previousConfigRuleUids)
+
+        del currentConfigRuleUids[3]
+        del currentConfigRuleUids[11]
+        currentConfigRuleUids.insert(5, "ec4d9310-0ebe-4321-a342-015a31863029")
+        currentConfigRuleUids.insert(11, "8dea22c7-ad09-4f2f-8896-f911d5eb12f4")
+        moving_element = currentConfigRuleUids.pop(9)
+        currentConfigRuleUids.insert(7, moving_element)
+        moving_element = currentConfigRuleUids.pop(13)
+        currentConfigRuleUids.insert(1, moving_element)
+
+        expectedResult = {
+            "moves": 6,
+            "operations": [
+                "Delete element 'fb914729-4858-491f-9816-a78ec17a8b83' at source index 3.", 
+                "Delete element '10b2e5d2-5143-402c-940a-716a8242dc38' at source index 12.", 
+                "Insert element 'ec4d9310-0ebe-4321-a342-015a31863029' at target position 6.", 
+                "Insert element '8dea22c7-ad09-4f2f-8896-f911d5eb12f4' at target position 12.", 
+                "Pop element '2c18bbd4-fa8e-475a-9268-f15f1d4dd6f5' from source index 9 and reinsert at target position 8.", 
+                "Pop element '4fd40964-61b4-471c-aa47-b28c6aa56a63' from source index 13 and reinsert at target position 1."
+            ],
+            "insertions": [(6, 'ec4d9310-0ebe-4321-a342-015a31863029'), (12, '8dea22c7-ad09-4f2f-8896-f911d5eb12f4')],
+            "deletions": [(3, 'fb914729-4858-491f-9816-a78ec17a8b83'), (12, '10b2e5d2-5143-402c-940a-716a8242dc38')],
+            "reposition_moves": [(9, '2c18bbd4-fa8e-475a-9268-f15f1d4dd6f5', 8), (13, '4fd40964-61b4-471c-aa47-b28c6aa56a63', 1)]
+        }
+
+        # act
+        compute_min_moves_result = compute_min_moves(previousConfigRuleUids, currentConfigRuleUids)
+
+        # assert
+        self.assertEqual(compute_min_moves_result["moves"], expectedResult["moves"])
+        self.assertEqual(compute_min_moves_result["operations"], expectedResult["operations"])
+        self.assertEqual(compute_min_moves_result["insertions"], expectedResult["insertions"])
+        self.assertEqual(compute_min_moves_result["deletions"], expectedResult["deletions"])     
+        self.assertEqual(compute_min_moves_result["reposition_moves"], expectedResult["reposition_moves"])      
+
+    def test_update_rulebase_diffs_recognize_same_config(self):
+        # arrange
+        previous_config = MockFwConfigNormalized()
+        previous_config.initialize_config(
+            {
+                "rule_config": [10,10,10]
+            }
+        )
+
+        fwconfig_import_rule = MockFwConfigImportRule()
+        fwconfig_import_rule.NormalizedConfig = copy.deepcopy(previous_config)
+
+        # act
+        fwconfig_import_rule.updateRulebaseDiffs(previous_config)
+
+        # assert
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleAddCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleDeleteCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleChangeCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleMoveCount, 0)
+
+    def test_update_rulebase_diffs_recognize_delete(self):
+        # arrange
+        previous_config = MockFwConfigNormalized()
+        previous_config.initialize_config(
+            {
+                "rule_config": [10,10,10]
+            }
+        )
+
+        fwconfig_import_rule = MockFwConfigImportRule()
+        fwconfig_import_rule.NormalizedConfig = copy.deepcopy(previous_config)
+        deleted_rule = list(fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules.keys())[0]
+        del fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules[deleted_rule]
+
+
+        # act
+        fwconfig_import_rule.updateRulebaseDiffs(previous_config)
+
+        # assert
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleAddCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleDeleteCount, 1)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleChangeCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleMoveCount, 0)
+
+    def test_update_rulebase_diffs_recognize_insert(self):
+        # arrange
+        previous_config = MockFwConfigNormalized()
+        previous_config.initialize_config(
+            {
+                "rule_config": [10,10,10]
+            }
+        )
+
+        fwconfig_import_rule = MockFwConfigImportRule()
+        fwconfig_import_rule.NormalizedConfig = copy.deepcopy(previous_config)
+        fwconfig_import_rule.NormalizedConfig.add_rule_to_rulebase(fwconfig_import_rule.NormalizedConfig.rulebases[0].uid)
+
+        # act
+        fwconfig_import_rule.updateRulebaseDiffs(previous_config)
+
+        # assert
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleAddCount, 1)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleDeleteCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleChangeCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleMoveCount, 0)
+
+    def test_update_rulebase_diffs_recognize_move(self):
+        # arrange
+        previous_config = MockFwConfigNormalized()
+        previous_config.initialize_config(
+            {
+                "rule_config": [10,10,10],
+                "initialize_rule_num_numeric": True
+            }
+        )
+
+        fwconfig_import_rule = MockFwConfigImportRule()
+        fwconfig_import_rule.NormalizedConfig = copy.deepcopy(previous_config)
+        moved_rule_uid = list(fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules.keys())[0]
+        fwconfig_import_rule.NormalizedConfig.rulebases[1].Rules[moved_rule_uid] = fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules.pop(moved_rule_uid)
+
+        # act
+        fwconfig_import_rule.updateRulebaseDiffs(previous_config)
+
+        # assert
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleAddCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleDeleteCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleChangeCount, 0)
+        self.assertEqual(fwconfig_import_rule.ImportDetails.Stats.RuleMoveCount, 1)
+
+    def test_update_rulebase_diffs_handle_move_simple(self):
+        # arrange
+        previous_config = MockFwConfigNormalized()
+        previous_config.initialize_config(
+            {
+                "rule_config": [10,10,10],
+                "initialize_rule_num_numeric": True
+            }
+        )
+
+        fwconfig_import_rule = MockFwConfigImportRule()
+        fwconfig_import_rule.NormalizedConfig = copy.deepcopy(previous_config)
+        moved_rule_uid = list(fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules.keys())[0]
+        moved_rule = fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules.pop(moved_rule_uid)
+        fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules = self.simulate_move(fwconfig_import_rule.NormalizedConfig.rulebases[0].Rules, moved_rule, 5) 
+
+        # act
+        fwconfig_import_rule.updateRulebaseDiffs(previous_config)
+
+        # assert
+
+
+    # TODO: Do that via mock_config.py
+
+    def mock_previous_config_rule_uids(self, with_rule_num_numeric = False, longer_version = False):
+        data = {
+            "5fe42dfa-47a0-41b9-b90e-cdde198cd651": 1,
+            "55f11a6a-f14f-4802-9af2-52309c81af23": 2,
+            "f31d21f5-2b5d-47e8-9011-cd16695f5644": 3,
+            "fb914729-4858-491f-9816-a78ec17a8b83": 4,
+            "e40d5b53-67e0-4ba7-923e-226909fc3c82": 5,
+            "d96a70ca-bb57-49a6-93c9-53344caa5f02": 6,
+            "1b4658f3-807b-4956-a01e-be5bf5090803": 7,
+            "41925458-36ec-42ab-9e25-90220a19a4d9": 8,
+            "a5d42650-43d5-4cab-9bc8-48cbf902fa34": 9,
+            "2c18bbd4-fa8e-475a-9268-f15f1d4dd6f5": 10
+        }
+
+        if longer_version:
+            data["b9018dcd-1362-4c5f-911b-445936b065f6"] = 11
+            data["1c82f131-1202-4c1b-9919-85f3a5bbbc2f"] = 12
+            data["10b2e5d2-5143-402c-940a-716a8242dc38"] = 13
+            data["4fd40964-61b4-471c-aa47-b28c6aa56a63"] = 14
+            data["ec783b63-5feb-40cf-8bc6-72094fabbc45"] = 15
+
+        if with_rule_num_numeric:
+            return data
+        else:
+            return list(data.keys())
+        
+    def simulate_move(self, rules: dict, moved_rule: Rule, new_position : int):
+
+        new_rules = {}
+
+        for idx, (k, v) in enumerate(rules.items()):
+            if idx == new_position:
+                new_rules[moved_rule.rule_uid] = moved_rule
+            new_rules[k] = v
+
+        return new_rules
 
 if __name__ == '__main__':
     unittest.main()

--- a/roles/lib/files/FWO.Report/ReportRules.cs
+++ b/roles/lib/files/FWO.Report/ReportRules.cs
@@ -292,7 +292,11 @@ namespace FWO.Report
 
             Dictionary<int, List<Rule>> rulesByRulebase = rules
                 .GroupBy(r => r.RulebaseId)
-                .ToDictionary(g => g.Key, g => g.OrderBy(r => r.RuleOrderNumber).ToList());
+                .ToDictionary(g => g.Key, g => g.OrderBy(r => r.OrderNumber).ToList());
+
+            // Normalize actual order numbers to incremental int like form.
+
+            NormalizeOrderNumbers(rulesByRulebase);
 
             // Creates a dictionary with rule IDs as keys and the rulebase link that has that rule as its from rule as values.
 
@@ -339,7 +343,7 @@ namespace FWO.Report
 
                 // Write order numbers to rule object.
 
-                List<int> path = new List<int>(currentPath) { rule.RuleOrderNumber + 1 };
+                List<int> path = new List<int>(currentPath) { (int) rule.OrderNumber };
                 string dotted = string.Join(".", path);
                 rule.DisplayOrderNumberString = dotted;
                 rule.OrderNumber = positionCounter++;
@@ -363,6 +367,25 @@ namespace FWO.Report
                             BuildOrderNumberTree(link.NextRulebaseId, path, rulesByRulebase, linksByFromRuleId, changedRules, ref positionCounter, rulebaseRules);
                             break;
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Normalizes float values within rule groups (grouped by rulebase ID) to ascending integers 
+        /// while preserving their relative order (e.g., [1.4, 4.645, 13.65] -> [1, 2, 3]).
+        /// </summary>
+        /// <param name="rulesByRulebase"></param>
+        private static void ResetRelativeOrderNumbers(Dictionary<int, List<Rule>> rulesByRulebase)
+        {
+            foreach (KeyValuePair<int, List<Rule>> rulebaseRules in rulesByRulebase)
+            {
+                int relativeOrderNumber = 1;
+
+                foreach (Rule rule in rulebaseRules.Value.ToList())
+                {
+                    rule.RuleOrderNumber = relativeOrderNumber;
+                    relativeOrderNumber++;
                 }
             }
         }

--- a/roles/lib/files/FWO.Report/ReportRules.cs
+++ b/roles/lib/files/FWO.Report/ReportRules.cs
@@ -343,7 +343,7 @@ namespace FWO.Report
 
                 // Write order numbers to rule object.
 
-                List<int> path = new List<int>(currentPath) { (int) rule.OrderNumber };
+                List<int> path = new List<int>(currentPath) { rule.RuleOrderNumber };
                 string dotted = string.Join(".", path);
                 rule.DisplayOrderNumberString = dotted;
                 rule.OrderNumber = positionCounter++;
@@ -376,7 +376,7 @@ namespace FWO.Report
         /// while preserving their relative order (e.g., [1.4, 4.645, 13.65] -> [1, 2, 3]).
         /// </summary>
         /// <param name="rulesByRulebase"></param>
-        private static void ResetRelativeOrderNumbers(Dictionary<int, List<Rule>> rulesByRulebase)
+        private static void NormalizeOrderNumbers(Dictionary<int, List<Rule>> rulesByRulebase)
         {
             foreach (KeyValuePair<int, List<Rule>> rulebaseRules in rulesByRulebase)
             {


### PR DESCRIPTION
1. The unit tests for the ruleorder are deprecated and need some work
2. The change counter for inserts is somehow doubled
3. There should be some additional commentary

But I would prefer to do that in a follow up PR, so that these changes can be reviewed and bugs, that I did not find while my testing can be revealed through practical usage. 