### PR TITLE
fix(UI); Better viewing experience for modelling connections

### DIFF
--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/NetworkModelling.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/NetworkModelling.razor
@@ -95,12 +95,12 @@
                     }
                     </h5>
                 </div>
-                <div class="m-2 vheight75">
+                <div class="mx-2 mt-2">
                     <TabSet WholeWidth="false" DarkMode="false" KeepPanelsAlive="false" @ref="appHandler!.tabset">
                         <Tab Title="@(userConfig.GetText("connections"))" Position=0>
                             <button type="button" class="btn btn-sm btn-success mb-2" @onclick="appHandler!.AddConnection">
                                 @(appHandler!.DisplayButton("add_connection", Icons.Add))
-                            </button>
+                            </button>                            
                             <ConnectionTable ShowPageSizeInput="true" Connections="@appHandler!.GetRegularConnections()" @bind-AppHandler="appHandler" AppActive="appActive" ShowModellingState="true" ShowProductionState="true" />
                         </Tab>
                         <Tab Title="@(userConfig.GetText("provided_interfaces"))" Position=1>
@@ -119,7 +119,7 @@
                                     </Authorized>
                                 </AuthorizeView>
                             </div>
-                            <ConnectionTable ShowPageSizeInput="true" Connections="@appHandler!.GetInterfaces(showRejected)" @bind-AppHandler="appHandler" AppActive="appActive" ShowModellingState="true" />
+                            <ConnectionTable ShowPageSizeInput="true" Connections="@appHandler!.GetInterfaces(showRejected)" @bind-AppHandler="appHandler" AppActive="appActive" ShowModellingState="true" />                            
                         </Tab>
                         @if (selectedApp.CommSvcPossible)
                         {

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/NetworkModelling.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/NetworkModelling.razor
@@ -101,7 +101,7 @@
                             <button type="button" class="btn btn-sm btn-success mb-2" @onclick="appHandler!.AddConnection">
                                 @(appHandler!.DisplayButton("add_connection", Icons.Add))
                             </button>                            
-                            <ConnectionTable ShowPageSizeInput="true" Connections="@appHandler!.GetRegularConnections()" @bind-AppHandler="appHandler" AppActive="appActive" ShowModellingState="true" ShowProductionState="true" />
+                            <ConnectionTable UseResponsiveTable="true" ShowPageSizeInput="true" Connections="@appHandler!.GetRegularConnections()" @bind-AppHandler="appHandler" AppActive="appActive" ShowModellingState="true" ShowProductionState="true" />
                         </Tab>
                         <Tab Title="@(userConfig.GetText("provided_interfaces"))" Position=1>
                             <div class="d-flex justify-content-between">
@@ -119,7 +119,7 @@
                                     </Authorized>
                                 </AuthorizeView>
                             </div>
-                            <ConnectionTable ShowPageSizeInput="true" Connections="@appHandler!.GetInterfaces(showRejected)" @bind-AppHandler="appHandler" AppActive="appActive" ShowModellingState="true" />                            
+                            <ConnectionTable UseResponsiveTable="true" ShowPageSizeInput="true" Connections="@appHandler!.GetInterfaces(showRejected)" @bind-AppHandler="appHandler" AppActive="appActive" ShowModellingState="true" />
                         </Tab>
                         @if (selectedApp.CommSvcPossible)
                         {
@@ -127,7 +127,7 @@
                                 <button type="button" class="btn btn-sm btn-success mb-2"
                                     @onclick="appHandler!.AddCommonService">@(appHandler!.DisplayButton("add_common_service", Icons.Add))
                                 </button>
-                                <ConnectionTable Connections="@appHandler!.GetCommonServices()" @bind-AppHandler="appHandler" AppActive="appActive" ShowModellingState="true" ShowProductionState="true" />
+                                <ConnectionTable UseResponsiveTable="true" Connections="@appHandler!.GetCommonServices()" @bind-AppHandler="appHandler" AppActive="appActive" ShowModellingState="true" ShowProductionState="true" />
                             </Tab>
                         }
                     </TabSet>

--- a/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
+++ b/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
@@ -8,7 +8,7 @@
     <PageSizeComponent PageSizeCallback="UpdatePageSize"></PageSizeComponent>
 }
 <div class="@(UseResponsiveTable ? "connectiontable-responsive" : "")">
-    <Table class="table table-bordered th-bg-secondary sticky-header table-responsive connectiontable" TableItem="ModellingConnection"
+    <Table class="@GetTableClass()" TableItem="ModellingConnection"
            Items="Connections" PageSize="PageSize" ColumnReorder="true" TableRowClass="@(con => getTableRowClass(con))"
            SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
         @if(!Readonly && !SelectInterfaceView && AppHandler != null)
@@ -199,6 +199,11 @@
     {
         PageSize = pageSize;
         PageSizeCallback.InvokeAsync(pageSize);
+    }
+
+    private string GetTableClass()
+    {
+        return $"table table-bordered th-bg-secondary sticky-header table-responsive {(UseResponsiveTable ? "connectiontable-responsive" : "")}";
     }
 
     private void ToggleSelection(ModellingConnection conn)

--- a/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
+++ b/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
@@ -7,135 +7,137 @@
 {
     <PageSizeComponent PageSizeCallback="UpdatePageSize"></PageSizeComponent>
 }
-<Table class="table table-bordered th-bg-secondary sticky-header show-scrollbar table-responsive" TableItem="ModellingConnection"
-        Items="Connections" PageSize="PageSize" ColumnReorder="true" TableRowClass="@(con => getTableRowClass(con))"
-        SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
-    @if (!Readonly && !SelectInterfaceView && AppHandler != null)
-    {
-        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("actions"))" Field="(x => x.Id)" Sortable="false" Filterable="false">
-            <Template>
-                <div class="btn-group">
-                    <button type="button" class="btn btn-sm btn-primary" @onclick="async () =>
-                        { await AppHandler.ShowDetails(context); await AppHandlerChanged.InvokeAsync(AppHandler); }">
+<div class="connectiontable-responsive">
+    <Table class="table table-bordered th-bg-secondary sticky-header table-responsive connectiontable" TableItem="ModellingConnection"
+           Items="Connections" PageSize="PageSize" ColumnReorder="true" TableRowClass="@(con => getTableRowClass(con))"
+           SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
+        @if(!Readonly && !SelectInterfaceView && AppHandler != null)
+        {
+            <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("actions"))" Field="(x => x.Id)" Sortable="false" Filterable="false">
+                <Template>
+                    <div class="btn-group">
+                        <button type="button" class="btn btn-sm btn-primary" @onclick="async () =>
+                                                                                                     { await AppHandler.ShowDetails(context); await AppHandlerChanged.InvokeAsync(AppHandler); }">
                         @(AppHandler.DisplayButton("details", Icons.Display))
                     </button>
-                    @if (AppActive)
-                    {
-                        @if (!context.GetBoolProperty(ConState.InterfaceRejected.ToString()) && !context.GetBoolProperty(ConState.Rejected.ToString()))
+                    @if(AppActive)
                         {
-                            <button type="button" class="btn btn-sm btn-warning" @onclick="async () =>
-                                { await AppHandler.EditConn(context); await AppHandlerChanged.InvokeAsync(AppHandler); }">
-                                @(AppHandler.DisplayButton("edit", Icons.Edit))
-                            </button>
-                        }
-                        <button type="button" class="btn btn-sm btn-danger" @onclick="async () =>
-                            { await AppHandler.RequestDeleteConnection(context); await AppHandlerChanged.InvokeAsync(AppHandler); }">
-                            @(AppHandler.DisplayButton("delete", Icons.Delete))
-                        </button>
+                            @if(!context.GetBoolProperty(ConState.InterfaceRejected.ToString()) && !context.GetBoolProperty(ConState.Rejected.ToString()))
+                            {
+                                <button type="button" class="btn btn-sm btn-warning" @onclick="async () =>
+                                                                                                                     { await AppHandler.EditConn(context); await AppHandlerChanged.InvokeAsync(AppHandler); }">
+                        @(AppHandler.DisplayButton("edit", Icons.Edit))
+                    </button>
+                                        }
+                            <button type="button" class="btn btn-sm btn-danger" @onclick="async () =>
+                                                                                                            { await AppHandler.RequestDeleteConnection(context); await AppHandlerChanged.InvokeAsync(AppHandler); }">
+                        @(AppHandler.DisplayButton("delete", Icons.Delete))
+                    </button>
+                                        }
+                    </div>
+                </Template>
+            </Column>
+        }
+        @if(ShowSelectionColumn)
+        {
+            <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("select"))" Sortable="false" Filterable="false">
+                <Template>
+                    @if(SelectionType == SelectionType.Single)
+                    {
+                        <input type="radio" checked="@(SelectedConns.Contains(context))" />
                     }
-                </div>
-            </Template>
-        </Column>
-    }
-    @if (ShowSelectionColumn)
-    {
-        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("select"))" Sortable="false" Filterable="false">
-            <Template>
-                @if (SelectionType == SelectionType.Single)
-                {
-                    <input type="radio" checked="@(SelectedConns.Contains(context))" />
-                }
-                else if (SelectionType == SelectionType.Multiple)
-                {
-                    <input type="checkbox" checked="@(SelectedConns.Contains(context))" />
-                }
-            </Template>
-        </Column>
-    }
-    <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true" />
-    @if (!SelectInterfaceView && !DiffMode)
-    {
-        @if (Connections.Count > 0 && Connections.First().IsInterface)
-        {
-            <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("published"))" Field="@(x => x.IsPublished)" Sortable="true" Filterable="true">
-                <Template>
-                    @(context.IsPublished.ShowAsHtml())
+                    else if(SelectionType == SelectionType.Multiple)
+                    {
+                        <input type="checkbox" checked="@(SelectedConns.Contains(context))" />
+                    }
                 </Template>
             </Column>
         }
-        @if(ShowModellingState)
+        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("id"))" Field="@(x => x.Id)" Sortable="true" Filterable="true" />
+        @if(!SelectInterfaceView && !DiffMode)
         {
-            <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("mod_state"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
+            @if(Connections.Count > 0 && Connections.First().IsInterface)
+            {
+                <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("published"))" Field="@(x => x.IsPublished)" Sortable="true" Filterable="true">
+                    <Template>
+                        @(context.IsPublished.ShowAsHtml())
+                    </Template>
+                </Column>
+            }
+            @if(ShowModellingState)
+            {
+                <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("mod_state"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
+                    <Template>
+                        @((MarkupString)DisplayModState(context))
+                    </Template>
+                </Column>
+            }
+            @if(ShowProductionState && (userConfig.VarianceAnalysisSync || userConfig.VarianceAnalysisRefresh || userConfig.VarianceAnalysisSleepTime > 0))
+            {
+                <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("impl_state"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
+                    <Template>
+                        @((MarkupString)DisplayImplState(context))
+                    </Template>
+                </Column>
+            }
+        }
+        @if(ShowAppName)
+        {
+            <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("owner"))" Field="@(x => x.App.Name)" Sortable="true" Filterable="true">
                 <Template>
-                    @((MarkupString)DisplayModState(context))
+                    @(context.App?.DisplayWithoutAppId(userConfig.GetText("common_service")))
+                </Template>
+            </Column>
+            <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("ext_app_id"))" Field="@(x => x.App.ExtAppId)" Sortable="true" Filterable="true">
+                <Template>
+                    @(context.App?.ExtAppId)
                 </Template>
             </Column>
         }
-        @if(ShowProductionState && (userConfig.VarianceAnalysisSync || userConfig.VarianceAnalysisRefresh || userConfig.VarianceAnalysisSleepTime > 0))
+        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Sortable="true" Filterable="true">
+            <Template>
+                @((MarkupString)DisplayConditional(context, context.Name ?? ""))
+            </Template>
+        </Column>
+        @if(!DiffMode)
         {
-            <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("impl_state"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
+            <Column TableItem="ModellingConnection" Title="@(Connections.Count > 0 && Connections.First().IsInterface ? userConfig.GetText("interface_description") : userConfig.GetText("func_reason"))"
+                    Field="@(x => x.Reason)" Sortable="true" Filterable="true">
                 <Template>
-                    @((MarkupString)DisplayImplState(context))
+                    @((MarkupString)DisplayConditional(context, context.Reason ?? ""))
                 </Template>
             </Column>
         }
-    }
-    @if (ShowAppName)
-    {
-        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("owner"))" Field="@(x => x.App.Name)" Sortable="true" Filterable="true">
+        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("source"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
             <Template>
-                @(context.App?.DisplayWithoutAppId(userConfig.GetText("common_service")))
+                <ExpandableList2 Elements="ModellingHandlerBase.GetSrcNames(context, userConfig)" Context="src" AlwaysShowElements="@userConfig.OverviewDisplayLines">
+                    <ElementTemplate>
+                        @((MarkupString)src)
+                    </ElementTemplate>
+                </ExpandableList2>
             </Template>
         </Column>
-        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("ext_app_id"))" Field="@(x => x.App.ExtAppId)" Sortable="true" Filterable="true">
+        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("service"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
             <Template>
-                @(context.App?.ExtAppId)
+                <ExpandableList2 Elements="ModellingHandlerBase.GetSvcNames(context, userConfig)" Context="svc" AlwaysShowElements="@userConfig.OverviewDisplayLines">
+                    <ElementTemplate>
+                        @((MarkupString)svc)
+                    </ElementTemplate>
+                </ExpandableList2>
             </Template>
         </Column>
-    }    
-    <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("name"))" Field="@(x => x.Name)" Sortable="true" Filterable="true">
-        <Template>
-            @((MarkupString)DisplayConditional(context, context.Name ?? ""))
-        </Template>
-    </Column>
-    @if(!DiffMode)
-    {
-        <Column TableItem="ModellingConnection" Title="@(Connections.Count > 0 && Connections.First().IsInterface ? userConfig.GetText("interface_description") : userConfig.GetText("func_reason"))"
-                Field="@(x => x.Reason)" Sortable="true" Filterable="true">
+        <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("destination"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
             <Template>
-                @((MarkupString)DisplayConditional(context, context.Reason ?? ""))
+                <ExpandableList2 Elements="ModellingHandlerBase.GetDstNames(context, userConfig)" Context="dest" AlwaysShowElements="@userConfig.OverviewDisplayLines">
+                    <ElementTemplate>
+                        @((MarkupString)dest)
+                    </ElementTemplate>
+                </ExpandableList2>
             </Template>
         </Column>
-    }
-    <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("source"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
-        <Template>
-            <ExpandableList2 Elements="ModellingHandlerBase.GetSrcNames(context, userConfig)" Context="src" AlwaysShowElements="@userConfig.OverviewDisplayLines">
-                <ElementTemplate>
-                    @((MarkupString)src)
-                </ElementTemplate>
-            </ExpandableList2>
-        </Template>
-    </Column>
-    <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("service"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
-        <Template>
-            <ExpandableList2 Elements="ModellingHandlerBase.GetSvcNames(context, userConfig)" Context="svc" AlwaysShowElements="@userConfig.OverviewDisplayLines">
-                <ElementTemplate>
-                    @((MarkupString)svc)
-                </ElementTemplate>
-            </ExpandableList2>
-        </Template>
-    </Column>
-    <Column TableItem="ModellingConnection" Title="@(userConfig.GetText("destination"))" Field="@(x => x.Id)" Sortable="true" Filterable="false">
-        <Template>
-            <ExpandableList2 Elements="ModellingHandlerBase.GetDstNames(context, userConfig)" Context="dest" AlwaysShowElements="@userConfig.OverviewDisplayLines">
-                <ElementTemplate>
-                    @((MarkupString)dest)
-                </ElementTemplate>
-            </ExpandableList2>
-        </Template>
-    </Column>
-    <Pager ShowPageNumber="true" ShowTotalCount="true" />
-</Table>
+        <Pager ShowPageNumber="true" ShowTotalCount="true" />
+    </Table>
+</div>
 
 
 @code

--- a/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
+++ b/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor
@@ -7,7 +7,7 @@
 {
     <PageSizeComponent PageSizeCallback="UpdatePageSize"></PageSizeComponent>
 }
-<div class="connectiontable-responsive">
+<div class="@(UseResponsiveTable ? "connectiontable-responsive" : "")">
     <Table class="table table-bordered th-bg-secondary sticky-header table-responsive connectiontable" TableItem="ModellingConnection"
            Items="Connections" PageSize="PageSize" ColumnReorder="true" TableRowClass="@(con => getTableRowClass(con))"
            SelectedItems="SelectedConns" RowClickAction="@(conn => ToggleSelection(conn))">
@@ -189,6 +189,9 @@
 
     [Parameter]
     public bool ShowProductionState { get; set; } = false;
+
+    [Parameter]
+    public bool UseResponsiveTable { get; set; } = false;
 
     private int PageSize { get; set; }
 

--- a/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor.css
+++ b/roles/ui/files/FWO.UI/Shared/ConnectionTable.razor.css
@@ -1,3 +1,40 @@
-.show-scrollbar .table-responsive {
-    overflow: scroll;
+.connectiontable-responsive {
+    max-height: 40vh;
+    overflow: auto;
+}
+
+@media(height < 700px) {
+    .connectiontable-responsive {
+        max-height: 30vh;
+    }
+}
+
+@media(height > 800px) and (width > 700px) {
+    .connectiontable-responsive {
+        max-height: 45vh;
+    }
+}
+
+@media(height > 900px) and (width > 800px) {
+    .connectiontable-responsive {
+        max-height: 50vh;
+    }
+}
+
+@media(height > 900px) and (width > 1200px) {
+    .connectiontable-responsive {
+        max-height: 55vh;
+    }
+}
+
+@media(height > 1100px) and (width > 1200px) {
+    .connectiontable-responsive {
+        max-height: 60vh;
+    }
+}
+
+@media(height > 1200px) and (width > 1600px) {
+    .connectiontable-responsive {
+        max-height: 64vh;
+    }
 }

--- a/roles/ui/files/FWO.UI/Shared/MainLayout.razor
+++ b/roles/ui/files/FWO.UI/Shared/MainLayout.razor
@@ -1,4 +1,4 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 @using FWO.Middleware.Client
 @using FWO.Ui.Auth
 @using FWO.Ui.Data
@@ -23,7 +23,7 @@
 </div>
 
 <div class="main">
-    <div class="content p-4">
+    <div class="content px-4">
         @* DON'T DELETE THESE BUTTONS / They might be needed for testing *@
         @*         <button type="button" @onclick="@(() => ShowMessage("info", "info", MessageType.Info))">info</button>
         <button type="button" @onclick="@(() => ShowMessage("warning", "warning", MessageType.Warning))">warning</button>

--- a/roles/ui/files/FWO.UI/wwwroot/css/site.css
+++ b/roles/ui/files/FWO.UI/wwwroot/css/site.css
@@ -493,6 +493,10 @@ thead {
     background-color: #a4d7f5;
 }
 
+.table-responsive:has(.connectiontable) {
+    overflow-x: visible;
+}
+
 .table-responsive:has(.popover, .bs-popover-bottom, .show) {
     overflow-x: visible;
 }


### PR DESCRIPTION
Closing #3398

This implements fixed heights for connection table component definied by media queries. These media queries can be adjusted if some window sizes are reported to not look good. This also fixes the sticky header that was not working, but only for connection tables with the "UseResponsiveTable" parameter enabled.

 Following minimum window sizes and display resolutions are recommended:

- **1200p (125% Display Zoom)/1080p/1440p**
- **minimum browser window height 755px**
- **minimum browser window width 615px**

**For 1080p Display Zoom is not recommended because it alters font sizes to much**

@abarz722 Could you quick check variance report it's not affected by my changes? (The css class/selector "table-responsive:has(.connectiontable)" shouldn't be applied). 