### PR TITLE
PR for Issue 3246 - Rules Report Export - rule numbering missing

### DIFF
--- a/roles/lib/files/FWO.Report/Display/RuleDisplayBase.cs
+++ b/roles/lib/files/FWO.Report/Display/RuleDisplayBase.cs
@@ -14,7 +14,7 @@ namespace FWO.Ui.Display
 
         public static string DisplayNumber(Rule rule)
         {
-            return rule.DisplayOrderNumber.ToString();
+            return rule.DisplayOrderNumberString;
         }
 
         public static string DisplayEnabled(Rule rule, OutputLocation location)

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
@@ -24,7 +24,7 @@
                             {
                                 <Column TableItem="Rule" Context="rule" Title="@(userConfig.GetText("number"))" DefaultSortColumn="true" Field="@(rChange => rChange.OrderNumber)" Sortable="true" Filterable="false" Hideable="true">
                                     <Template>
-                                        @((MarkupString) rule.DisplayOrderNumberString)
+                                        @((MarkupString) RuleDisplayHtml.DisplayNumber(rule))
                                     </Template>
                                 </Column>
                             }


### PR DESCRIPTION
- changed source for RuleDisplayBase.DisplayNumber to correct property
- changed to use that method in dynamic report also, to be more coherent with the other fields