### PR TITLE
PR for issue 3261

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+annotated-types==0.7.0
+certifi==2025.4.26
+cffi==1.17.1
+charset-normalizer==3.4.2
+cryptography==45.0.2
+graphql-core==3.2.6
+idna==3.10
+jsonpickle==4.0.5
+netaddr==1.3.0
+pycparser==2.22
+pydantic==1.10.22
+pydantic_core==2.33.2
+requests==2.32.3
+typing-inspection==0.4.0
+typing_extensions==4.13.2
+urllib3==2.4.0

--- a/roles/common/files/fwo-api-calls/rule/updateChanglogRules.graphql
+++ b/roles/common/files/fwo-api-calls/rule/updateChanglogRules.graphql
@@ -1,0 +1,5 @@
+mutation updateChanglogRules($rule_changes: [changelog_rule_insert_input!]!) {
+    insert_changelog_rule(objects: $rule_changes) {
+        affected_rows
+    }
+}

--- a/roles/importer/files/importer/fwo_globals.py
+++ b/roles/importer/files/importer/fwo_globals.py
@@ -1,4 +1,5 @@
 shutdown_requested = False
+debug_level = 0 
 
 def setGlobalValues (
         verify_certs_in=None, 

--- a/roles/importer/files/importer/fwo_log.py
+++ b/roles/importer/files/importer/fwo_log.py
@@ -127,3 +127,88 @@ def getFwoAlertLogger(debug_level=0):
     if debug_level>8:
         logger.debug ("debug_level=" + str(debug_level) )
     return logger
+
+
+class ChangeLogger:
+    """
+         A singleton service that holds data and provides logic to compute changelog data for network objects, services and rules.
+    """
+
+    _instance = None
+    changed_nwobj_id_map: dict
+    changed_svc_id_map: dict
+    _import_state = None
+    _uid2id_mapper = None
+
+    def __new__(cls):
+        """
+            Singleton pattern: Creates instance and sets defaults if constructed first time and sets that object to a protected class variable. 
+            If the constructor is called when there is already an instance returns that instance instead. That way there will only be one instance of this type throudgh the whole runtime.
+        """
+
+        if cls._instance is None:
+            cls._instance = super(ChangeLogger, cls).__new__(cls)
+            cls.changed_nwobj_id_map = {}
+            cls.changed_svc_id_map = {}
+        return cls._instance
+
+
+    def create_change_id_maps(self, uid2id_mapper, changed_nw_objs, changed_svcs, removedNwObjIds, removedNwSvcIds):
+
+        self._uid2id_mapper = uid2id_mapper
+
+        self.changed_object_id_map = {
+            next(removedNwObjId['obj_id']
+                for removedNwObjId in removedNwObjIds
+                if removedNwObjId['obj_uid'] == old_item
+            ): self._uid2id_mapper.nwobj_uid2id[old_item]
+            for old_item in changed_nw_objs
+        }
+
+        self.changed_service_id_map = {
+            next(removedNwSvcId['svc_id']
+                for removedNwSvcId in removedNwSvcIds
+                if removedNwSvcId['svc_uid'] == old_item
+            ): self._uid2id_mapper.svc_uid2id[old_item]
+            for old_item in changed_svcs
+        }
+
+
+    def create_changelog_import_object(self, type, import_state, change_action, changeTyp, importTime, rule_id, rule_id_alternative = 0):
+        
+        uniqueName = self._get_changelog_import_object_unique_name(rule_id)
+        old_rule_id = None
+        new_rule_id = None
+        self._import_state = import_state
+
+        if change_action in ['I', 'C']:
+            new_rule_id = rule_id
+        
+        if change_action == 'C':
+            old_rule_id = rule_id_alternative
+
+        if change_action == 'D':
+            old_rule_id = rule_id
+
+        rule_changelog_object =  {
+            f"new_{type}_id": new_rule_id,
+            f"old_{type}_id": old_rule_id,
+            "control_id": self._import_state.ImportId,
+            "change_action": change_action,
+            "mgm_id": self._import_state.MgmDetails.Id,
+            "change_type_id": changeTyp,
+            "change_time": importTime,
+            "unique_name": uniqueName,
+        }
+
+        # Can be removed as soon as the column gets removed from db.
+        
+        if type == "rule":
+            rule_changelog_object["dev_id"] = 3
+
+        return rule_changelog_object
+    
+
+    def _get_changelog_import_object_unique_name(self, changelog_entity_id):
+        return  str(changelog_entity_id)
+    

--- a/roles/importer/files/importer/model_controllers/fwconfig_import_object.py
+++ b/roles/importer/files/importer/model_controllers/fwconfig_import_object.py
@@ -3,7 +3,7 @@ import traceback
 import time, datetime
 import json
 
-from fwo_log import getFwoLogger
+from fwo_log import ChangeLogger, getFwoLogger
 from model_controllers.import_state_controller import ImportStateController
 from model_controllers.fwconfig_normalized_controller import FwConfigNormalized
 from model_controllers.fwconfig_import_base import FwConfigImportBase
@@ -41,12 +41,18 @@ class FwConfigImportObject(FwConfigImportBase):
         deletedNwobjUids = list(prevConfig.network_objects.keys() - self.NormalizedConfig.network_objects.keys())
         newNwobjUids = list(self.NormalizedConfig.network_objects.keys() - prevConfig.network_objects.keys())
         nwobjUidsInBoth = list(self.NormalizedConfig.network_objects.keys() & prevConfig.network_objects.keys())
+        change_logger = ChangeLogger()
+
+        # For correct changelog and stats.
+        changed_nw_objs = []
+        changed_svcs = []
 
         # decide if it is prudent to mix changed, deleted and added rules here:
         for nwObjUid in nwobjUidsInBoth:
             if self.NormalizedConfig.network_objects[nwObjUid].did_change(prevConfig.network_objects[nwObjUid]):
                 newNwobjUids.append(nwObjUid)
                 deletedNwobjUids.append(nwObjUid)
+                changed_nw_objs.append(nwObjUid)
 
         # calculate service object diffs
         deletedSvcObjUids = list(prevConfig.service_objects.keys() - self.NormalizedConfig.service_objects.keys())
@@ -57,6 +63,7 @@ class FwConfigImportObject(FwConfigImportBase):
             if self.NormalizedConfig.service_objects[nwSvcUid].did_change(prevConfig.service_objects[nwSvcUid]):
                 newSvcObjUids.append(nwSvcUid)
                 deletedSvcObjUids.append(nwSvcUid)
+                changed_svcs.append(nwSvcUid)
         
         #TODO: calculate user diffs
         # deletedUserUids = list(prevConfig.users.keys() - self.NormalizedConfig.users.keys())
@@ -96,14 +103,41 @@ class FwConfigImportObject(FwConfigImportBase):
         # TODO: calculate user diffs
         # TODO: calculate zone diffs
 
-        # TODO: write changes to changelog_xxx tables
+
+        # Get Changed Ids.
+
+        change_logger.create_change_id_maps(self.uid2id_mapper, changed_nw_objs, changed_svcs, removedNwObjIds, removedNwSvcIds)
+
+        # Seperate changes from adds and removes for changelog and stats.
+
+        newNwObjIds = [newNwObjId
+            for newNwObjId in newNwObjIds
+            if newNwObjId['obj_id'] not in list(change_logger.changed_object_id_map.values())       
+        ]
+        removedNwObjIds = [removedNwObjId
+            for removedNwObjId in removedNwObjIds
+            if removedNwObjId['obj_id'] not in list(change_logger.changed_object_id_map.keys())       
+        ]
+        newNwSvcIds = [newNwSvcId
+            for newNwSvcId in newNwSvcIds
+            if newNwSvcId['svc_id'] not in list(change_logger.changed_service_id_map.values())       
+        ]
+        removedNwSvcIds = [removedNwSvcId
+            for removedNwSvcId in removedNwSvcIds
+            if removedNwSvcId['svc_id'] not in list(change_logger.changed_service_id_map.keys())       
+        ]
+
+        # Write change logs to tables.
+        
         self.addChangelogObjects(newNwObjIds, newNwSvcIds, removedNwObjIds, removedNwSvcIds)
 
         # note changes:
         self.ImportDetails.Stats.NetworkObjectAddCount = len(newNwObjIds)
         self.ImportDetails.Stats.NetworkObjectDeleteCount = len(removedNwObjIds)
+        self.ImportDetails.Stats.NetworkObjectChangeCount = len(change_logger.changed_object_id_map.items())
         self.ImportDetails.Stats.ServiceObjectAddCount = len(newNwSvcIds)
         self.ImportDetails.Stats.ServiceObjectDeleteCount = len(removedNwSvcIds)
+        self.ImportDetails.Stats.ServiceObjectChangeCount = len(change_logger.changed_service_id_map.items())
 
     def GetNetworkObjTypeMap(self):
         query = "query getNetworkObjTypeMap { stm_obj_typ { obj_typ_name obj_typ_id } }"
@@ -779,108 +813,43 @@ class FwConfigImportObject(FwConfigImportBase):
 
         nwObjs = []
         svcObjs = []
-        usrObjs = []
         importTime = datetime.datetime.now().isoformat()
         changeTyp = 3  # standard
+        change_logger = ChangeLogger()
 
         if self.ImportDetails.IsFullImport or self.ImportDetails.IsClearingImport:
             changeTyp = 2   # to be ignored in change reports
         
         # Write changelog for network objects.
 
-        for obj in [obj for obj in nwObjIdsAdded if obj["obj_typ_id"] != 21]:
-            uniqueName = self.lookupObjIdToUidAndPolicyName(obj['obj_id'])
-            nwObjs.append({
-                "new_obj_id": obj['obj_id'],
-                "control_id": self.ImportDetails.ImportId,
-                "change_action": "I",
-                "mgm_id": self.ImportDetails.MgmDetails.Id,
-                "change_type_id": changeTyp,
-                # "security_relevant": secRelevant, # assuming everything is security relevant for now
-                "change_time": importTime,
-                "unique_name": uniqueName
-            })
+        for nw_obj_id in [nw_obj_ids_added_item["obj_id"] for nw_obj_ids_added_item in nwObjIdsAdded]:
+            nwObjs.append(change_logger.create_changelog_import_object("obj", self.ImportDetails, 'I', changeTyp, importTime, nw_obj_id))
 
-        for obj in [obj for obj in nwObjIdsRemoved if obj["obj_typ_id"] != 21]:
-            uniqueName = self.lookupObjIdToUidAndPolicyName(obj['obj_id'])
-            nwObjs.append({
-                "new_obj_id": None,
-                "old_obj_id": obj['obj_id'],
-                "control_id": self.ImportDetails.ImportId,
-                "change_action": "D",
-                "mgm_id": self.ImportDetails.MgmDetails.Id,
-                "change_type_id": changeTyp,
-                # "security_relevant": secRelevant, # assuming everything is security relevant for now
-                "change_time": importTime,
-                "unique_name": uniqueName
-            })
+        for nw_obj_id in [nw_obj_ids_removed_item["obj_id"] for nw_obj_ids_removed_item in nwObjIdsRemoved]:
+            nwObjs.append(change_logger.create_changelog_import_object("obj", self.ImportDetails, 'D', changeTyp, importTime, nw_obj_id))
 
-        # Write changelog for users.
-
-        for obj in [obj for obj in nwObjIdsAdded if obj["obj_typ_id"] == 21]:
-            uniqueName = self.lookupObjIdToUidAndPolicyName(obj['obj_id'])
-            usrObjs.append({
-                "new_user_id": obj['obj_id'],
-                "control_id": self.ImportDetails.ImportId,
-                "change_action": "I",
-                "mgm_id": self.ImportDetails.MgmDetails.Id,
-                "change_type_id": changeTyp,
-                # "security_relevant": secRelevant, # assuming everything is security relevant for now
-                "change_time": importTime,
-                "unique_name": uniqueName
-            })
-
-        for obj in [obj for obj in nwObjIdsRemoved if obj["obj_typ_id"] == 21]:
-            uniqueName = self.lookupObjIdToUidAndPolicyName(obj['obj_id'])
-            usrObjs.append({
-                "new_user_id": None,
-                "old_user_id": obj['obj_id'],
-                "control_id": self.ImportDetails.ImportId,
-                "change_action": "D",
-                "mgm_id": self.ImportDetails.MgmDetails.Id,
-                "change_type_id": changeTyp,
-                # "security_relevant": secRelevant, # assuming everything is security relevant for now
-                "change_time": importTime,
-                "unique_name": uniqueName
-            })
+        for old_nw_obj_id, new_nw_obj_id in change_logger.changed_object_id_map.items():
+            nwObjs.append(change_logger.create_changelog_import_object("obj", self.ImportDetails, 'C', changeTyp, importTime, new_nw_obj_id, old_nw_obj_id))
 
         # Write changelog for Services.
 
-        for svc in svcObjIdsAdded:
-            uniqueName = self.lookupSvcIdToUidAndPolicyName(svc['svc_id'])
-            svcObjs.append({
-                "new_svc_id": svc['svc_id'],
-                "control_id": self.ImportDetails.ImportId,
-                "change_action": "I",
-                "mgm_id": self.ImportDetails.MgmDetails.Id,
-                "change_type_id": changeTyp,
-                # "security_relevant": secRelevant, # assuming everything is security relevant for now
-                "change_time": importTime,
-                "unique_name": uniqueName
-            })
+        for svc_id in [svc_ids_added_item["svc_id"] for svc_ids_added_item in svcObjIdsAdded]:
+            svcObjs.append(change_logger.create_changelog_import_object("svc", self.ImportDetails, 'I', changeTyp, importTime, svc_id))
 
-        for svc in svcObjIdsRemoved:
-            uniqueName = self.lookupSvcIdToUidAndPolicyName(svc['svc_id'])
-            svcObjs.append({
-                "new_svc_id": None,
-                "old_svc_id": svc['svc_id'],
-                "control_id": self.ImportDetails.ImportId,
-                "change_action": "D",
-                "mgm_id": self.ImportDetails.MgmDetails.Id,
-                "change_type_id": changeTyp,
-                # "security_relevant": secRelevant, # assuming everything is security relevant for now
-                "change_time": importTime,
-                "unique_name": uniqueName
-            })
+        for svc_id in [svc_ids_removed_item["svc_id"] for svc_ids_removed_item in svcObjIdsRemoved]:
+            svcObjs.append(change_logger.create_changelog_import_object("svc", self.ImportDetails, 'D', changeTyp, importTime, svc_id))
 
+        for old_svc_id, new_svc_id in change_logger.changed_service_id_map.items():
+            svcObjs.append(change_logger.create_changelog_import_object("svc", self.ImportDetails, 'C', changeTyp, importTime, new_svc_id, old_svc_id))
 
-        return nwObjs, svcObjs, usrObjs
+        return nwObjs, svcObjs
+
 
     def addChangelogObjects(self, nwObjIdsAdded, svcObjIdsAdded, nwObjIdsRemoved, svcObjIdsRemoved):
         logger = getFwoLogger()
         errors = 0
 
-        nwObjsChanged, svcObjsChanged, usrObjsChanged = self.prepareChangelogObjects(nwObjIdsAdded, svcObjIdsAdded, nwObjIdsRemoved, svcObjIdsRemoved)
+        nwObjsChanged, svcObjsChanged = self.prepareChangelogObjects(nwObjIdsAdded, svcObjIdsAdded, nwObjIdsRemoved, svcObjIdsRemoved)
 
         changelogMutation = """
             mutation updateObjChangelogs($nwObjChanges: [changelog_object_insert_input!]!, $svcObjChanges: [changelog_service_insert_input!]!) {
@@ -893,16 +862,9 @@ class FwConfigImportObject(FwConfigImportBase):
             }
         """
 
-        # TODO: Add to mutation when writing usr to db is implemented
-        #, $usrObjChanges: [changelog_user_insert_input!]!
-        # insert_changelog_user(objects: $usrObjChanges) {
-        #     affected_rows
-        # }
-
         queryVariables = {
             'nwObjChanges': nwObjsChanged, 
             'svcObjChanges': svcObjsChanged
-            # , 'usrObjChanges': usrObjsChanged # TODO: Uncomment when writing usr to db is implemented
         }
 
         if len(nwObjsChanged) + len(svcObjsChanged)>0:

--- a/roles/importer/files/importer/models/fwconfig_normalized.py
+++ b/roles/importer/files/importer/models/fwconfig_normalized.py
@@ -52,7 +52,7 @@ class FwConfigNormalized(FwConfig):
     users: dict = {}
     zone_objects: dict = {}
     rulebases: List[Rulebase] = []
-    gateways: List[Gateway]
+    gateways: List[Gateway] = []
     ConfigFormat: ConfFormat = ConfFormat.NORMALIZED_LEGACY
 
     class Config:

--- a/roles/importer/files/test/mocking/mock_config.py
+++ b/roles/importer/files/test/mocking/mock_config.py
@@ -1,10 +1,36 @@
 import json
 import uuid
-from typing import Union, Dict
+from typing import List, Union, Dict
+import random
+
+
 
 if __name__ == '__main__': # for usage as executable script
+    import sys
+    import os
+    sys.path.append(
+        os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '../../importer')
+        )
+    )
+    sys.path.append(
+        os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '../../')
+        )
+    )
     from uid_manager import UidManager
     from mock_rulebase import MockRulebase
+    from models.fwconfig_normalized import FwConfigNormalized
+    from pydantic import PrivateAttr
+    from models.rule import Rule
+    from models.networkobject import NetworkObject
+    from models.serviceobject import ServiceObject
+    from models.rulebase import Rulebase
+    from fwo_const import rule_num_numeric_steps, dummy_ip
+    from fwo_globals import setGlobalValues
+    from model_controllers.fwconfigmanagerlist_controller import FwConfigManagerListController
+    from mock_import_state import MockImportStateController
+    from model_controllers.fwconfigmanager_controller import FwConfigManager
 else: # for usage in unit tests
     from . uid_manager import UidManager
     from . mock_rulebase import MockRulebase
@@ -13,61 +39,122 @@ else: # for usage in unit tests
     from importer.models.rule import Rule
     from pydantic import PrivateAttr
     from importer.fwo_const import rule_num_numeric_steps
+    from importer.models.networkobject import NetworkObject
+    from importer.models.serviceobject import ServiceObject
 
 
 class MockFwConfigNormalized(FwConfigNormalized):
     """
-    A mock subclass of FwConfigNormalized for testing purposes.
+        A mock subclass of FwConfigNormalized for testing purposes.
 
-    This class creates a fake firewall configuration including rulebases
-    and rules, using a UID manager to generate unique identifiers.
+        This class creates a fake firewall configuration including rulebases
+        and rules, using a UID manager to generate unique identifiers.
     """
 
     _uid_manager: UidManager = PrivateAttr()
 
+    @property
+    def uid_manager(self) -> UidManager:
+        """Returns the internal UID manager."""
+        return self._uid_manager
+    
+
     def __init__(self, **kwargs):
         """
-        Initializes the mock configuration with default action and an empty gateway list.
+            Initializes the mock configuration with default action and an empty gateway list.
         """
+
         super().__init__(action="INSERT", gateways=[], **kwargs)
         self._uid_manager = UidManager()
 
-    @property
-    def uid_manager(self) -> UidManager:
-        """
-        Returns the internal UID manager.
-        """
-        return self._uid_manager
 
     def initialize_config(self, mock_config: Dict):
         """
-        Initializes the mock configuration with rulebases and rules.
+            Initializes the mock configuration with rulebases and rules.
 
-        Args:
-            mock_config (dict): A dictionary with configuration values. Expected keys:
-                - "rule_config": List of integers, each representing the number of rules per rulebase.
-                - "initialize_rule_num_numeric": Optional boolean, if True assigns incremental numeric rule numbers.
+            Args:
+                mock_config (dict): A dictionary with configuration values. Expected keys:
+                    - "rule_config": List of integers, each representing the number of rules per rulebase.
+                    - "initialize_rule_num_numeric": Optional boolean, if True assigns incremental numeric rule numbers.
         """
+
         mock_mgm_uid = self.uid_manager.create_uid()
         created_rule_counter = 1
 
+        # Add network objects.
+
+        for index in range(mock_config["network_object_config"]):
+
+            new_network_object_uid = self.uid_manager.create_uid()
+
+            new_network_object = NetworkObject(
+                obj_uid = new_network_object_uid,
+                obj_ip = dummy_ip,
+                obj_ip_end = dummy_ip,
+                obj_name = f"Network Object {index}",
+                obj_color = "black",
+                obj_typ = "group"
+            )
+            
+            self.network_objects[new_network_object_uid] = new_network_object
+
+        # Add users.
+
+        for index in range(mock_config["user_config"]):
+
+            new_user_uid = self.uid_manager.create_uid()
+
+            new_user = NetworkObject(
+                obj_uid = new_user_uid,
+                obj_ip = dummy_ip,
+                obj_ip_end = dummy_ip,
+                obj_name = f"IA_{index}",
+                obj_color = "black",
+                obj_typ = "access-role"
+            )
+            
+            self.network_objects[new_user_uid] = new_user
+
+        # Add services.
+
+        for index in range(mock_config["service_config"]):
+
+            new_service_uid = self.uid_manager.create_uid()
+
+            new_service = ServiceObject(
+                svc_uid = new_service_uid,
+                svc_name = f"Service {index}",
+                svc_color = "black",
+                svc_typ = "group"
+            )
+            
+            self.service_objects[new_service_uid] = new_service
+
+        # Add rules and rulebases.
+            
         for number_of_rules in mock_config["rule_config"]:
-            # Create a new rulebase
+
+            # Create a new rulebase.
+
             new_rulebase_uid = self.uid_manager.create_uid()
             new_rulebase = Rulebase(
-                uid=new_rulebase_uid,
-                name=f"Rulebase {new_rulebase_uid}",
-                mgm_uid=mock_mgm_uid
+                uid = new_rulebase_uid,
+                name = f"Rulebase {new_rulebase_uid}",
+                mgm_uid = mock_mgm_uid
             )
             self.rulebases.append(new_rulebase)
 
             for i in range(number_of_rules):
-                # Add a new rule to the rulebase
+
+                # Add a new rule to the rulebase.
+
                 new_rule = self.add_rule_to_rulebase(new_rulebase_uid)
+                self.add_references_to_rule(new_rule)
 
                 if mock_config.get("initialize_rule_num_numeric"):
                     new_rule.rule_num_numeric = created_rule_counter * rule_num_numeric_steps
                     created_rule_counter += 1
+
 
     def add_rule_to_rulebase(self, rulebase_uid: str) -> Rule:
         """
@@ -110,224 +197,53 @@ class MockFwConfigNormalized(FwConfigNormalized):
         return new_rule
         
 
-class ConfigMocker:
-    config_type = "normalized"
-    file_name_prefix = ''
-    tmp_dir = "/usr/local/fworch/tmp/import/"
-    mgm_id = 3
-    manager_uid = "6ae3760206b9bfbd2282b5964f6ea07869374f427533c72faa7418c28f7a77f2"
-    manager_name = 'sting-mgmt'
-    file_name = f'{file_name_prefix}mgm_id_{mgm_id}_config_{config_type}.json'
-    default_file_path = tmp_dir + file_name
-    default_number_config = [100000]
-    uid_manager = UidManager()
-    checkpoint_object_types = ["hosts", 
-                                "networks", 
-                                "groups", 
-                                "address-ranges", 
-                                "groups-with-exclusion",
-                                "gateways-and-servers",
-                                "dns-domains",
-                                "updatable-objects-repository-content",
-                                "interoperable-devices",
-                                "security-zones",
-                                "Global",
-                                "access-roles",
-                                "updatable-objects",
-                                "service-groups",
-                                "application-site-categories",
-                                "application-sites",
-                                "services-tcp",
-                                "services-udp",
-                                "services-dce-rpc",
-                                "services-rpc",
-                                "services-other",
-                                "services-icmp",
-                                "services-icmp6",
-                                "services-sctp",
-                                "services-gtp",
-                                "CpmiAnyObject",
-                                "user-groups",
-                                "users",
-                                "access-roles",
-                                "user-templates"]
+    def add_references_to_rule(self, rule: Rule):
+        network_objects = [
+            network_object for network_object in self.network_objects.values()
+            if network_object.obj_typ == "group"
+        ]
+        src_network_object = random.choice(network_objects)
+        dst_network_object = random.choice(network_objects)
 
-    config = {}
-    rules_uids = []
-    rulebases = []
-    checkpoint_config_objects = []
+        service_objects = list(self.service_objects.values())
+        service = random.choice(service_objects)
 
-    checkpoint_objects_config = {}
+        users = [
+            user for user in self.network_objects.values()
+            if user.obj_typ == "access-role"
+        ]
+        src_user = random.choice(users)
+        dst_user = random.choice(users)
 
-
-    def create_checkpoint_config(self):
-        self.config["object_tables"] = []
-        for object_type in self.checkpoint_object_types:
-            self.config["object_tables"].append(
-                {
-                    "object_type": object_type,
-                    "object_chunks": [{"objects":[]}]
-                }
-            )
-
-
-    def create_checkpoint_config_object(self, uid, name, type, domain_uid = "", domain_name = "", domain_type = "", icon = "", color = ""):
-        return {
-            "uid": uid,
-            "name": name,
-            "type": type,
-            "domain": {
-            "uid": domain_uid,
-            "name": domain_name,
-            "domain-type": domain_type
-            },
-            "icon": icon,
-            "color": color
-        }
-
-
-    def create_checkpoint_config_objects(self):
-        for objects_config in self.checkpoint_objects_config.keys():
-            object_tables = self.config["object_tables"]
-            table = next((object_table for object_table in object_tables if object_table["object_type"] == objects_config), None)
-            counter = 1
-            while counter <= self.checkpoint_objects_config[objects_config]:
-                new_uid = self.uid_manager.create_uid()
-                new_object = self.create_checkpoint_config_object(new_uid, f"{table["object_type"]}_object {counter}", table["object_type"])
-                self.checkpoint_config_objects.append(new_object)
-                table["object_chunks"][0]["objects"].append(new_object) # TODO: Support more than one chunk
-                counter += 1
-
-
-    def create_config(self, as_dict: bool = False, file_path: str = "", number_config: list = []) -> Union[dict, None]: 
-        if number_config == []:
-            number_config = self.default_number_config
-
-        self.generate_rulebases(number_config)
-
-        match self.config_type:
-            case "normalized":
-                self.build_normalized_config()
-            case "checkpoint":
-                self.create_checkpoint_config()
-                self.create_checkpoint_config_objects()
-                
-        
-        if as_dict:
-            if self.config_type == "normalized":
-                return self, self.rules_uids
-            else:
-                return self.checkpoint_config_objects, self.config
-        else:
-            if file_path == "":
-                file_path = self.default_file_path
-
-            with open(file_path, "w") as file:
-                json.dump(self.config, file, indent=4)
-            print(f"Config file saved to {file_path}")
-
-            return None
-
-
-    def build_normalized_config(self):
-        self.config = {
-            "ConfigFormat": self.config_type.upper(),
-            "ManagerSet": [
-                {
-                    "ManagerUid": self.manager_uid,
-                    "ManagerName": self.manager_name,
-                    "IsGlobal": False,
-                    "DependantManagerUids": [],
-                    "Configs": [
-                        {
-                            "ConfigFormat": "NORMALIZED_LEGACY",
-                            "action": "INSERT",
-                            "network_objects":{
-
-                            },
-                            "users":{
-
-                            },
-                            "zone_objects":{
-
-                            },
-                            "rulebases": [rulebase.to_dict() for rulebase in self.rulebases] or [],
-                            "gateways":[
-                                
-                            ]
-                        }  
-                    ]
-                }
-            ]
-        }
-
-
-    def generate_rules(self, rules_number=0):
-        rules = {}
-        counter = 0
-
-        while counter < rules_number:
-            rule_uid = self.uid_manager.create_uid()
-            rules[rule_uid]={
-                "rule_num": 0,
-                "rule_disabled": False,
-                "rule_src_neg": False,
-                "rule_src": "None",
-                "rule_src_refs": "",
-                "rule_dst_neg": False,
-                "rule_dst": "None",
-                "rule_dst_refs": "",
-                "rule_svc_neg": False,
-                "rule_svc": "None",
-                "rule_svc_refs": "",
-                "rule_action": "accept",
-                "rule_track": "log",
-                "rule_installon": "Policy Targets",
-                "rule_time": "Any",
-                "rule_name": "Rule",
-                "rule_uid": rule_uid,
-                "rule_custom_fields": "{'field-1': '', 'field-2': '', 'field-3': ''}",
-                "rule_implied": False,
-                "rule_type": "access",
-                "rule_last_change_admin": "admin",
-                "parent_rule_uid": None,
-                "last_hit": None,
-                "rule_comment": None,
-                "rule_src_zone": None,
-                "rule_dst_zone": None,
-                "rule_head_text": None
-            }
-            self.rules_uids.append(rule_uid)
-            counter +=1
-
-        return rules
-
-
-    def generate_rulebase(self, rules_number=0):
-        rulebase = MockRulebase()
-        rulebase.uid = self.uid_manager.create_uid()
-        rulebase.name = f"Rulebase {rulebase.uid}" # to ensure unique key 'unique_rulebase_mgm_id_name'
-        rulebase.mgm_uid = self.uid_manager.create_uid()
-        rulebase.Rules = self.generate_rules(rules_number) or {}
-        return rulebase
-
-
-    def generate_rulebases(self, rulebase_config):
-        for number_of_rules in rulebase_config:
-            new_rulebase = self.generate_rulebase(number_of_rules)
-            self.rulebases.append(new_rulebase)
+        rule.rule_dst = f"{dst_network_object.obj_name}|{dst_user.obj_name}"
+        rule.rule_dst_refs = f"{dst_network_object.obj_uid}|{dst_user.obj_uid}"
+        rule.rule_src = f"{src_network_object.obj_name}|{src_user.obj_name}"
+        rule.rule_src_refs = f"{src_network_object.obj_uid}|{src_user.obj_uid}"
+        rule.rule_svc = service.svc_name
+        rule.rule_svc_refs = service.svc_uid
 
 
 if __name__ == '__main__':
-    """ 
+    mock_config = MockFwConfigNormalized()
+    mock_config.initialize_config(
+        {
+            "rule_config": [10,10,10],
+            "network_object_config": 10,
+            "service_config": 10,
+            "user_config": 10
+        }
+    )
 
-    DISCLAIMER
+    fw_mock_import_state = MockImportStateController()
+    setGlobalValues(debug_level_in = 8)
+    fw_config_manager_list_controller = FwConfigManagerListController()
+    fw_config_manager = FwConfigManager(
+        ManagerUid = "6ae3760206b9bfbd2282b5964f6ea07869374f427533c72faa7418c28f7a77f2",
+        ManagerName= "sting-mgmt"
+    )
+    fw_config_manager.Configs.append(mock_config)
+    fw_config_manager_list_controller.ManagerSet.append(fw_config_manager)
+    fw_config_manager_list_controller.storeFullNormalizedConfigToFile(fw_mock_import_state)
 
-    This script does create a config similar to the normalized config we get when we import and transform a config from sting. However, it is not very sophisticated at this point.
-    It simply creates an empty config with the bare minimum to import n rules. To make it work you have to deactivate the consistency checks and create only one rulebase. 
-
-    """
-
-    config_mocker = ConfigMocker()
-    config_mocker.create_config()
+    print(f"MockConfig: File saved on disk.")
 

--- a/roles/importer/files/test/mocking/mock_import_state.py
+++ b/roles/importer/files/test/mocking/mock_import_state.py
@@ -1,5 +1,6 @@
 from importer.model_controllers.import_state_controller import ImportStateController
 from importer.model_controllers.import_statistics_controller import ImportStatisticsController
+from mock_management_details_controller import MockManagementDetailsController
 
 
 class MockImportStateController(ImportStateController):
@@ -16,6 +17,8 @@ class MockImportStateController(ImportStateController):
         self.Stats = ImportStatisticsController()
         self.call_log = []
         self.stub_responses = {}
+        self.ImportVersion = 9
+        self.MgmDetails = MockManagementDetailsController()
 
         
     def call(self, *args, **kwargs):

--- a/roles/importer/files/test/mocking/mock_management_details_controller.py
+++ b/roles/importer/files/test/mocking/mock_management_details_controller.py
@@ -1,0 +1,11 @@
+
+from importer.model_controllers.management_details_controller import ManagementDetailsController
+
+
+class MockManagementDetailsController(ManagementDetailsController):
+    def __init__(self):
+        """
+            Initializes without calling base init.
+        """
+
+        self.Id = 3

--- a/roles/importer/files/test/tools/set_up_test.py
+++ b/roles/importer/files/test/tools/set_up_test.py
@@ -14,7 +14,10 @@ def set_up_test_for_ruleorder_test_with_defaults():
     previous_config = MockFwConfigNormalized()
     previous_config.initialize_config(
         {
-            "rule_config": [10,10,10]
+            "rule_config": [10,10,10],
+            "network_object_config": 10,
+            "service_config": 10,
+            "user_config": 10
         }
     )
     new_num_numeric = 0.0


### PR DESCRIPTION
For implementation I used config files that I created with MockConfig.py, since I can not make changes to the test firewall. So I would appreciate it if you could test it with real api imports. @tpurschke  

**Todos:**
- [x] Write basic changelogs for network objects, services and rules
- [ ] Write changelogs for usr
- [ ] Differentiate between initial import and in operation
- [ ] Remove field dev_id from db table changelog_rule
- [ ] Fill all columns of changelog tables correctly
- [ ] implement _get_changelog_import_object_unique_name

**Todos concerning implementation details and other issues:**
- [ ] abstract create_change_id_maps and implement it for rules
- [ ] consolidate handling of changes of objects/services and rules (very similar processes, so the way to do it should be similar too)
- [ ] make change handling in nwobjs/services more efficient

Bonus:

- More sophisticated version of the config file creation funktionality in MockConfig.py
- Changes for network objects and services are now registered in the change_stats as changes