### PR TITLE
Issue 3325 importer rework adjust report rules to new rulebase link structure

### DIFF
--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -785,6 +785,22 @@ ALTER TABLE "rulebase_link" ADD COLUMN IF NOT EXISTS "removed" BIGINT;
 -- add obj type access-role for cp import
 INSERT INTO stm_obj_typ (obj_typ_id,obj_typ_name) VALUES (21,'access-role') ON CONFLICT DO NOTHING;
 
+-- remove dev_id fk and set nullable if column exists
+ALTER TABLE changelog_rule DROP CONSTRAINT IF EXISTS changelog_rule_dev_id_fkey;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'changelog_rule'
+      AND column_name = 'dev_id'
+  ) THEN
+    ALTER TABLE changelog_rule ALTER COLUMN dev_id DROP NOT NULL;
+  END IF;
+END
+$$;
+
 -- adding labels (simple version without mapping tables and without foreign keys)
 
 -- CREATE TABLE label (

--- a/roles/importer/files/importer/checkpointR8x/cp_rule.py
+++ b/roles/importer/files/importer/checkpointR8x/cp_rule.py
@@ -38,6 +38,7 @@ def normalizeRulebases (nativeConfig, importState, normalizedConfig):
         for rulebase_link in gateway['rulebase_links']:
             if rulebase_link['to_rulebase_uid'] not in fetched_links:
                 rulebase_to_parse, is_section = find_rulebase_to_parse(nativeConfig['rulebases'], rulebase_link['to_rulebase_uid'])
+                rulebase_link['is_section'] = is_section
                 normalized_rulebase = initialize_normalized_rulebase(rulebase_to_parse, importState.MgmDetails.Uid)
                 parse_rulebase(rulebase_to_parse, is_section, normalized_rulebase)
                 fetched_links.append(rulebase_link['to_rulebase_uid'])

--- a/roles/importer/files/importer/model_controllers/fwconfig_import_gateway.py
+++ b/roles/importer/files/importer/model_controllers/fwconfig_import_gateway.py
@@ -62,6 +62,7 @@ class FwConfigImportGateway(FwConfigImportBase):
                                 link_type=link_type_id,
                                 is_initial=link.is_initial,
                                 is_global=link.is_global,
+                                is_section = link.is_section,
                                 from_rulebase_id=from_rulebase_id,
                                 created=self.ImportDetails.ImportId).toDict())
         logger.debug(f"link {link} was added")

--- a/roles/importer/files/importer/models/rulebase_link.py
+++ b/roles/importer/files/importer/models/rulebase_link.py
@@ -11,6 +11,7 @@ class RulebaseLinkUidBased(BaseModel, ImportStateController):
     link_type: str = "section"
     is_initial: bool
     is_global: bool
+    is_section: bool
 
 class RulebaseLink(BaseModel):
     id: Optional[int] = None    # will be created during db import
@@ -21,6 +22,7 @@ class RulebaseLink(BaseModel):
     link_type: int = 1
     is_initial: bool
     is_global: bool
+    is_section: bool
     created: int
     removed: Optional[int] = None
 
@@ -34,6 +36,7 @@ class RulebaseLink(BaseModel):
             "link_type": self.link_type,
             "is_initial": self.is_initial,
             "is_global": self.is_global,
+            "is_section": self.is_section,
             "created": self.created,
             "removed": self.removed
         }

--- a/roles/importer/files/test/mocking/mock_config.py
+++ b/roles/importer/files/test/mocking/mock_config.py
@@ -180,7 +180,8 @@ class MockFwConfigNormalized(FwConfigNormalized):
                 to_rulebase_uid = initial_rulebase_uid,
                 link_type = "ordered",
                 is_initial = True,
-                is_global = False
+                is_global = False,
+                is_section = False
             )
         )
 
@@ -204,7 +205,8 @@ class MockFwConfigNormalized(FwConfigNormalized):
                     to_rulebase_uid = self.rulebases[index].uid,
                     link_type = "ordered",
                     is_initial = False,
-                    is_global = False
+                    is_global = False,
+                    is_section = False
                 )
             )
 

--- a/roles/lib/files/FWO.Basics/TreeItem.cs
+++ b/roles/lib/files/FWO.Basics/TreeItem.cs
@@ -1,0 +1,44 @@
+namespace FWO.Basics
+{
+    public class TreeItem<T>
+    {
+        public List<TreeItem<T>> Children { get; set; }
+
+        public TreeItem<T>? Parent { get; set; }
+        public TreeItem<T>? LastAddedItem { get; set; }
+
+        public List<int> Position { get; set; }
+
+        public T? Data { get; set; }
+
+        public bool IsRoot { get; set; }
+
+
+        public TreeItem() : this(default!)
+        {
+            IsRoot = true;
+        }
+
+        public TreeItem(T data)
+        {
+            Children = new();
+            Position = new();
+            Data = data;
+        }
+
+        public string GetPositionString()
+        {
+            return string.Join(".", Position);
+        }
+
+        public void SetPosition(string orderNumberString)
+        {
+            Position = orderNumberString
+                .Split('.')
+                .Select(int.Parse)
+                .ToList();
+        }
+
+
+    }
+}

--- a/roles/lib/files/FWO.Data/RulebaseLink.cs
+++ b/roles/lib/files/FWO.Data/RulebaseLink.cs
@@ -23,6 +23,9 @@ namespace FWO.Data
         [JsonProperty("is_global"), JsonPropertyName("is_global")]
         public bool IsGlobal { get; set; } = false;
 
+        [JsonProperty("is_section"), JsonPropertyName("is_section")]
+        public bool IsSection { get; set; } = false;
+
         [JsonProperty("to_rulebase_id"), JsonPropertyName("to_rulebase_id")]
         public int NextRulebaseId = new();
 

--- a/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
+++ b/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
@@ -137,8 +137,10 @@ namespace FWO.Report.Filter
                                 link_type
                                 is_initial
                                 is_global
+                                is_section
                                 gw_id
                                 from_rule_id
+                                from_rulebase_id
                                 to_rulebase_id
                                 created
                                 removed

--- a/roles/lib/files/FWO.Report/ReportRules.cs
+++ b/roles/lib/files/FWO.Report/ReportRules.cs
@@ -332,6 +332,11 @@ namespace FWO.Report
 
             if (!rulesByRulebase.TryGetValue(rulebaseId, out var rules))
             {
+                if (currentLink.LinkType == 3 && GetNextRulebaseLink(null,processedLinks,rulebaseByLink,rulebaseId)?.LinkType == 4)
+                {
+                    currentPath.Add(0);
+                }
+
                 HandleOrderNumberTreeNode(currentLink, currentLink.NextRulebaseId, currentPath, rulesByRulebase, rulebaseByLink, changedRules, ref positionCounter, rulebaseRules, processedLinks, null, null, managementReport, concatenationCounters);
                 return;
             }
@@ -354,7 +359,6 @@ namespace FWO.Report
 
                 if (currentLink.LinkType == 4)
                 {
-                    path = currentPath;
                     path[path.Count() - 1] = GetIncrementedConcatenationCounter(rulebaseId, concatenationCounters);
                 }
                 else
@@ -452,6 +456,15 @@ namespace FWO.Report
                 nextRulebaseLink = rulebaseByLink.Keys
                     .Where(rulebaseLink => !processedLinks.Contains(rulebaseLink))
                     .FirstOrDefault(rulebaseLink => rulebaseLink.FromRuleId == currentRule.Id);
+
+                if (nextRulebaseLink != null)
+                {
+                    return nextRulebaseLink;
+                }
+
+                nextRulebaseLink = rulebaseByLink.Keys
+                    .Where(rulebaseLink => !processedLinks.Contains(rulebaseLink))
+                    .FirstOrDefault(rulebaseLink => rulebaseLink.FromRulebaseId == rulebaseId);
             }
             else
             {
@@ -459,6 +472,9 @@ namespace FWO.Report
                     .Where(rulebaseLink => !processedLinks.Contains(rulebaseLink))
                     .FirstOrDefault(rulebaseLink => rulebaseLink.FromRulebaseId == rulebaseId);
             }
+
+
+
 
             return nextRulebaseLink;
         }


### PR DESCRIPTION
- made a complete overhaul of the logic for dynamic order number creation in ReportRules, to fit to the new rulebase links
- prepared a logic for a treelike data structure (incomplete, but no prio for this PR. Currently there is just the root element and a flat list as its children)
- finalized the wrtiting and reading of the is_section flag

I tested with a normalized config file, because currently I am not able to test via API because of the issue that should be resolved in PR https://github.com/CactuseSecurity/firewall-orchestrator/pull/3324

