### PR TITLE
importer: fixing 2 rulebase link bugs in MDS context

### DIFF
--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -1012,6 +1012,8 @@ ON UPDATE RESTRICT ON DELETE CASCADE;
 
 UPDATE config SET config_value = '[1,2,3,4,5,6,7,8,9,10,21,22,31]' WHERE config_key = 'availableReportTypes';
 
+insert into config (config_key, config_value, config_user) VALUES ('complianceCheckRestrictedServices', '', 0);
+
 -- adding labels (simple version without mapping tables and without foreign keys)
 
 -- CREATE TABLE label (

--- a/roles/importer/files/importer/checkpointR8x/fwcommon.py
+++ b/roles/importer/files/importer/checkpointR8x/fwcommon.py
@@ -344,7 +344,7 @@ def define_global_rulebase_link(deviceConfig, globalOrderedLayerUids, orderedLay
 
                     deviceConfig['rulebase_links'].append({
                         'from_rulebase_uid': placeholder_rulebase_uid,
-                        'from_rule_uid': placeholder_rule_uid,
+                        'from_rule_uid': '',
                         'to_rulebase_uid': orderedLayerUid,
                         'type': 'domain',
                         'is_global': False,
@@ -421,7 +421,7 @@ def add_ordered_layers_to_native_config(orderedLayerUids, show_params_rules,
                     
         # link to next ordered layer
         # in case of mds: domain ordered layers are linked once there is no global ordered layer counterpart
-        if is_global or orderedLayerIndex > global_ordered_layer_count - 1:
+        if is_global or orderedLayerIndex >= global_ordered_layer_count - 1:
             if orderedLayerIndex < len(orderedLayerUids) - 1:
                 deviceConfig['rulebase_links'].append({
                     'from_rulebase_uid': orderedLayerUid,


### PR DESCRIPTION
note: for placeholder (switch of context), some rules could be suppressed in this version (see issue https://github.com/CactuseSecurity/firewall-orchestrator/issues/3483)