### PR TITLE
PR for latest version of Compliance Check

### DIFF
--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -1316,13 +1316,6 @@
                   "role": "middleware-server",
                   "permission": {
                     "columns": [
-                      "id",
-                      "rule_id",
-                      "criterion_id",
-                      "policy_id",
-                      "risk_score",
-                      "details",
-                      "found_date",
                       "removed_date"
                     ],
                     "filter": {},

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -1310,6 +1310,26 @@
                   },
                   "comment": ""
                 }
+              ],
+              "update_permissions": [
+                {
+                  "role": "middleware-server",
+                  "permission": {
+                    "columns": [
+                      "id",
+                      "rule_id",
+                      "criterion_id",
+                      "policy_id",
+                      "risk_score",
+                      "details",
+                      "found_date",
+                      "removed_date"
+                    ],
+                    "filter": {},
+                    "check": null
+                  },
+                  "comment": ""
+                }
               ]
             },
             {

--- a/roles/common/files/fwo-api-calls/compliance/removeViolations.graphql
+++ b/roles/common/files/fwo-api-calls/compliance/removeViolations.graphql
@@ -1,0 +1,8 @@
+mutation removeViolations($ids: [Int!]!) {
+  update_compliance_violation(
+    where: { id: { _in: $ids } },
+    _set: { removed_date: now() }
+  ) {
+    affected_rows
+  }
+}

--- a/roles/common/files/fwo-api-calls/compliance/removeViolations.graphql
+++ b/roles/common/files/fwo-api-calls/compliance/removeViolations.graphql
@@ -1,7 +1,7 @@
-mutation removeViolations($ids: [Int!]!) {
+mutation removeViolations($ids: [bigint!]!, $removedAt: timestamptz!) {
   update_compliance_violation(
     where: { id: { _in: $ids } },
-    _set: { removed_date: now() }
+    _set: { removed_date: $removedAt }
   ) {
     affected_rows
   }

--- a/roles/common/files/fwo-api-calls/compliance/updateViolationById.graphql
+++ b/roles/common/files/fwo-api-calls/compliance/updateViolationById.graphql
@@ -1,4 +1,4 @@
-mutation updateViolation($id: Int!, $changes: compliance_violation_set_input!) {
+mutation updateViolation($id: bigint!, $changes: compliance_violation_set_input!) {
   update_compliance_violation_by_pk(
     pk_columns: { id: $id },
     _set: $changes

--- a/roles/common/files/fwo-api-calls/compliance/updateViolationById.graphql
+++ b/roles/common/files/fwo-api-calls/compliance/updateViolationById.graphql
@@ -1,0 +1,8 @@
+mutation updateViolation($id: Int!, $changes: compliance_violation_set_input!) {
+  update_compliance_violation_by_pk(
+    pk_columns: { id: $id },
+    _set: $changes
+  ) {
+    id
+  }
+}

--- a/roles/database/files/sql/creation/fworch-create-constraints.sql
+++ b/roles/database/files/sql/creation/fworch-create-constraints.sql
@@ -50,6 +50,7 @@ create unique index if not exists only_one_future_recert_per_owner_per_rule on r
     where recert_date IS NULL;
 
 --- compliance
+
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 ALTER TABLE compliance.ip_range ADD CONSTRAINT "exclude_overlapping_ip_ranges"
 EXCLUDE USING gist (
@@ -57,4 +58,10 @@ EXCLUDE USING gist (
     numrange(ip_range_start - '0.0.0.0'::inet, ip_range_end - '0.0.0.0'::inet, '[]') WITH &&
 )
 WHERE (removed IS NULL);
+
+--- report template
+
+ALTER TABLE report_template
+ADD CONSTRAINT unique_report_template_name UNIQUE (report_template_name);
+
 

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -286,7 +286,10 @@ INSERT INTO "report_template" ("report_filter","report_template_name","report_te
                 "start_time": "2022-01-01T00:00:00.0000000+01:00",
                 "end_time": "2022-01-01T00:00:00.0000000+01:00",
                 "open_start": false,
-                "open_end": false}}');
+                "open_end": false}}'),
+            "compliance_filter": {
+                ""
+            };
 
 insert into parent_rule_type (id, name) VALUES (1, 'section');          -- do not restart numbering
 insert into parent_rule_type (id, name) VALUES (2, 'guarded-layer');    -- restart numbering, rule restrictions are ANDed to all rules below it, layer is not entered if guard does not apply

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -291,7 +291,7 @@ INSERT INTO "report_template" ("report_filter","report_template_name","report_te
                 "isDiffReport": false,
                 "diffReferenceInDays: 0,
                 "showCompliantRules: false,
-                "excludedRuleActions": ["inner layer", "drop"]}');
+                "excludedRuleActions": ["inner layer", "drop"]}}');
 
 insert into parent_rule_type (id, name) VALUES (1, 'section');          -- do not restart numbering
 insert into parent_rule_type (id, name) VALUES (2, 'guarded-layer');    -- restart numbering, rule restrictions are ANDed to all rules below it, layer is not entered if guard does not apply

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -146,7 +146,6 @@ insert into config (config_key, config_value, config_user) VALUES ('complianceCh
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckMailRecipients', '', 0);
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckMailSubject', '', 0);
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckMailBody', '', 0);
-insert into config (config_key, config_value, config_user) VALUES ('complianceCheckPersistData', 'true', 0);
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckPolicy', '0', 0);
 insert into config (config_key, config_value, config_user) VALUES ('availableModules', '[1,2,3,4,5,6]', 0);
 insert into config (config_key, config_value, config_user) VALUES ('debugConfig', '{"debugLevel":8, "extendedLogComplianceCheck":true, "extendedLogReportGeneration":true, "extendedLogScheduler":true}', 0);

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -147,8 +147,10 @@ insert into config (config_key, config_value, config_user) VALUES ('complianceCh
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckMailSubject', '', 0);
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckMailBody', '', 0);
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckPersistData', 'true', 0);
+insert into config (config_key, config_value, config_user) VALUES ('complianceCheckPolicy', '0', 0);
 insert into config (config_key, config_value, config_user) VALUES ('availableModules', '[1,2,3,4,5,6]', 0);
 insert into config (config_key, config_value, config_user) VALUES ('debugConfig', '{"debugLevel":8, "extendedLogComplianceCheck":true, "extendedLogReportGeneration":true, "extendedLogScheduler":true}', 0);
+
 
 INSERT INTO "report_format" ("report_format_name") VALUES ('json');
 INSERT INTO "report_format" ("report_format_name") VALUES ('pdf');

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -147,6 +147,8 @@ insert into config (config_key, config_value, config_user) VALUES ('complianceCh
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckMailSubject', '', 0);
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckMailBody', '', 0);
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckPolicy', '0', 0);
+insert into config (config_key, config_value, config_user) VALUES ('complianceCheckScheduledDiffReports', '[]', 0);
+insert into config (config_key, config_value, config_user) VALUES ('complianceCheckDiffReferenceInterval', '0', 0);
 insert into config (config_key, config_value, config_user) VALUES ('availableModules', '[1,2,3,4,5,6]', 0);
 insert into config (config_key, config_value, config_user) VALUES ('debugConfig', '{"debugLevel":8, "extendedLogComplianceCheck":true, "extendedLogReportGeneration":true, "extendedLogScheduler":true}', 0);
 

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -271,6 +271,22 @@ INSERT INTO "report_template" ("report_filter","report_template_name","report_te
                 "recertOwnerList": [],
                 "recertShowAnyMatch": true,
                 "recertificationDisplayPeriod": 30}}');
+INSERT INTO "report_template" ("report_filter","report_template_name","report_template_comment","report_template_owner", "report_parameters") 
+    VALUES ('',
+        'Compliance: Unresolved violations','T0108', 0, 
+        '{"report_type":31,"device_filter":{"management":[]},
+            "time_filter": {
+                "is_shortcut": true,
+                "shortcut": "now",
+                "report_time": "2022-01-01T00:00:00.0000000+01:00",
+                "timerange_type": "SHORTCUT",
+                "shortcut_range": "this year",
+                "offset": 0,
+                "interval": "DAYS",
+                "start_time": "2022-01-01T00:00:00.0000000+01:00",
+                "end_time": "2022-01-01T00:00:00.0000000+01:00",
+                "open_start": false,
+                "open_end": false}}');
 
 insert into parent_rule_type (id, name) VALUES (1, 'section');          -- do not restart numbering
 insert into parent_rule_type (id, name) VALUES (2, 'guarded-layer');    -- restart numbering, rule restrictions are ANDed to all rules below it, layer is not entered if guard does not apply

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -286,10 +286,12 @@ INSERT INTO "report_template" ("report_filter","report_template_name","report_te
                 "start_time": "2022-01-01T00:00:00.0000000+01:00",
                 "end_time": "2022-01-01T00:00:00.0000000+01:00",
                 "open_start": false,
-                "open_end": false}}'),
+                "open_end": false}},
             "compliance_filter": {
-                ""
-            };
+                "isDiffReport": false,
+                "diffReferenceInDays: 0,
+                "showCompliantRules: false,
+                "excludedRuleActions": ["inner layer", "drop"]}');
 
 insert into parent_rule_type (id, name) VALUES (1, 'section');          -- do not restart numbering
 insert into parent_rule_type (id, name) VALUES (2, 'guarded-layer');    -- restart numbering, rule restrictions are ANDed to all rules below it, layer is not entered if guard does not apply

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -286,7 +286,7 @@ INSERT INTO "report_template" ("report_filter","report_template_name","report_te
                 "start_time": "2022-01-01T00:00:00.0000000+01:00",
                 "end_time": "2022-01-01T00:00:00.0000000+01:00",
                 "open_start": false,
-                "open_end": false}},
+                "open_end": false},
             "compliance_filter": {
                 "isDiffReport": false,
                 "diffReferenceInDays: 0,

--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -289,8 +289,8 @@ INSERT INTO "report_template" ("report_filter","report_template_name","report_te
                 "open_end": false},
             "compliance_filter": {
                 "isDiffReport": false,
-                "diffReferenceInDays: 0,
-                "showCompliantRules: false,
+                "diffReferenceInDays": 0,
+                "showCompliantRules": false,
                 "excludedRuleActions": ["inner layer", "drop"]}}');
 
 insert into parent_rule_type (id, name) VALUES (1, 'section');          -- do not restart numbering

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -3481,6 +3481,8 @@ INSERT INTO txt VALUES ('T0106', 'German',  'Aktuell aktive unbenutzte Regeln al
 INSERT INTO txt VALUES ('T0106', 'English', 'Currently active unused rules of all gateways');
 INSERT INTO txt VALUES ('T0107', 'German',  'Aktuell aktive Regeln, die zur Rezertifizierung anstehen');
 INSERT INTO txt VALUES ('T0107', 'English', 'Currently active rules with upcoming recertification');
+INSERT INTO txt VALUES ('T0108', 'German',  'Alle nicht gel&ouml;sten Compliance-Verletzungen');
+INSERT INTO txt VALUES ('T0108', 'English', 'All unresolved compliance violations');
 
 -- Contextual Info (Tooltips)
 INSERT INTO txt VALUES ('C9000', 'German',  'Dieses Objekt wurde deaktiviert und sollte von der App Rolle entfernt werden.');

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -2511,8 +2511,6 @@ INSERT INTO txt VALUES ('complianceCheckMailSubject','German','Titel der Benachr
 INSERT INTO txt VALUES ('complianceCheckMailSubject','English','Subject of notification emails');
 INSERT INTO txt VALUES ('complianceCheckMailBody','German', 'Text der Benachrichtigung');
 INSERT INTO txt VALUES ('complianceCheckMailBody','English','Body of notification emails');
-INSERT INTO txt VALUES ('complianceCheckPersistData','German', 'Daten persistieren');
-INSERT INTO txt VALUES ('complianceCheckPersistData','English','Persist Data');
 INSERT INTO txt VALUES ('complianceMatrixAllowNetworkZones','German', 'Netzwerkzonenverschachtelung erlauben');
 INSERT INTO txt VALUES ('complianceMatrixAllowNetworkZones','English','Nested Network Zones allowed');
 INSERT INTO txt VALUES ('availableModules',     'German', 	'Verf&uuml;gbare Module');

--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -1067,6 +1067,17 @@ VALUES ('',
             "open_end": false}}')
 ON CONFLICT (report_template_name) DO NOTHING;
 
+-- add compliance diff report parameters to config
+
+INSERT INTO config (config_key, config_value, config_user) 
+VALUES ('complianceCheckScheduledDiffReportConfig', '[]', 0) 
+ON CONFLICT (config_key, config_user) DO NOTHING;
+
+INSERT INTO config (config_key, config_value, config_user) 
+VALUES ('complianceCheckDiffReferenceInterval', '0', 0) 
+ON CONFLICT (config_key, config_user) DO NOTHING;
+
+
 -- adding labels (simple version without mapping tables and without foreign keys)
 
 -- CREATE TABLE label (

--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -1039,6 +1039,22 @@ INSERT INTO config (config_key, config_value, config_user)
 VALUES ('complianceCheckPersistData', 'true', 0)
 ON CONFLICT (config_key, config_user) DO NOTHING;
 
+-- add unique constraint for report_template_name
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'unique_report_template_name'
+    ) THEN
+        ALTER TABLE report_template
+        ADD CONSTRAINT unique_report_template_name UNIQUE (report_template_name);
+    END IF;
+END$$;
+
+-- add new report template for compliance: unresolved violations
+
 INSERT INTO "report_template" ("report_filter","report_template_name","report_template_comment","report_template_owner", "report_parameters") 
 VALUES ('',
     'Compliance: Unresolved violations','T0108', 0, 

--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -1027,6 +1027,19 @@ INSERT INTO config (config_key, config_value, config_user)
 VALUES ('debugConfig', '{"debugLevel":8, "extendedLogComplianceCheck":true, "extendedLogReportGeneration":true, "extendedLogScheduler":true}', 0)
 ON CONFLICT (config_key, config_user) DO NOTHING;
 
+-- add config parameter complianceCheckPolicy if not exists
+
+INSERT INTO config (config_key, config_value, config_user) 
+VALUES ('complianceCheckPolicy', '0', 0)
+ON CONFLICT (config_key, config_user) DO NOTHING;
+
+-- add config parameter complianceCheckPersistData if not exists
+
+INSERT INTO config (config_key, config_value, config_user) 
+VALUES ('complianceCheckPersistData', 'true', 0)
+ON CONFLICT (config_key, config_user) DO NOTHING;
+
+
 -- adding labels (simple version without mapping tables and without foreign keys)
 
 -- CREATE TABLE label (

--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -1033,12 +1033,6 @@ INSERT INTO config (config_key, config_value, config_user)
 VALUES ('complianceCheckPolicy', '0', 0)
 ON CONFLICT (config_key, config_user) DO NOTHING;
 
--- add config parameter complianceCheckPersistData if not exists
-
-INSERT INTO config (config_key, config_value, config_user) 
-VALUES ('complianceCheckPersistData', 'true', 0)
-ON CONFLICT (config_key, config_user) DO NOTHING;
-
 -- add unique constraint for report_template_name
 
 DO $$

--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -1039,6 +1039,23 @@ INSERT INTO config (config_key, config_value, config_user)
 VALUES ('complianceCheckPersistData', 'true', 0)
 ON CONFLICT (config_key, config_user) DO NOTHING;
 
+INSERT INTO "report_template" ("report_filter","report_template_name","report_template_comment","report_template_owner", "report_parameters") 
+VALUES ('',
+    'Compliance: Unresolved violations','T0108', 0, 
+    '{"report_type":31,"device_filter":{"management":[]},
+        "time_filter": {
+            "is_shortcut": true,
+            "shortcut": "now",
+            "report_time": "2022-01-01T00:00:00.0000000+01:00",
+            "timerange_type": "SHORTCUT",
+            "shortcut_range": "this year",
+            "offset": 0,
+            "interval": "DAYS",
+            "start_time": "2022-01-01T00:00:00.0000000+01:00",
+            "end_time": "2022-01-01T00:00:00.0000000+01:00",
+            "open_start": false,
+            "open_end": false}}')
+ON CONFLICT (report_template_name) DO NOTHING;
 
 -- adding labels (simple version without mapping tables and without foreign keys)
 

--- a/roles/importer/files/importer/common.py
+++ b/roles/importer/files/importer/common.py
@@ -251,8 +251,7 @@ def get_config_from_api(importState: ImportStateController, configNative) -> tup
         normalized_config_list = FwConfigManagerListController.generate_empty_config(importState.MgmDetails.IsSuperManager)
 
     # if we already have a native config (read from file) we do not bother to dump it again
-    if len(configNative.native_config.keys()) > 0:
-        write_native_config_to_file(importState, configNative.native_config)
+    write_native_config_to_file(importState, configNative.native_config)
 
     logger.debug("import_management: get_config completed (including normalization), duration: " + str(int(time.time()) - importState.StartTime) + "s") 
 

--- a/roles/importer/files/importer/common.py
+++ b/roles/importer/files/importer/common.py
@@ -251,7 +251,7 @@ def get_config_from_api(importState: ImportStateController, configNative) -> tup
         normalized_config_list = FwConfigManagerListController.generate_empty_config(importState.MgmDetails.IsSuperManager)
 
     # if we already have a native config (read from file) we do not bother to dump it again
-    write_native_config_to_file(importState, configNative.native_config)
+    # write_native_config_to_file(importState, configNative.native_config)
 
     logger.debug("import_management: get_config completed (including normalization), duration: " + str(int(time.time()) - importState.StartTime) + "s") 
 

--- a/roles/lib/files/FWO.Api.Client/Queries/ComplianceQueries.cs
+++ b/roles/lib/files/FWO.Api.Client/Queries/ComplianceQueries.cs
@@ -13,6 +13,7 @@ namespace FWO.Api.Client.Queries
 
         public static readonly string addViolations;
         public static readonly string getViolations;
+        public static readonly string updateViolationById;
 
         public static readonly string addPolicy;
         public static readonly string disablePolicy;
@@ -41,6 +42,7 @@ namespace FWO.Api.Client.Queries
 
                 addViolations = File.ReadAllText(QueryPath + "compliance/addViolations.graphql");
                 getViolations = File.ReadAllText(QueryPath + "compliance/getViolations.graphql");
+                updateViolationById = File.ReadAllText(QueryPath + "compliance/updateViolationById.graphql");
 
                 addPolicy = File.ReadAllText(QueryPath + "compliance/addPolicy.graphql");
                 disablePolicy = File.ReadAllText(QueryPath + "compliance/disablePolicy.graphql");

--- a/roles/lib/files/FWO.Api.Client/Queries/ComplianceQueries.cs
+++ b/roles/lib/files/FWO.Api.Client/Queries/ComplianceQueries.cs
@@ -14,6 +14,7 @@ namespace FWO.Api.Client.Queries
         public static readonly string addViolations;
         public static readonly string getViolations;
         public static readonly string updateViolationById;
+        public static readonly string removeViolations;
 
         public static readonly string addPolicy;
         public static readonly string disablePolicy;
@@ -43,6 +44,7 @@ namespace FWO.Api.Client.Queries
                 addViolations = File.ReadAllText(QueryPath + "compliance/addViolations.graphql");
                 getViolations = File.ReadAllText(QueryPath + "compliance/getViolations.graphql");
                 updateViolationById = File.ReadAllText(QueryPath + "compliance/updateViolationById.graphql");
+                removeViolations = File.ReadAllText(QueryPath + "compliance/removeViolations.graphql");
 
                 addPolicy = File.ReadAllText(QueryPath + "compliance/addPolicy.graphql");
                 disablePolicy = File.ReadAllText(QueryPath + "compliance/disablePolicy.graphql");

--- a/roles/lib/files/FWO.Basics/Comparer/ComplianceViolationComparer.cs
+++ b/roles/lib/files/FWO.Basics/Comparer/ComplianceViolationComparer.cs
@@ -1,0 +1,23 @@
+using FWO.Basics.Interfaces;
+
+namespace FWO.Basics.Comparer
+{
+    public class ComplianceViolationComparer : IEqualityComparer<IComplianceViolation>
+    {
+        public bool Equals(IComplianceViolation? x, IComplianceViolation? y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+
+            return x.RuleId == y.RuleId &&
+                x.PolicyId == y.PolicyId &&
+                x.CriterionId == y.CriterionId &&
+                x.Details == y.Details;
+        }
+
+        public int GetHashCode(IComplianceViolation obj)
+        {
+            return HashCode.Combine(obj.RuleId, obj.PolicyId, obj.CriterionId, obj.Details);
+        }
+    }
+}

--- a/roles/lib/files/FWO.Basics/Interfaces/IComplianceViolation.cs
+++ b/roles/lib/files/FWO.Basics/Interfaces/IComplianceViolation.cs
@@ -1,0 +1,15 @@
+namespace FWO.Basics.Interfaces
+{
+    public interface IComplianceViolation
+    {
+        int RuleId { get; set; }
+        DateTime FoundDate { get; set; }
+        DateTime? RemovedDate { get; set; }
+        string Details { get; set; }
+        long RiskScore { get; set; }
+        int PolicyId { get; set; }
+        int CriterionId { get; set; }
+    } 
+}
+
+

--- a/roles/lib/files/FWO.Basics/ReportType.cs
+++ b/roles/lib/files/FWO.Basics/ReportType.cs
@@ -2,6 +2,8 @@ namespace FWO.Basics
 {
     public enum ReportType
     {
+        Undefined = 0,
+
         Rules = 1,
         Changes = 2,
         Statistics = 3,
@@ -90,6 +92,11 @@ namespace FWO.Basics
                 ReportType.VarianceAnalysis => true,
                 _ => false,
             };
+        }
+
+        public static bool IsComplianceReport(this ReportType reportType)
+        {
+            return reportType == ReportType.Compliance;
         }
     }
 }

--- a/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
@@ -155,6 +155,14 @@ namespace FWO.Compliance
         {
             try
             {
+                List<ComplianceViolationBase> violations = await CreateViolationInsertObjectsAsync();
+
+                if (violations.Count == 0)
+                {
+                    Log.TryWriteLog(LogType.Info, "Compliance Check", "No new violations to persist", _debugConfig.ExtendedLogComplianceCheck);
+                    return;
+                }
+
                 var variables = new
                 {
                     violations = await CreateViolationInsertObjectsAsync()

--- a/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
@@ -260,7 +260,7 @@ namespace FWO.Compliance
 
             if (ComplianceReport is ReportCompliance complianceReport)
             {
-                foreach (ComplianceViolation existingViolation in existingViolations)
+                foreach (ComplianceViolation existingViolation in existingViolations.Where(ev => ev.RemovedDate == null).ToList())
                 {
                     ComplianceViolation? validatedViolation = complianceReport.Violations.FirstOrDefault(v =>
                                                                 v.RuleId == existingViolation.RuleId &&

--- a/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
@@ -183,13 +183,17 @@ namespace FWO.Compliance
 
                 if (violationsForRemoveTask.Result.Count == 0)
                 {
-                    Log.TryWriteLog(LogType.Info, "Compliance Check", "No violations to remove", _debugConfig.ExtendedLogComplianceCheck);
+                    Log.TryWriteLog(LogType.Info, "Compliance Check", "No violations to remove.", _debugConfig.ExtendedLogComplianceCheck);
+                }
+                else
+                {
+                    Log.TryWriteLog(LogType.Info, "Compliance Check", $"{violationsForRemoveTask.Result.Count} violations to remove.", _debugConfig.ExtendedLogComplianceCheck);
                 }
 
-                foreach ((int, ComplianceViolation) ruleIdAndViolation in violationsForRemoveTask.Result)
+                foreach ((int, ComplianceViolationBase) ruleIdAndViolation in violationsForRemoveTask.Result)
                 {
                     int id = ruleIdAndViolation.Item1;
-                    ComplianceViolation changes = ruleIdAndViolation.Item2;
+                    ComplianceViolationBase changes = ruleIdAndViolation.Item2;
 
                     object variablesUpdate = new
                     {

--- a/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
@@ -324,8 +324,13 @@ namespace FWO.Compliance
                     ComplianceViolation violation = new()
                     {
                         RuleId = (int)item.Item1.Id,
-                        Details = $"Matrix violation: {item.Item2.Item1.Name} -> {item.Item2.Item2.Name}"
+                        Details = $"Matrix violation: {item.Item2.Item1.Name} -> {item.Item2.Item2.Name}",
+                        CriterionId = _policy?.Criteria
+                                                .FirstOrDefault(criterionWrapper => criterionWrapper.Content.CriterionType == "Matrix")?
+                                                .Content.Id ?? 0,
+                        PolicyId = _policy?.Id ?? 0
                     };
+
                     complianceReport.Violations.Add(violation);
                 }
                 
@@ -451,7 +456,7 @@ namespace FWO.Compliance
             }
         }
 
-        public static List<ComplianceViolation> TryGetRestrictedServiceViolation(Rule rule, ComplianceCriterion criterion)
+        public List<ComplianceViolation> TryGetRestrictedServiceViolation(Rule rule, ComplianceCriterion criterion)
         {
             List<ComplianceViolation> violations = [];
             List<string> restrictedServices = [.. criterion.Content.Split(',').Select(s => s.Trim())
@@ -464,7 +469,9 @@ namespace FWO.Compliance
                     ComplianceViolation violation = new()
                     {
                         RuleId = (int)rule.Id,
-                        Details = $"Restricted service used: {service.Content.Name}"
+                        Details = $"Restricted service used: {service.Content.Name}",
+                        CriterionId = criterion.Id,
+                        PolicyId = _policy?.Id ?? 0
                     };
                     violations.Add(violation);
                 }

--- a/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
@@ -190,13 +190,15 @@ namespace FWO.Compliance
                     Log.TryWriteLog(LogType.Info, "Compliance Check", $"{violationsForRemoveTask.Result.Count} violations to remove.", _debugConfig.ExtendedLogComplianceCheck);
 
                     List<int> ids = violationsForRemoveTask.Result;
+                    DateTime removedAt = DateTime.UtcNow;
 
-                    object varioablesRemove = new
+                    object variablesRemove = new
                     {
-                        ids
+                        ids,
+                        removedAt
                     };
 
-                    await _apiConnection.SendQueryAsync<dynamic>(ComplianceQueries.removeViolations, varioablesRemove);
+                    await _apiConnection.SendQueryAsync<dynamic>(ComplianceQueries.removeViolations, variablesRemove);
 
                     Log.TryWriteLog(LogType.Info, "Compliance Check", $"Removed {violationsForRemoveTask.Result.Count} violations", _debugConfig.ExtendedLogComplianceCheck && violationsForRemoveTask.Result.Count > 0);                    
                 }

--- a/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
@@ -258,20 +258,25 @@ namespace FWO.Compliance
 
             if (ComplianceReport is ReportCompliance complianceReport)
             {
-                foreach (var violation in complianceReport.Violations)
+                foreach (ComplianceViolation existingViolation in existingViolations)
                 {
-                    var existingViolation = existingViolations.FirstOrDefault(ev => ev.RuleId == violation.RuleId && ev.PolicyId == violation.PolicyId && ev.CriterionId == violation.CriterionId && ev.Details == violation.Details);
-                    if (existingViolation != null)
+                    ComplianceViolation? validatedViolation = complianceReport.Violations.FirstOrDefault(v =>
+                                                                v.RuleId == existingViolation.RuleId &&
+                                                                v.PolicyId == existingViolation.PolicyId &&
+                                                                v.CriterionId == existingViolation.CriterionId &&
+                                                                v.Details == existingViolation.Details);
+                                                                
+                    if (validatedViolation == null)
                     {
                         violationsForUpdate.Add((existingViolation.Id, new ComplianceViolationBase
                         {
-                            RuleId = violation.RuleId,
-                            Details = violation.Details,
-                            FoundDate = violation.FoundDate,
+                            RuleId = existingViolation.RuleId,
+                            Details = existingViolation.Details,
+                            FoundDate = existingViolation.FoundDate,
                             RemovedDate = DateTime.Now,
-                            RiskScore = violation.RiskScore,
-                            PolicyId = violation.PolicyId,
-                            CriterionId = violation.CriterionId
+                            RiskScore = existingViolation.RiskScore,
+                            PolicyId = existingViolation.PolicyId,
+                            CriterionId = existingViolation.CriterionId
                         }));
                     }
                 }

--- a/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
@@ -302,58 +302,58 @@ namespace FWO.Compliance
             return violations;
         }
 
-        /// <summary>
-        /// Send Email with compliance report to all recipients defined in compliance settings
-        /// </summary>
-        /// <returns></returns>
-        public async Task SendComplianceCheckEmail()
-        {
-            if (_userConfig.GlobalConfig is GlobalConfig globalConfig)
-            {
-                string decryptedSecret = AesEnc.TryDecrypt(globalConfig.EmailPassword, false, "Compliance Check", "Could not decrypt mailserver password.");
+        // /// <summary>
+        // /// Send Email with compliance report to all recipients defined in compliance settings
+        // /// </summary>
+        // /// <returns></returns>
+        // public async Task SendComplianceCheckEmail()
+        // {
+        //     if (_userConfig.GlobalConfig is GlobalConfig globalConfig)
+        //     {
+        //         string decryptedSecret = AesEnc.TryDecrypt(globalConfig.EmailPassword, false, "Compliance Check", "Could not decrypt mailserver password.");
 
-                EmailConnection emailConnection = new(
-                    globalConfig.EmailServerAddress,
-                    globalConfig.EmailPort,
-                    globalConfig.EmailTls,
-                    globalConfig.EmailUser,
-                    decryptedSecret,
-                    globalConfig.EmailSenderAddress
-                );
+        //         EmailConnection emailConnection = new(
+        //             globalConfig.EmailServerAddress,
+        //             globalConfig.EmailPort,
+        //             globalConfig.EmailTls,
+        //             globalConfig.EmailUser,
+        //             decryptedSecret,
+        //             globalConfig.EmailSenderAddress
+        //         );
 
-                MailData? mail = PrepareEmail();
+        //         MailData? mail = PrepareEmail();
 
-                if (mail != null)
-                {
-                    await MailKitMailer.SendAsync(mail, emailConnection, false, new CancellationToken());
-                }
-            }
-        }
+        //         if (mail != null)
+        //         {
+        //             await MailKitMailer.SendAsync(mail, emailConnection, false, new CancellationToken());
+        //         }
+        //     }
+        // }
 
-        private MailData? PrepareEmail()
-        {
-            if (_userConfig.GlobalConfig is GlobalConfig globalConfig)
-            {
-                string subject = globalConfig.ComplianceCheckMailSubject;
-                string body = globalConfig.ComplianceCheckMailBody;
-                MailData mailData = new(EmailHelper.CollectRecipientsFromConfig(_userConfig, globalConfig.ComplianceCheckMailRecipients), subject) { Body = body };
+        // private MailData? PrepareEmail()
+        // {
+        //     if (_userConfig.GlobalConfig is GlobalConfig globalConfig)
+        //     {
+        //         string subject = globalConfig.ComplianceCheckMailSubject;
+        //         string body = globalConfig.ComplianceCheckMailBody;
+        //         MailData mailData = new(EmailHelper.CollectRecipientsFromConfig(_userConfig, globalConfig.ComplianceCheckMailRecipients), subject) { Body = body };
 
-                if (ComplianceReport is ReportCompliance complianceReport)
-                {
-                    FormFile? attachment = EmailHelper.CreateAttachment(complianceReport.ExportToCsv(), GlobalConst.kCsv, subject);
-                    if (attachment != null)
-                    {
-                        mailData.Attachments = new FormFileCollection() { attachment };
-                    }
-                }
+        //         if (ComplianceReport is ReportCompliance complianceReport)
+        //         {
+        //             FormFile? attachment = EmailHelper.CreateAttachment(complianceReport.ExportToCsv(), GlobalConst.kCsv, subject);
+        //             if (attachment != null)
+        //             {
+        //                 mailData.Attachments = new FormFileCollection() { attachment };
+        //             }
+        //         }
 
-                return mailData;
-            }
-            else
-            {
-                return null;
-            }
-        }
+        //         return mailData;
+        //     }
+        //     else
+        //     {
+        //         return null;
+        //     }
+        // }
 
         /// <summary>
         /// Compliance check used in current UI implementation

--- a/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
+++ b/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
@@ -413,9 +413,6 @@ namespace FWO.Config.Api.Data
         [JsonProperty("complianceCheckMailBody"), JsonPropertyName("complianceCheckMailBody")]
         public string ComplianceCheckMailBody { get; set; } = "";
 
-        [JsonProperty("complianceCheckPersistData"), JsonPropertyName("complianceCheckPersistData")]
-        public bool ComplianceCheckPersistData { get; set; } = false;
-
         [JsonProperty("complianceMatrixAllowNetworkZones"), JsonPropertyName("complianceMatrixAllowNetworkZones")]
         public bool ComplianceMatrixAllowNetworkZones { get; set; } = false;
 

--- a/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
+++ b/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
@@ -416,6 +416,9 @@ namespace FWO.Config.Api.Data
         [JsonProperty("complianceMatrixAllowNetworkZones"), JsonPropertyName("complianceMatrixAllowNetworkZones")]
         public bool ComplianceMatrixAllowNetworkZones { get; set; } = false;
 
+        [JsonProperty("complianceCheckScheduledDiffReportsIntervals"), JsonPropertyName("complianceCheckScheduledDiffReportsIntervals")]
+        public string ComplianceCheckScheduledDiffReportsIntervals { get; set; } = "";
+
         [JsonProperty("debugConfig"), JsonPropertyName("debugConfig")]
         public string DebugConfig { get; set; } = "";
 

--- a/roles/lib/files/FWO.Data/ComplianceViolation.cs
+++ b/roles/lib/files/FWO.Data/ComplianceViolation.cs
@@ -1,12 +1,28 @@
+using FWO.Basics.Interfaces;
 using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 namespace FWO.Data
 {
-    public class ComplianceViolation : ComplianceViolationBase
+    public class ComplianceViolation : ComplianceViolationBase, IComplianceViolation
     {
         [JsonProperty("id"), JsonPropertyName("id")]
         public int Id { get; set; }
+
+        public static ComplianceViolation Copy(ComplianceViolation violation)
+        {
+            return new()
+            {
+                Id = violation.Id,
+                RuleId = violation.RuleId,
+                FoundDate = violation.FoundDate,
+                RemovedDate = violation.RemovedDate,
+                Details = violation.Details,
+                RiskScore = violation.RiskScore,
+                PolicyId = violation.PolicyId,
+                CriterionId = violation.CriterionId
+            };
+        }
     }
 
     /// <summary>

--- a/roles/lib/files/FWO.Data/ComplianceViolation.cs
+++ b/roles/lib/files/FWO.Data/ComplianceViolation.cs
@@ -20,7 +20,7 @@ namespace FWO.Data
         [JsonProperty("found_date"), JsonPropertyName("found_date")]
         public DateTime FoundDate { get; set; } = DateTime.Now;
         [JsonProperty("removed_date"), JsonPropertyName("removed_date")]
-        public DateTime RemovedDate { get; set; } = DateTime.Now;
+        public DateTime? RemovedDate { get; set; } = null;
         [JsonProperty("details"), JsonPropertyName("details")]
         public string Details { get; set; } = "";
         [JsonProperty("risk_score"), JsonPropertyName("risk_score")]

--- a/roles/lib/files/FWO.Data/Report/ComplianceFilter.cs
+++ b/roles/lib/files/FWO.Data/Report/ComplianceFilter.cs
@@ -1,0 +1,23 @@
+namespace FWO.Data.Report
+{
+    public class ComplianceFilter
+    {
+        public bool IsDiffReport { get; set; } = false;
+        public int DiffReferenceInDays { get; set; } = 0;
+        public bool ShowCompliantRules { get; set; } = false;
+        List<RuleAction> ExcludedRuleActions { get; set; } = [];
+
+        public ComplianceFilter()
+        {
+
+        }
+
+        public ComplianceFilter(ComplianceFilter complianceFilter)
+        {
+            IsDiffReport = complianceFilter.IsDiffReport;
+            ShowCompliantRules = complianceFilter.ShowCompliantRules;
+            ExcludedRuleActions = complianceFilter.ExcludedRuleActions;
+        }
+    }
+    
+}

--- a/roles/lib/files/FWO.Data/Report/ComplianceFilter.cs
+++ b/roles/lib/files/FWO.Data/Report/ComplianceFilter.cs
@@ -5,7 +5,7 @@ namespace FWO.Data.Report
         public bool IsDiffReport { get; set; } = false;
         public int DiffReferenceInDays { get; set; } = 0;
         public bool ShowCompliantRules { get; set; } = false;
-        List<RuleAction> ExcludedRuleActions { get; set; } = [];
+        List<string> ExcludedRuleActions { get; set; } = [];
 
         public ComplianceFilter()
         {
@@ -15,6 +15,7 @@ namespace FWO.Data.Report
         public ComplianceFilter(ComplianceFilter complianceFilter)
         {
             IsDiffReport = complianceFilter.IsDiffReport;
+            DiffReferenceInDays = complianceFilter.DiffReferenceInDays;
             ShowCompliantRules = complianceFilter.ShowCompliantRules;
             ExcludedRuleActions = complianceFilter.ExcludedRuleActions;
         }

--- a/roles/lib/files/FWO.Data/Report/ReportTemplate.cs
+++ b/roles/lib/files/FWO.Data/Report/ReportTemplate.cs
@@ -71,8 +71,11 @@ namespace FWO.Data.Report
         [JsonProperty("modelling_filter"), JsonPropertyName("modelling_filter")]
         public ModellingFilter ModellingFilter { get; set; } = new();
 
+        [JsonProperty("compliance_filter"), JsonPropertyName("compliance_filter")]
+        public ComplianceFilter ComplianceFilter { get; set; } = new();
+
         public ReportParams()
-        {}
+        { }
         
         public ReportParams(int reportType, DeviceFilter deviceFilter)
         {

--- a/roles/lib/files/FWO.Data/Report/ScheduledComplianceDiffReportConfig.cs
+++ b/roles/lib/files/FWO.Data/Report/ScheduledComplianceDiffReportConfig.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+using System.Text.Json.Serialization;
+
+namespace FWO.Data.Report
+{
+    public class ScheduledComplianceDiffReportConfig
+    {
+        [JsonProperty("complianceCheckScheduledDiffReportsIntervals"), JsonPropertyName("complianceCheckScheduledDiffReportsIntervals")]
+        public Dictionary<int, int> ScheduledDiffReportsIntervals { get; set; } = new();
+        
+    }
+    
+}

--- a/roles/lib/files/FWO.Report.Filter/FilterTypes/ReportFilters.cs
+++ b/roles/lib/files/FWO.Report.Filter/FilterTypes/ReportFilters.cs
@@ -28,6 +28,8 @@ namespace FWO.Report.Filter.FilterTypes
 
         public ModellingFilter ModellingFilter { get; set; } = new();
 
+        public ComplianceFilter ComplianceFilter { get; set; } = new();
+
         public string DisplayedTimeSelection = "";
 
         private UserConfig? userConfig;
@@ -48,13 +50,13 @@ namespace FWO.Report.Filter.FilterTypes
         public void SyncFiltersFromTemplate(ReportTemplate template)
         {
             ReportType = (ReportType)template.ReportParams.ReportType;
-            if(template.ReportParams.DeviceFilter != null && template.ReportParams.DeviceFilter.Managements.Count > 0)
+            if (template.ReportParams.DeviceFilter != null && template.ReportParams.DeviceFilter.Managements.Count > 0)
             {
                 DeviceFilter.SynchronizeDevFilter(template.ReportParams.DeviceFilter);
             }
             SelectAll = !DeviceFilter.IsAnyDeviceFilterSet();
 
-            if(template.ReportParams.TimeFilter != null)
+            if (template.ReportParams.TimeFilter != null)
             {
                 TimeFilter = template.ReportParams.TimeFilter;
             }
@@ -62,6 +64,7 @@ namespace FWO.Report.Filter.FilterTypes
             RecertFilter = new(template.ReportParams.RecertFilter);
             UnusedDays = template.ReportParams.UnusedFilter.UnusedForDays;
             ModellingFilter = template.ReportParams.ModellingFilter;
+            ComplianceFilter = new(template.ReportParams.ComplianceFilter);
         }
 
         public ReportParams ToReportParams()

--- a/roles/lib/files/FWO.Report/ReportCompliance.cs
+++ b/roles/lib/files/FWO.Report/ReportCompliance.cs
@@ -181,21 +181,16 @@ namespace FWO.Report
         {
                 DateTime referenceDate = DateTime.Now.AddDays(-DiffReferenceInDays);
 
-                List<ComplianceViolation> referenceViolations = allViolations
-                                                                    .Where(violation => violation.FoundDate <= referenceDate)
-                                                                    .Where(violation => violation.RemovedDate == null || violation.RemovedDate >= referenceDate)
-                                                                    .ToList();
-
                 Dictionary<ComplianceViolation, char> violationDiffs = new();
                 ComplianceViolationComparer comparer = new();
 
-                List<ComplianceViolation> removedViolations = referenceViolations
-                                                                .Except(Violations, comparer)
+                List<ComplianceViolation> removedViolations = allViolations
+                                                                .Where(violation => violation.RemovedDate is DateTime removedDate && removedDate >= referenceDate)
                                                                 .Cast<ComplianceViolation>()
                                                                 .ToList();
 
-                List<ComplianceViolation> addedViolations = Violations
-                                                                .Except(referenceViolations, comparer)
+                List<ComplianceViolation> addedViolations = allViolations
+                                                                .Where(violation => violation.FoundDate >= referenceDate)
                                                                 .Cast<ComplianceViolation>()
                                                                 .ToList();
 
@@ -238,6 +233,14 @@ namespace FWO.Report
 
             foreach (var violation in violations.Where(v => v.RuleId == rule.Id))
             {
+                if (IsDiffReport)
+                {
+                    if (ViolationDiffs.TryGetValue(violation, out char changeSign))
+                    {
+                        violation.Details = $"({changeSign}) {violation.Details}";
+                    }
+                }
+                
                 if (rule.ViolationDetails != "")
                 {
                     rule.ViolationDetails += "\n";

--- a/roles/lib/files/FWO.Report/ReportCompliance.cs
+++ b/roles/lib/files/FWO.Report/ReportCompliance.cs
@@ -159,7 +159,7 @@ namespace FWO.Report
 
             await Task.WhenAll(baseTask, violationsTask);
 
-            Violations = violationsTask.Result;
+            Violations = violationsTask.Result.Where(v => v.RemovedDate == null).ToList();
             await SetComplianceData();
         }
 

--- a/roles/lib/files/FWO.Report/ReportCompliance.cs
+++ b/roles/lib/files/FWO.Report/ReportCompliance.cs
@@ -14,6 +14,7 @@ namespace FWO.Report
     {
         public ReportCompliance(DynGraphqlQuery query, UserConfig userConfig, ReportType reportType) : base(query, userConfig, reportType) { }
         public List<ComplianceViolation> Violations { get; set; } = [];
+        public List<ComplianceViolation> NewViolations { get; set; } = [];
         public List<Rule> Rules { get; set; } = [];
 
         private readonly bool _includeHeaderInExport = true;

--- a/roles/lib/files/FWO.Report/ReportCompliance.cs
+++ b/roles/lib/files/FWO.Report/ReportCompliance.cs
@@ -233,12 +233,9 @@ namespace FWO.Report
 
             foreach (var violation in violations.Where(v => v.RuleId == rule.Id))
             {
-                if (IsDiffReport)
+                if (IsDiffReport && ViolationDiffs.TryGetValue(violation, out char changeSign))
                 {
-                    if (ViolationDiffs.TryGetValue(violation, out char changeSign))
-                    {
-                        violation.Details = $"({changeSign}) {violation.Details}";
-                    }
+                    violation.Details = $"({changeSign}) {violation.Details}";
                 }
                 
                 if (rule.ViolationDetails != "")

--- a/roles/middleware/files/FWO.Middleware.Server/ComplianceCheckScheduler.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ComplianceCheckScheduler.cs
@@ -51,7 +51,7 @@ namespace FWO.Middleware.Server
                 ComplianceCheck complianceCheck = new(userConfig, apiConnection);
 
                 await complianceCheck.CheckAll();
-                await complianceCheck.SendComplianceCheckEmail();
+                await complianceCheck.PersistData();
             }
             catch (Exception exc)
             {

--- a/roles/middleware/files/FWO.Middleware.Server/ComplianceCheckScheduler.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ComplianceCheckScheduler.cs
@@ -51,7 +51,7 @@ namespace FWO.Middleware.Server
                 ComplianceCheck complianceCheck = new(userConfig, apiConnection);
 
                 await complianceCheck.CheckAll();
-                await complianceCheck.PersistData();
+                await complianceCheck.PersistDataAsync();
             }
             catch (Exception exc)
             {

--- a/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
@@ -12,6 +12,8 @@ using FWO.Services;
 using System.Timers;
 using FWO.Config.File;
 using System.Collections.Concurrent;
+using FWO.Encryption;
+using FWO.Mail;
 
 namespace FWO.Middleware.Server
 {
@@ -26,15 +28,20 @@ namespace FWO.Middleware.Server
         private readonly string apiServerUri;
         private readonly ApiConnection apiConnectionScheduler;
         private ApiConnection? apiConnectionUserContext;
-        private UserConfig? userConfig;
+        private UserConfig? _userConfig;
         private readonly JwtWriter jwtWriter;
         private const string LogMessageTitle = "Report Scheduling";
 
         private List<Ldap> connectedLdaps;
 
-		/// <summary>
-		/// Async Constructor needing the connection, jwtWriter and subscription
-		/// </summary>
+        private ReportBase? _report = null;
+        private ReportFile? _reportFile = null;
+        private List<FileFormat>? _fileFormats = null;
+
+
+        /// <summary>
+        /// Async Constructor needing the connection, jwtWriter and subscription
+        /// </summary>
         public static async Task<ReportScheduler> CreateAsync(ApiConnection apiConnection, JwtWriter jwtWriter, GraphQlApiSubscription<List<Ldap>> connectedLdapsSubscription)
         {
             GlobalConfig globalConfig = await GlobalConfig.ConstructAsync(apiConnection, true);
@@ -44,7 +51,7 @@ namespace FWO.Middleware.Server
         private ReportScheduler(ApiConnection apiConnection, GlobalConfig globalConfig, JwtWriter jwtWriter, GraphQlApiSubscription<List<Ldap>> connectedLdapsSubscription)
             : base(apiConnection, globalConfig, ReportQueries.subscribeReportScheduleChanges, SchedulerInterval.Minutes, "Report")
         {
-            this.jwtWriter = jwtWriter;            
+            this.jwtWriter = jwtWriter;
             apiConnectionScheduler = apiConnection;
             apiServerUri = ConfigFile.ApiServerUri;
 
@@ -58,19 +65,19 @@ namespace FWO.Middleware.Server
 
         private void OnLdapUpdate(List<Ldap> connectedLdaps)
         {
-            this.connectedLdaps = connectedLdaps;            
+            this.connectedLdaps = connectedLdaps;
         }
 
         private void OnScheduleUpdate(ReportSchedule[] scheduledReports)
         {
-            this.scheduledReports = [.. scheduledReports];            
+            this.scheduledReports = [.. scheduledReports];
         }
 
-		/// <summary>
-		/// set scheduling timer from config values (not applicable here)
-		/// </summary>
+        /// <summary>
+        /// set scheduling timer from config values (not applicable here)
+        /// </summary>
         protected override void OnGlobalConfigChange(List<ConfigItem> config)
-        {}
+        { }
 
         /// <summary>
         /// define the processing to be done
@@ -79,15 +86,15 @@ namespace FWO.Middleware.Server
         {
             DateTime dateTimeNowRounded = RoundDown(DateTime.Now, CheckScheduleInterval);
 
-            await Parallel.ForEachAsync(scheduledReports, new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount }, 
-                async (reportSchedule,  ct) =>
+            await Parallel.ForEachAsync(scheduledReports, new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount },
+                async (reportSchedule, ct) =>
                 {
                     try
                     {
-                        if(reportSchedule.Active)
+                        if (reportSchedule.Active)
                         {
                             // Add schedule interval as long as schedule time is smaller then current time 
-                            while(RoundDown(reportSchedule.StartTime, CheckScheduleInterval) < dateTimeNowRounded)
+                            while (RoundDown(reportSchedule.StartTime, CheckScheduleInterval) < dateTimeNowRounded)
                             {
                                 reportSchedule.StartTime = reportSchedule.RepeatInterval switch
                                 {
@@ -100,13 +107,13 @@ namespace FWO.Middleware.Server
                                 };
                             }
 
-                            if(RoundDown(reportSchedule.StartTime, CheckScheduleInterval) == dateTimeNowRounded)
+                            if (RoundDown(reportSchedule.StartTime, CheckScheduleInterval) == dateTimeNowRounded)
                             {
                                 await GenerateReport(reportSchedule, dateTimeNowRounded, ct);
                             }
                         }
                     }
-                    catch(Exception exception)
+                    catch (Exception exception)
                     {
                         Log.WriteError(LogMessageTitle, "Checking scheduled reports lead to exception.", exception);
                     }
@@ -116,19 +123,21 @@ namespace FWO.Middleware.Server
 
         private async Task GenerateReport(ReportSchedule reportSchedule, DateTime dateTimeNowRounded, CancellationToken token)
         {
+            _fileFormats = reportSchedule.OutputFormat;
+
             await Task.Run(async () =>
             {
                 try
                 {
                     Log.WriteInfo(LogMessageTitle, $"Generating scheduled report \"{reportSchedule.Name}\" with id \"{reportSchedule.Id}\" for user \"{reportSchedule.ScheduleOwningUser.Name}\" with id \"{reportSchedule.ScheduleOwningUser.DbId}\" ...");
 
-                    if(!await InitUserEnvironment(reportSchedule) || apiConnectionUserContext == null || userConfig == null)
+                    if (!await InitUserEnvironment(reportSchedule) || apiConnectionUserContext == null || _userConfig == null)
                     {
                         return;
                     }
 
-                    ReportFile reportFile = new ()
-                    { 
+                    _reportFile = new()
+                    {
                         Name = $"{reportSchedule.Name}_{dateTimeNowRounded.ToShortDateString()}",
                         GenerationDateStart = DateTime.Now,
                         TemplateId = reportSchedule.Template.Id,
@@ -139,20 +148,24 @@ namespace FWO.Middleware.Server
                     await apiConnectionUserContext.SendQueryAsync<object>(ReportQueries.countReportSchedule, new { report_schedule_id = reportSchedule.Id });
                     await AdaptDeviceFilter(reportSchedule.Template.ReportParams, apiConnectionUserContext);
 
-                    ReportBase? report = await ReportGenerator.Generate(reportSchedule.Template, apiConnectionUserContext, userConfig, DefaultInit.DoNothing, token);
-                    if(report != null)
+                    _report = await ReportGenerator.Generate(reportSchedule.Template, apiConnectionUserContext, _userConfig, DefaultInit.DoNothing, token);
+                    if (_report != null)
                     {
-                        await report.GetObjectsInReport(int.MaxValue, apiConnectionUserContext, _ => Task.CompletedTask);
-                        await WriteReportFile(report, reportSchedule.OutputFormat, reportFile);
-                        await SaveReport(reportFile, report.SetDescription(), apiConnectionUserContext);
+                        await _report.GetObjectsInReport(int.MaxValue, apiConnectionUserContext, _ => Task.CompletedTask);
+                        await WriteReportFile(_report, reportSchedule.OutputFormat, _reportFile);
+                        await SaveReport(_reportFile, _report.SetDescription(), apiConnectionUserContext);
                         Log.WriteInfo(LogMessageTitle, $"Scheduled report \"{reportSchedule.Name}\" with id \"{reportSchedule.Id}\" for user \"{reportSchedule.ScheduleOwningUser.Name}\" with id \"{reportSchedule.ScheduleOwningUser.DbId}\" successfully generated.");
+                        if (!string.IsNullOrWhiteSpace(_userConfig?.GlobalConfig?.ComplianceCheckMailRecipients))
+                        {
+                            await SendComplianceCheckEmail();
+                        }
                     }
                     else
                     {
                         Log.WriteInfo(LogMessageTitle, $"Scheduled report \"{reportSchedule.Name}\" with id \"{reportSchedule.Id}\" for user \"{reportSchedule.ScheduleOwningUser.Name}\" with id \"{reportSchedule.ScheduleOwningUser.DbId}\" was empty.");
                     }
                 }
-                catch(TaskCanceledException)
+                catch (TaskCanceledException)
                 {
                     Log.WriteWarning(LogMessageTitle, $"Generating scheduled report \"{reportSchedule.Name}\" was cancelled");
                 }
@@ -165,17 +178,17 @@ namespace FWO.Middleware.Server
 
         private async Task<bool> InitUserEnvironment(ReportSchedule reportSchedule)
         {
-            AuthManager authManager = new (jwtWriter, connectedLdaps, apiConnectionScheduler);
+            AuthManager authManager = new(jwtWriter, connectedLdaps, apiConnectionScheduler);
             string jwt = await authManager.AuthorizeUserAsync(reportSchedule.ScheduleOwningUser, validatePassword: false, lifetime: TimeSpan.FromDays(365));
             apiConnectionUserContext = new GraphQlApiConnection(apiServerUri, jwt);
             GlobalConfig globalConfig = await GlobalConfig.ConstructAsync(jwt);
-            userConfig = await UserConfig.ConstructAsync(globalConfig, apiConnectionUserContext, reportSchedule.ScheduleOwningUser.DbId);
+            _userConfig = await UserConfig.ConstructAsync(globalConfig, apiConnectionUserContext, reportSchedule.ScheduleOwningUser.DbId);
 
-            if(((ReportType)reportSchedule.Template.ReportParams.ReportType).IsModellingReport())
+            if (((ReportType)reportSchedule.Template.ReportParams.ReportType).IsModellingReport())
             {
-                userConfig.User.Groups = reportSchedule.ScheduleOwningUser.Groups;
-                await UiUserHandler.GetOwnerships(apiConnectionUserContext, userConfig.User);
-                if(!userConfig.User.Ownerships.Contains(reportSchedule.Template.ReportParams.ModellingFilter.SelectedOwner.Id))
+                _userConfig.User.Groups = reportSchedule.ScheduleOwningUser.Groups;
+                await UiUserHandler.GetOwnerships(apiConnectionUserContext, _userConfig.User);
+                if (!_userConfig.User.Ownerships.Contains(reportSchedule.Template.ReportParams.ModellingFilter.SelectedOwner.Id))
                 {
                     Log.WriteInfo(LogMessageTitle, "Report not generated as owner is not valid anymore.");
                     return false;
@@ -188,13 +201,13 @@ namespace FWO.Middleware.Server
         {
             try
             {
-                if(!reportParams.DeviceFilter.IsAnyDeviceFilterSet())
+                if (!reportParams.DeviceFilter.IsAnyDeviceFilterSet())
                 {
                     // for scheduling no device selection means "all"
                     reportParams.DeviceFilter.Managements = await apiConnectionUser.SendQueryAsync<List<ManagementSelect>>(DeviceQueries.getDevicesByManagement);
                     reportParams.DeviceFilter.ApplyFullDeviceSelection(true);
                 }
-                if(reportParams.ReportType == (int)ReportType.UnusedRules)
+                if (reportParams.ReportType == (int)ReportType.UnusedRules)
                 {
                     reportParams.DeviceFilter = (await ReportDevicesBase.GetUsageDataUnsupportedDevices(apiConnectionUser, reportParams.DeviceFilter)).reducedDeviceFilter;
                 }
@@ -267,6 +280,90 @@ namespace FWO.Middleware.Server
         {
             long delta = dateTime.Ticks % roundInterval.Ticks;
             return new DateTime(dateTime.Ticks - delta);
+        }
+        
+        /// <summary>
+        /// Send Email with compliance report to all recipients defined in compliance settings
+        /// </summary>
+        /// <returns></returns>
+        public async Task SendComplianceCheckEmail()
+        {
+            if (_userConfig?.GlobalConfig is GlobalConfig globalConfig)
+            {
+                string decryptedSecret = AesEnc.TryDecrypt(globalConfig.EmailPassword, false, "Report Scheduler", "Could not decrypt mailserver password.");
+
+                EmailConnection emailConnection = new(
+                    globalConfig.EmailServerAddress,
+                    globalConfig.EmailPort,
+                    globalConfig.EmailTls,
+                    globalConfig.EmailUser,
+                    decryptedSecret,
+                    globalConfig.EmailSenderAddress
+                );
+
+                MailData? mail = PrepareEmail();
+
+                if (mail != null)
+                {
+                    bool emailSend = await MailKitMailer.SendAsync(mail, emailConnection, false, new CancellationToken());
+                    if (emailSend)
+                    {
+                        Log.WriteInfo(LogMessageTitle, "Report email sent successfully.");
+                    }
+                    else
+                    {
+                        Log.WriteError(LogMessageTitle, "Report email could not be sent.");
+                    }
+                }
+            }
+        }
+
+        private MailData? PrepareEmail()
+        {
+            if (_userConfig?.GlobalConfig is GlobalConfig globalConfig && _reportFile is ReportFile reportFile && _fileFormats is List<FileFormat> fileFormats)
+            {
+                string subject = globalConfig.ComplianceCheckMailSubject;
+                string body = globalConfig.ComplianceCheckMailBody;
+                MailData mailData = new(EmailHelper.CollectRecipientsFromConfig(_userConfig, globalConfig.ComplianceCheckMailRecipients), subject) { Body = body };
+                FormFile? attachment;
+                mailData.Attachments = new FormFileCollection();
+
+                foreach (FileFormat format in fileFormats)
+                {
+                    switch (format.Name)
+                    {
+                        case GlobalConst.kCsv:
+                            attachment = EmailHelper.CreateAttachment(reportFile.Csv, GlobalConst.kCsv, subject);
+                            break;
+
+                        case GlobalConst.kHtml:
+                            attachment = EmailHelper.CreateAttachment(reportFile.Html, GlobalConst.kHtml, subject);
+                            break;
+
+                        case GlobalConst.kPdf:
+                            attachment = EmailHelper.CreateAttachment(reportFile.Pdf, GlobalConst.kPdf, subject);
+                            break;
+
+                        case GlobalConst.kJson:
+                            attachment = null;
+                            break;
+
+                        default:
+                            throw new NotSupportedException("Output format is not supported.");
+                    }
+
+                    if (attachment != null)
+                    {
+                        ((FormFileCollection) mailData.Attachments).Add(attachment);
+                    }
+                }
+
+                return mailData;
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
@@ -153,7 +153,8 @@ namespace FWO.Middleware.Server
                     {
                         if (_userConfig.GlobalConfig is GlobalConfig globalConfig && !string.IsNullOrEmpty(globalConfig.ComplianceCheckScheduledDiffReportsIntervals))
                         {
-                            ScheduledComplianceDiffReportConfig complianceDiffReportConfig = JsonSerializer.Deserialize<ScheduledComplianceDiffReportConfig>(globalConfig.ComplianceCheckScheduledDiffReportsIntervals) ?? new();
+                            ScheduledComplianceDiffReportConfig complianceDiffReportConfig = new();
+                            complianceDiffReportConfig.ScheduledDiffReportsIntervals = JsonSerializer.Deserialize<Dictionary<int,int>>(globalConfig.ComplianceCheckScheduledDiffReportsIntervals) ?? new();
 
                             if (complianceDiffReportConfig.ScheduledDiffReportsIntervals.Keys.Any(scheduledReportId => scheduledReportId == reportSchedule.Id))
                             {

--- a/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ReportScheduler.cs
@@ -148,7 +148,7 @@ namespace FWO.Middleware.Server
 
                     await apiConnectionUserContext.SendQueryAsync<object>(ReportQueries.countReportSchedule, new { report_schedule_id = reportSchedule.Id });
                     await AdaptDeviceFilter(reportSchedule.Template.ReportParams, apiConnectionUserContext);
-                    await TryAdaptComplianceDiffReportConfig();
+                    await TryAdaptComplianceDiffReportConfig(reportSchedule);
 
                     _report = await ReportGenerator.Generate(reportSchedule.Template, apiConnectionUserContext, _userConfig, DefaultInit.DoNothing, token);
                     if (_report != null)

--- a/roles/tests-unit/files/FWO.Test/ReportComplianceTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ReportComplianceTest.cs
@@ -1,0 +1,96 @@
+using FWO.Data;
+using FWO.Report;
+using NUnit.Framework;
+
+namespace FWO.Test
+{
+    [TestFixture]
+    internal class ReportComplianceTest
+    {
+        private ReportCompliance _complianceReport => new(new(""), new(), Basics.ReportType.Compliance);
+        private ReportCompliance _testReport = default!;
+
+        [SetUp]
+        public void SetUpTest()
+        {
+            _testReport = _complianceReport;
+        }
+
+        [Test]
+        public async Task GetViolationDiffs_MinimalTestData_CreatesCorrectDiffs()
+        {
+            // ARRANGE
+
+            _testReport.DiffReferenceInDays = 7;
+
+            Dictionary<ComplianceViolation, char> violationDiffs = new();
+
+            List<ComplianceViolation> allViolations = new();
+
+            ComplianceViolation unchanged = new()
+            {
+                Id = 1,
+                RuleId = 1,
+                FoundDate = DateTime.Now.AddDays(-(_testReport.DiffReferenceInDays + 1)),
+                Details = "Test violation 1",
+                RiskScore = 0,
+                PolicyId = 1,
+                CriterionId = 1
+            };
+
+            ComplianceViolation removed = new()
+            {
+                Id = 2,
+                RuleId = 1,
+                FoundDate = DateTime.Now.AddDays(-(_testReport.DiffReferenceInDays + 1)),
+                RemovedDate = DateTime.Now.AddDays(-1),
+                Details = "Test violation 2",
+                RiskScore = 0,
+                PolicyId = 1,
+                CriterionId = 2
+            };
+
+            ComplianceViolation irrelevant = new()
+            {
+                Id = 3,
+                RuleId = 1,
+                FoundDate = DateTime.Now.AddDays(-(_testReport.DiffReferenceInDays + 2)),
+                RemovedDate = DateTime.Now.AddDays(-(_testReport.DiffReferenceInDays + 1)),
+                Details = "Test violation 3",
+                RiskScore = 0,
+                PolicyId = 1,
+                CriterionId = 2
+            };
+
+            ComplianceViolation added = new()
+            {
+                Id = 4,
+                RuleId = 1,
+                FoundDate = DateTime.Now.AddDays(-1),
+                Details = "Test violation 4",
+                RiskScore = 0,
+                PolicyId = 1,
+                CriterionId = 3
+            };
+
+            allViolations.AddRange([unchanged, removed, irrelevant, added]);
+
+            _testReport.Violations.AddRange([unchanged, added]);
+
+            // ACT
+
+            violationDiffs = await _testReport.GetViolationDiffs(allViolations);
+
+            // ASSERT
+
+            Assert.That(!violationDiffs.Keys.Contains(unchanged));
+            Assert.That(violationDiffs[removed] == '-');
+            Assert.That(!violationDiffs.Keys.Contains(irrelevant));
+            Assert.That(violationDiffs[added] == '+');
+
+        }
+
+
+    }
+
+}

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
@@ -55,7 +55,7 @@
     </Table>
 </div>
 
-<PopUp Size=PopupSize.Large Title="@(_userConfig.GetText("report_schedule"))" Show="@(ShowAddReportScheduleDialog || ShowEditReportScheduleDialog)">
+<PopUp Size=PopupSize.XLarge Title="@(_userConfig.GetText("report_schedule"))" Show="@(ShowAddReportScheduleDialog || ShowEditReportScheduleDialog)">
     <Body>
         <div>
             <div class="form-group row">
@@ -105,7 +105,7 @@
             <div class="form-group row mt-2">
                 <label for="scheduleOutputFormat" class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("output_format")):</label>
                 <div class="col-sm-8">
-                    <div class="form-inline justify-content-between">
+                    <div class="d-flex flex-wrap gap-3">
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" id="outputFormatHtml" value="Html"
                                    checked="@(reportScheduleInEdit.OutputFormat.Exists(format => format.Name == GlobalConst.kHtml))"
@@ -137,46 +137,62 @@
                         {
                             reportScheduleInEdit.OutputFormat.Remove(GlobalConst.kCsv);
                         }
-
-                        @if (reportScheduleInEdit.Template.ReportParams != null && GetReportType().IsComplianceReport()) @* Restriction on compliance report solely while development. Dont have the time to verify, wether this works for every report type *@
-                        {
-                            <div class="form-group row mt-2" data-toggle="tooltip" title="@(_userConfig.PureLine("H5810"))">
-                                <label class="col-form-label col-sm-4">@(_userConfig.GetText("policy"))*:</label>
-                                <div class="col-sm-2">
-                                    <Dropdown ElementType="CompliancePolicy" ElementToString="@(p => p.Name)" @bind-SelectedElement="_actPolicy" Elements="_policies">
-                                        <ElementTemplate Context="policy">
-                                            @policy.Name
-                                        </ElementTemplate>
-                                    </Dropdown>
-                                </div>
-                            </div>
-                        }
-
-                        @* Mail config *@
-                        @if (reportScheduleInEdit.Template.ReportParams != null && GetReportType().IsComplianceReport()) @* Restriction on compliance report solely while development. Dont have the time to verify, wether this works for every report type *@
-                        {
-                            <div class="form-group row" data-toggle="tooltip" title="@(_userConfig.PureLine("H5804"))">
-                                <label class="col-form-label col-sm-4">@(_userConfig.GetText("complianceCheckMailRecipients")):</label>
-                                <div class="col-sm-7" data-toggle="tooltip" title="@(_userConfig.GetText("U5320"))">
-                                    <input type="text" @bind="_configData!.ComplianceCheckMailRecipients" />
-                                </div>
-                            </div>
-                            <div class="form-group row mt-2" data-toggle="tooltip" title="@(_userConfig.PureLine("H5805"))">
-                                <label class="col-form-label col-sm-4">@(_userConfig.GetText("complianceCheckMailSubject")):</label>
-                                <div class="col-sm-7">
-                                    <input type="text" @bind="_configData!.ComplianceCheckMailSubject" />
-                                </div>
-                            </div>
-                            <div class="form-group row" data-toggle="tooltip" title="@(_userConfig.PureLine("H5806"))">
-                                <label class="col-form-label col-sm-4">@(_userConfig.GetText("complianceCheckMailBody")):</label>
-                                <div class="col-sm-7">
-                                    <textarea rows="6" cols="60" name="text" placeholder=@(_userConfig.GetText("complianceCheckMailBody")) @bind="_configData!.ComplianceCheckMailBody"></textarea>
-                                </div>
-                            </div>
-                        }
                     </div>
                 </div>
             </div>
+
+            
+            @if (reportScheduleInEdit.Template.ReportParams != null && GetReportType().IsComplianceReport())
+            {
+                @* Mail config *@
+
+                <div class="form-group row mt-2" data-toggle="tooltip" title="@(_userConfig.PureLine("H5804"))">
+                    <label class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("complianceCheckMailRecipients")):</label>
+                    <div class="col-sm-8" data-toggle="tooltip" title="@(_userConfig.GetText("U5320"))">
+                        <input type="text" @bind="_configData!.ComplianceCheckMailRecipients" class="form-control form-control-sm"/>
+                    </div>
+                </div>
+                <div class="form-group row mt-2" data-toggle="tooltip" title="@(_userConfig.PureLine("H5805"))">
+                    <label class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("complianceCheckMailSubject")):</label>
+                    <div class="col-sm-8">
+                        <input type="text" @bind="_configData!.ComplianceCheckMailSubject" class="form-control form-control-sm"/>
+                    </div>
+                </div>
+                <div class="form-group row mt-2" data-toggle="tooltip" title="@(_userConfig.PureLine("H5806"))">
+                    <label class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("complianceCheckMailBody")):</label>
+                    <div class="col-sm-8">
+                        <textarea rows="6" cols="60" name="text" placeholder=@(_userConfig.GetText("complianceCheckMailBody")) @bind="_configData!.ComplianceCheckMailBody" class="form-control form-control-sm"></textarea>
+                    </div>
+                </div>
+
+                @* Compliance specific *@
+
+                <div class="form-group row mt-2" data-toggle="tooltip" title="@(_userConfig.PureLine("H5810"))">
+                    <label class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("policy"))*:</label>
+                    <div class="col-sm-8">
+                        <Dropdown ElementType="CompliancePolicy" ElementToString="@(p => p.Name)" @bind-SelectedElement="_actPolicy" Elements="_policies">
+                            <ElementTemplate Context="policy">
+                                @policy.Name
+                            </ElementTemplate>
+                        </Dropdown>
+                    </div>
+                </div>
+
+                <div class="form-group row mt-2">
+                    <div class="col-sm-6 d-flex align-items-center">
+                        <label for="scheduleActive" class="col-sm-3 col-form-label col-form-label-sm">Diff-Report:</label>
+                        <div class="col-sm-8" style="padding-top: calc(0.25rem + 1px);">
+                            <input id="scheduleActive" type="checkbox" style="max-height: 22px;" @bind="reportScheduleInEdit.Template.ReportParams.ComplianceFilter.IsDiffReport" />
+                        </div>
+                    </div>
+                    <div class="col-sm-6 d-flex align-items-center">
+                        <label for="intervalDays" class="col-sm-3 col-form-label col-form-label-sm">Diff interval (in days):</label>
+                        <input id="intervalDays" type="number" class="form-control form-control-sm" style="width: 80px;" min="1" max="365" @bind="reportScheduleInEdit.Template.ReportParams.ComplianceFilter.DiffReferenceInDays"/> 
+                    </div>
+                </div>
+            }
+
+
             <div class="form-group row mt-2">
                 <label for="scheduleActive" class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("active")):</label>
                 <div class="col-sm-8" style="padding-top: calc(0.25rem + 1px);">
@@ -342,6 +358,10 @@
                 reportScheduleInEdit.Id = (await apiConnection.SendQueryAsync<ReturnIdWrapper>(ReportQueries.addReportSchedule, queryVariablesReportSchedule)).ReturnIds[0].NewId;
 
                 ShowAddReportScheduleDialog = false;
+
+                // update config
+
+                await _globalConfig.WriteToDatabase(_configData, apiConnection);
             }
         }
         catch (Exception exception)
@@ -380,6 +400,10 @@
                 await apiConnection.SendQueryAsync<object>(ReportQueries.editReportSchedule, queryVariables);
 
                 ShowEditReportScheduleDialog = false;
+
+                // update config
+
+                await _globalConfig.WriteToDatabase(_configData, apiConnection);
             }
         }
         catch (Exception exception)

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
@@ -453,9 +453,14 @@
     {
         if (reportScheduleInEdit.Template.ReportParams.ReportType == (int) ReportType.Compliance)
         {
-            if (_userConfig.GlobalConfig is GlobalConfig globalConfig && !string.IsNullOrEmpty(globalConfig.ComplianceCheckScheduledDiffReportsIntervals))
+            if (_userConfig.GlobalConfig is GlobalConfig globalConfig)
             {
-                _complianceDiffReportConfig = JsonSerializer.Deserialize<ScheduledComplianceDiffReportConfig>(globalConfig.ComplianceCheckScheduledDiffReportsIntervals) ?? new();
+                _complianceDiffReportConfig = new();
+
+                if(!string.IsNullOrEmpty(globalConfig.ComplianceCheckScheduledDiffReportsIntervals))
+                {
+                    _complianceDiffReportConfig.ScheduledDiffReportsIntervals = JsonSerializer.Deserialize<Dictionary<int, int>>(globalConfig.ComplianceCheckScheduledDiffReportsIntervals) ?? new();
+                }
 
                 if (_complianceDiffReportConfig.ScheduledDiffReportsIntervals.Keys.Any(scheduledReportId => scheduledReportId == reportScheduleInEdit.Id))
                 {

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
@@ -122,7 +122,7 @@
                                    @onchange="@(_ => reportScheduleInEdit.OutputFormat.AddOrRemove(GlobalConst.kJson))">
                             <label class="form-check-label" for="outputFormatJson">JSON</label>
                         </div>
-                        @if (reportScheduleInEdit.Template.ReportParams != null && ((ReportType)reportScheduleInEdit.Template.ReportParams.ReportType).IsResolvedReport())
+                        @if (reportScheduleInEdit.Template.ReportParams != null && (GetReportType().IsResolvedReport() || GetReportType().IsComplianceReport()))
                         {
                             <div class="form-check">
                                 <input class="form-check-input" type="checkbox" id="outputFormatCsv" value="Csv"
@@ -345,6 +345,16 @@
             return false;
         }
         return true;
+    }
+
+    private ReportType GetReportType()
+    {
+        if (reportScheduleInEdit.Template?.ReportParams?.ReportType != null)
+        {
+            return (ReportType)reportScheduleInEdit.Template.ReportParams.ReportType;
+        }
+
+        return ReportType.Undefined;
     }
 
     public void Dispose()

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
@@ -1,5 +1,6 @@
 ﻿@using FWO.Config.Api.Data
 @using FWO.Report.Filter
+@using System.Text.Json;
 
 @implements IDisposable
 
@@ -12,7 +13,7 @@
 
 <ReportTabset/>
 
-<button type="button" class="btn btn-sm btn-success mb-1" @onclick="() => { reportScheduleInEdit = new ReportSchedule() { RepeatInterval = SchedulerInterval.Never }; ShowAddReportScheduleDialog = true; }">@(_userConfig.GetText("add"))</button>
+<button type="button" class="btn btn-sm btn-success mb-1" @onclick="OnAddReportScheduleButtonClick">@(_userConfig.GetText("add"))</button>
 
 <div class="vheight75">
     <Table TableClass="table table-bordered table-sm th-bg-secondary table-responsive overflow-auto sticky-header" TableItem="ReportSchedule" Items="reportSchedules" PageSize="0">
@@ -21,7 +22,7 @@
                 @if (context.ScheduleOwningUser.DbId == uiUserDbId || authenticationState != null && authenticationState.User.IsInRole(Roles.Admin))
                 {
                     <div class="btn-group">
-                        <button type="button" class="btn btn-sm btn-warning" @onclick="() => { reportScheduleInEdit = context; actDate = actTime = context.StartTime; ShowEditReportScheduleDialog = true; }">@(_userConfig.GetText("edit"))</button>
+                        <button type="button" class="btn btn-sm btn-warning" @onclick="() => OnEditReportScheduleButtonClick(context)">@(_userConfig.GetText("edit"))</button>
                         <button type="button" class="btn btn-sm btn-danger" @onclick="() => { reportScheduleInEdit = context; ShowDeleteReportScheduleDialog = true; }">@(_userConfig.GetText("delete"))</button>
                     </div>
                 }
@@ -256,28 +257,8 @@
     private List<CompliancePolicy> _policies = [];
     private CompliancePolicy? _actPolicy;
     private ConfigData? _configData;
+    private ScheduledComplianceDiffReportConfig? _complianceDiffReportConfig = null;
 
-@* 
-
-    protected override async Task OnInitializedAsync()
-    {
-        try
-        {
-            configData = await globalConfig.GetEditableConfig();
-            complianceCheckStartDate = complianceCheckStartTime = configData.ComplianceCheckStartAt;
-            policies = await apiConnection.SendQueryAsync<List<CompliancePolicy>>(ComplianceQueries.getPolicies);
-            if(configData.ComplianceCheckPolicyId > 0)
-            {
-                actPolicy = policies.FirstOrDefault(p => p.Id == configData.ComplianceCheckPolicyId);
-            }
-        }
-        catch(Exception exception)
-        {
-            DisplayMessageInUi(exception, _userConfig.GetText("read_config"), _userConfig.GetText("E5301"), false);
-        }
-    }
-
- *@
     protected override async Task OnInitializedAsync()
     {
         try
@@ -312,6 +293,21 @@
         }
     }
 
+    private async Task OnAddReportScheduleButtonClick()
+    {
+        reportScheduleInEdit = new ReportSchedule() { RepeatInterval = SchedulerInterval.Never };
+        await LoadComplianceReportParamsFromConfig();
+        ShowAddReportScheduleDialog = true;
+    }
+
+    private async Task OnEditReportScheduleButtonClick(ReportSchedule context)
+    {
+        reportScheduleInEdit = context; 
+        actDate = actTime = context.StartTime;
+        await LoadComplianceReportParamsFromConfig();
+        ShowEditReportScheduleDialog = true; 
+    }
+
     private async void HandleSubscriptionError(Exception exception)
     {
         await InvokeAsync(() => DisplayMessageInUi(exception, _userConfig.GetText("schedule_tile"), _userConfig.GetText("schedule_upd_err_msg"), true));
@@ -328,13 +324,6 @@
     {
         try
         {
-            //$report_schedule_name: String!
-            //$report_schedule_owner_id: Int!
-            //$report_schedule_template_id: Int!
-            //$report_schedule_start_time: timestamp!
-            //$report_schedule_repeat: Int! # 0 do not repeat, 2 daily, 2 weekly, 3 monthly, 4 yearly
-            //$report_schedule_every: Int! # every x days/weeks/months/years
-            //$report_schedule_active: Boolean!
 
             reportScheduleInEdit.StartTime = actDate.Date.Add(actTime.TimeOfDay);
             if (reportScheduleInEdit.Sanitize())
@@ -359,9 +348,7 @@
 
                 ShowAddReportScheduleDialog = false;
 
-                // update config
-
-                await _globalConfig.WriteToDatabase(_configData, apiConnection);
+                await UpdateConfig();
             }
         }
         catch (Exception exception)
@@ -401,9 +388,7 @@
 
                 ShowEditReportScheduleDialog = false;
 
-                // update config
-
-                await _globalConfig.WriteToDatabase(_configData, apiConnection);
+                await UpdateConfig();
             }
         }
         catch (Exception exception)
@@ -451,6 +436,34 @@
         }
 
         return ReportType.Undefined;
+    }
+
+    private async Task UpdateConfig()
+    {
+        if(_complianceDiffReportConfig is ScheduledComplianceDiffReportConfig complianceDiffReportConfig && reportScheduleInEdit.Template.ReportParams.ComplianceFilter.IsDiffReport)
+        {
+            complianceDiffReportConfig.ScheduledDiffReportsIntervals[reportScheduleInEdit.Id] = reportScheduleInEdit.Template.ReportParams.ComplianceFilter.DiffReferenceInDays;
+            _configData.ComplianceCheckScheduledDiffReportsIntervals = JsonSerializer.Serialize(complianceDiffReportConfig.ScheduledDiffReportsIntervals);
+        }
+
+        await _globalConfig.WriteToDatabase(_configData, apiConnection);
+    }
+
+    private async Task LoadComplianceReportParamsFromConfig()
+    {
+        if (reportScheduleInEdit.Template.ReportParams.ReportType == (int) ReportType.Compliance)
+        {
+            if (_userConfig.GlobalConfig is GlobalConfig globalConfig && !string.IsNullOrEmpty(globalConfig.ComplianceCheckScheduledDiffReportsIntervals))
+            {
+                _complianceDiffReportConfig = JsonSerializer.Deserialize<ScheduledComplianceDiffReportConfig>(globalConfig.ComplianceCheckScheduledDiffReportsIntervals) ?? new();
+
+                if (_complianceDiffReportConfig.ScheduledDiffReportsIntervals.Keys.Any(scheduledReportId => scheduledReportId == reportScheduleInEdit.Id))
+                {
+                    reportScheduleInEdit.Template.ReportParams.ComplianceFilter.IsDiffReport = true;
+                    reportScheduleInEdit.Template.ReportParams.ComplianceFilter.DiffReferenceInDays = _complianceDiffReportConfig.ScheduledDiffReportsIntervals[reportScheduleInEdit.Id];
+                }
+            }
+        }
     }
 
     public void Dispose()

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Schedule.razor
@@ -1,51 +1,53 @@
-﻿@using FWO.Report.Filter
+﻿@using FWO.Config.Api.Data
+@using FWO.Report.Filter
 
 @implements IDisposable
 
 @inject ApiConnection apiConnection
-@inject UserConfig userConfig
+@inject UserConfig _userConfig
+@inject GlobalConfig _globalConfig
 
 @page "/report/schedule"
 @attribute [Authorize(Roles = $"{Roles.Admin}, {Roles.FwAdmin}, {Roles.Reporter}, {Roles.ReporterViewAll}, {Roles.Auditor}, {Roles.Modeller}")]
 
 <ReportTabset/>
 
-<button type="button" class="btn btn-sm btn-success mb-1" @onclick="() => { reportScheduleInEdit = new ReportSchedule() { RepeatInterval = SchedulerInterval.Never }; ShowAddReportScheduleDialog = true; }">@(userConfig.GetText("add"))</button>
+<button type="button" class="btn btn-sm btn-success mb-1" @onclick="() => { reportScheduleInEdit = new ReportSchedule() { RepeatInterval = SchedulerInterval.Never }; ShowAddReportScheduleDialog = true; }">@(_userConfig.GetText("add"))</button>
 
 <div class="vheight75">
     <Table TableClass="table table-bordered table-sm th-bg-secondary table-responsive overflow-auto sticky-header" TableItem="ReportSchedule" Items="reportSchedules" PageSize="0">
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("actions"))">
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("actions"))">
             <Template>
                 @if (context.ScheduleOwningUser.DbId == uiUserDbId || authenticationState != null && authenticationState.User.IsInRole(Roles.Admin))
                 {
                     <div class="btn-group">
-                        <button type="button" class="btn btn-sm btn-warning" @onclick="() => { reportScheduleInEdit = context; actDate = actTime = context.StartTime; ShowEditReportScheduleDialog = true; }">@(userConfig.GetText("edit"))</button>
-                        <button type="button" class="btn btn-sm btn-danger" @onclick="() => { reportScheduleInEdit = context; ShowDeleteReportScheduleDialog = true; }">@(userConfig.GetText("delete"))</button>
+                        <button type="button" class="btn btn-sm btn-warning" @onclick="() => { reportScheduleInEdit = context; actDate = actTime = context.StartTime; ShowEditReportScheduleDialog = true; }">@(_userConfig.GetText("edit"))</button>
+                        <button type="button" class="btn btn-sm btn-danger" @onclick="() => { reportScheduleInEdit = context; ShowDeleteReportScheduleDialog = true; }">@(_userConfig.GetText("delete"))</button>
                     </div>
                 }
             </Template>
         </Column>
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("id"))" Field="@(reportSchedule => reportSchedule.Id)" Sortable="true" Filterable="true"/>
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("name"))" Field="@(reportSchedule => reportSchedule.Name)" Sortable="true" Filterable="true"/>
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("start_time"))" Field="@(reportSchedule => reportSchedule.StartTime)" Sortable="true" Filterable="true">
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("id"))" Field="@(reportSchedule => reportSchedule.Id)" Sortable="true" Filterable="true"/>
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("name"))" Field="@(reportSchedule => reportSchedule.Name)" Sortable="true" Filterable="true"/>
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("start_time"))" Field="@(reportSchedule => reportSchedule.StartTime)" Sortable="true" Filterable="true">
             <Template>
                 @(context.StartTime.ToString("yyyy-MM-dd HH:mm:ssK"))
             </Template>
         </Column>
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("repeat_interval"))" Field="@(reportSchedule => reportSchedule.RepeatOffset)">
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("repeat_interval"))" Field="@(reportSchedule => reportSchedule.RepeatOffset)">
             <Template>
-                @(context.RepeatInterval != SchedulerInterval.Never ? context.RepeatOffset : "") @(userConfig.GetText(context.RepeatInterval.ToString()))
+                @(context.RepeatInterval != SchedulerInterval.Never ? context.RepeatOffset : "") @(_userConfig.GetText(context.RepeatInterval.ToString()))
             </Template>
         </Column>
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("template"))" Field="@(reportSchedule => reportSchedule.Template.Name)" Sortable="true" Filterable="true"/>
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("schedule_owner"))" Field="@(reportSchedule => reportSchedule.ScheduleOwningUser.Name)" Sortable="true" Filterable="true"/>
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("active"))" Field="@(reportSchedule => reportSchedule.Active)" Sortable="true" Filterable="true">
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("template"))" Field="@(reportSchedule => reportSchedule.Template.Name)" Sortable="true" Filterable="true"/>
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("schedule_owner"))" Field="@(reportSchedule => reportSchedule.ScheduleOwningUser.Name)" Sortable="true" Filterable="true"/>
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("active"))" Field="@(reportSchedule => reportSchedule.Active)" Sortable="true" Filterable="true">
                 <Template>
                     @(context.Active.ShowAsHtml())
                 </Template>
         </Column>
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("count"))" Field="@(reportSchedule => reportSchedule.Counter)" Sortable="true" Filterable="true"/>
-        <Column TableItem="ReportSchedule" Title="@(userConfig.GetText("output_format"))" Field="@(reportSchedule => reportSchedule.OutputFormat)">
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("count"))" Field="@(reportSchedule => reportSchedule.Counter)" Sortable="true" Filterable="true"/>
+        <Column TableItem="ReportSchedule" Title="@(_userConfig.GetText("output_format"))" Field="@(reportSchedule => reportSchedule.OutputFormat)">
             <Template>
                 @String.Join(", ", context.OutputFormat.ConvertAll(format => format.Name.ToUpperInvariant()))
             </Template>
@@ -53,21 +55,21 @@
     </Table>
 </div>
 
-<PopUp Size=PopupSize.Large Title="@(userConfig.GetText("report_schedule"))" Show="@(ShowAddReportScheduleDialog || ShowEditReportScheduleDialog)">
+<PopUp Size=PopupSize.Large Title="@(_userConfig.GetText("report_schedule"))" Show="@(ShowAddReportScheduleDialog || ShowEditReportScheduleDialog)">
     <Body>
         <div>
             <div class="form-group row">
-                <label for="scheduleId" class="col-sm-3 col-form-label col-form-label-sm">@(userConfig.GetText("id")):</label>
+                <label for="scheduleId" class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("id")):</label>
                 <label class="col-sm-8 col-form-label col-form-label-sm">@reportScheduleInEdit.Id</label>
             </div>
             <div class="form-group row mt-2">
-                <label for="scheduleName" class="col-sm-3 col-form-label col-form-label-sm">@(userConfig.GetText("name")):</label>
+                <label for="scheduleName" class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("name")):</label>
                 <div class="col-sm-8">
                     <input id="scheduleName" type="text" class="form-control form-control-sm" @bind="reportScheduleInEdit.Name" />
                 </div>
             </div>
             <div class="form-group row mt-2">
-                <label for="scheduleStartTime" class="col-sm-3 col-form-label col-form-label-sm">@(userConfig.GetText("start_time")):</label>
+                <label for="scheduleStartTime" class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("start_time")):</label>
                 <div class="col-sm-4">
                     <input id="scheduleStartTime" type="time" step="60" class="form-control form-control-sm" @bind="actTime" />
                 </div>
@@ -76,21 +78,21 @@
                 </div>
             </div>
             <div class="form-group row mt-2">
-                <label for="scheduleRepeatEvery" class="col-sm-3 col-form-label col-form-label-sm">@(userConfig.GetText("repeat_every")):</label>
+                <label for="scheduleRepeatEvery" class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("repeat_every")):</label>
                 <div class="col-sm-3">
                     <input id="scheduleRepeatEvery" type="number" min="1" class="form-control form-control-sm" @bind="reportScheduleInEdit.RepeatOffset" />
                 </div>
                 <div class="col-sm-5">
-                    <Dropdown @bind-SelectedElement="reportScheduleInEdit.RepeatInterval" ElementToString="@(i => userConfig.GetText(i.ToString()))"
+                    <Dropdown @bind-SelectedElement="reportScheduleInEdit.RepeatInterval" ElementToString="@(i => _userConfig.GetText(i.ToString()))"
                             Elements="Enum.GetValues(typeof(SchedulerInterval)).Cast<SchedulerInterval>().Where(x => x.OfferedForReportOrNever())" >
                         <ElementTemplate Context="interval">
-                            @(userConfig.GetText(interval.ToString()))
+                            @(_userConfig.GetText(interval.ToString()))
                         </ElementTemplate>
                     </Dropdown>
                 </div>
             </div>
             <div class="form-group row mt-2">
-                <label for="scheduleTemplate" class="col-sm-3 col-form-label col-form-label-sm">@(userConfig.GetText("template")):</label>
+                <label for="scheduleTemplate" class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("template")):</label>
                 <div class="col-sm-8">
                     <Dropdown ElementType="ReportTemplate" ElementToString="@(o => o.Name)" Nullable="false"
                         @bind-SelectedElement="reportScheduleInEdit.Template" Elements="reportTemplates">
@@ -101,7 +103,7 @@
                 </div>
             </div>
             <div class="form-group row mt-2">
-                <label for="scheduleOutputFormat" class="col-sm-3 col-form-label col-form-label-sm">@(userConfig.GetText("output_format")):</label>
+                <label for="scheduleOutputFormat" class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("output_format")):</label>
                 <div class="col-sm-8">
                     <div class="form-inline justify-content-between">
                         <div class="form-check">
@@ -135,11 +137,48 @@
                         {
                             reportScheduleInEdit.OutputFormat.Remove(GlobalConst.kCsv);
                         }
+
+                        @if (reportScheduleInEdit.Template.ReportParams != null && GetReportType().IsComplianceReport()) @* Restriction on compliance report solely while development. Dont have the time to verify, wether this works for every report type *@
+                        {
+                            <div class="form-group row mt-2" data-toggle="tooltip" title="@(_userConfig.PureLine("H5810"))">
+                                <label class="col-form-label col-sm-4">@(_userConfig.GetText("policy"))*:</label>
+                                <div class="col-sm-2">
+                                    <Dropdown ElementType="CompliancePolicy" ElementToString="@(p => p.Name)" @bind-SelectedElement="_actPolicy" Elements="_policies">
+                                        <ElementTemplate Context="policy">
+                                            @policy.Name
+                                        </ElementTemplate>
+                                    </Dropdown>
+                                </div>
+                            </div>
+                        }
+
+                        @* Mail config *@
+                        @if (reportScheduleInEdit.Template.ReportParams != null && GetReportType().IsComplianceReport()) @* Restriction on compliance report solely while development. Dont have the time to verify, wether this works for every report type *@
+                        {
+                            <div class="form-group row" data-toggle="tooltip" title="@(_userConfig.PureLine("H5804"))">
+                                <label class="col-form-label col-sm-4">@(_userConfig.GetText("complianceCheckMailRecipients")):</label>
+                                <div class="col-sm-7" data-toggle="tooltip" title="@(_userConfig.GetText("U5320"))">
+                                    <input type="text" @bind="_configData!.ComplianceCheckMailRecipients" />
+                                </div>
+                            </div>
+                            <div class="form-group row mt-2" data-toggle="tooltip" title="@(_userConfig.PureLine("H5805"))">
+                                <label class="col-form-label col-sm-4">@(_userConfig.GetText("complianceCheckMailSubject")):</label>
+                                <div class="col-sm-7">
+                                    <input type="text" @bind="_configData!.ComplianceCheckMailSubject" />
+                                </div>
+                            </div>
+                            <div class="form-group row" data-toggle="tooltip" title="@(_userConfig.PureLine("H5806"))">
+                                <label class="col-form-label col-sm-4">@(_userConfig.GetText("complianceCheckMailBody")):</label>
+                                <div class="col-sm-7">
+                                    <textarea rows="6" cols="60" name="text" placeholder=@(_userConfig.GetText("complianceCheckMailBody")) @bind="_configData!.ComplianceCheckMailBody"></textarea>
+                                </div>
+                            </div>
+                        }
                     </div>
                 </div>
             </div>
             <div class="form-group row mt-2">
-                <label for="scheduleActive" class="col-sm-3 col-form-label col-form-label-sm">@(userConfig.GetText("active")):</label>
+                <label for="scheduleActive" class="col-sm-3 col-form-label col-form-label-sm">@(_userConfig.GetText("active")):</label>
                 <div class="col-sm-8" style="padding-top: calc(0.25rem + 1px);">
                     <input id="scheduleActive" type="checkbox" style="max-height: 22px;" @bind="reportScheduleInEdit.Active" />
                 </div>
@@ -148,20 +187,20 @@
     </Body>
     <Footer>
         <div class="btn-group">
-            <button type="button" class="btn btn-sm btn-primary" @onclick="async () => await (ShowAddReportScheduleDialog ? AddReportSchedule() : UpdateReportSchedule())">@(userConfig.GetText("save"))</button>
-            <button type="button" class="btn btn-sm btn-secondary" @onclick="() => ShowEditReportScheduleDialog = ShowAddReportScheduleDialog = false">@(userConfig.GetText("cancel"))</button>
+            <button type="button" class="btn btn-sm btn-primary" @onclick="async () => await (ShowAddReportScheduleDialog ? AddReportSchedule() : UpdateReportSchedule())">@(_userConfig.GetText("save"))</button>
+            <button type="button" class="btn btn-sm btn-secondary" @onclick="() => ShowEditReportScheduleDialog = ShowAddReportScheduleDialog = false">@(_userConfig.GetText("cancel"))</button>
         </div>
     </Footer>
 </PopUp>
 
 <PopUp Title="Report Schedule" Size=PopupSize.Small Show="@ShowDeleteReportScheduleDialog">
     <Body>
-        <p>@(userConfig.GetText("U2002")) "@reportScheduleInEdit.Name" ?</p>
+        <p>@(_userConfig.GetText("U2002")) "@reportScheduleInEdit.Name" ?</p>
     </Body>
     <Footer>
         <div class="btn-group">
-            <button type="button" class="btn btn-sm btn-danger" @onclick="DeleteReportSchedule">@(userConfig.GetText("delete"))</button>
-            <button type="button" class="btn btn-sm btn-secondary" @onclick="() => ShowDeleteReportScheduleDialog = false">@(userConfig.GetText("cancel"))</button>
+            <button type="button" class="btn btn-sm btn-danger" @onclick="DeleteReportSchedule">@(_userConfig.GetText("delete"))</button>
+            <button type="button" class="btn btn-sm btn-secondary" @onclick="() => ShowDeleteReportScheduleDialog = false">@(_userConfig.GetText("cancel"))</button>
         </div>
     </Footer>
 </PopUp>
@@ -198,15 +237,48 @@
         || authenticationStateTask!.Result.User.IsInRole(Roles.Admin)
         || authenticationStateTask!.Result.User.IsInRole(Roles.Auditor);
 
+    private List<CompliancePolicy> _policies = [];
+    private CompliancePolicy? _actPolicy;
+    private ConfigData? _configData;
+
+@* 
 
     protected override async Task OnInitializedAsync()
     {
         try
         {
-            uiUserDbId = userConfig.User.DbId;
+            configData = await globalConfig.GetEditableConfig();
+            complianceCheckStartDate = complianceCheckStartTime = configData.ComplianceCheckStartAt;
+            policies = await apiConnection.SendQueryAsync<List<CompliancePolicy>>(ComplianceQueries.getPolicies);
+            if(configData.ComplianceCheckPolicyId > 0)
+            {
+                actPolicy = policies.FirstOrDefault(p => p.Id == configData.ComplianceCheckPolicyId);
+            }
+        }
+        catch(Exception exception)
+        {
+            DisplayMessageInUi(exception, _userConfig.GetText("read_config"), _userConfig.GetText("E5301"), false);
+        }
+    }
+
+ *@
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _configData = await _globalConfig.GetEditableConfig();
+
+            _policies = await apiConnection.SendQueryAsync<List<CompliancePolicy>>(ComplianceQueries.getPolicies);
+
+            if(_configData.ComplianceCheckPolicyId > 0)
+            {
+                _actPolicy = _policies.FirstOrDefault(p => p.Id == _configData.ComplianceCheckPolicyId);
+            }
+
+            uiUserDbId = _userConfig.User.DbId;
             if(showModellingReports)
             {
-                modOwnerList = await ModellingHandlerBase.GetOwnApps(authenticationStateTask!, userConfig, apiConnection, DisplayMessageInUi);
+                modOwnerList = await ModellingHandlerBase.GetOwnApps(authenticationStateTask!, _userConfig, apiConnection, DisplayMessageInUi);
             }
 
             // Initial fetch to speed up loading before subscription is established
@@ -220,13 +292,13 @@
         }
         catch (Exception exception)
         {
-            DisplayMessageInUi(exception, userConfig.GetText("schedule_fetch"), userConfig.GetText("schedule_upd_err_msg"), true);
+            DisplayMessageInUi(exception, _userConfig.GetText("schedule_fetch"), _userConfig.GetText("schedule_upd_err_msg"), true);
         }
     }
 
     private async void HandleSubscriptionError(Exception exception)
     {
-        await InvokeAsync(() => DisplayMessageInUi(exception, userConfig.GetText("schedule_tile"), userConfig.GetText("schedule_upd_err_msg"), true));
+        await InvokeAsync(() => DisplayMessageInUi(exception, _userConfig.GetText("schedule_tile"), _userConfig.GetText("schedule_upd_err_msg"), true));
     }
 
     private async void OnReportScheduleUpdate(List<ReportSchedule> newReportSchedules)
@@ -251,7 +323,7 @@
             reportScheduleInEdit.StartTime = actDate.Date.Add(actTime.TimeOfDay);
             if (reportScheduleInEdit.Sanitize())
             {
-                DisplayMessageInUi(null, userConfig.GetText("save_scheduled_report"), userConfig.GetText("U0001"), true);
+                DisplayMessageInUi(null, _userConfig.GetText("save_scheduled_report"), _userConfig.GetText("U0001"), true);
             }
             if (checkInput())
             {
@@ -275,7 +347,7 @@
         catch (Exception exception)
         {
             Log.WriteError("Save scheduled report", "Unclassified error.", exception);
-            DisplayMessageInUi(exception, userConfig.GetText("save_scheduled_report"), "", false);
+            DisplayMessageInUi(exception, _userConfig.GetText("save_scheduled_report"), "", false);
         }
     }
 
@@ -286,7 +358,7 @@
             reportScheduleInEdit.StartTime = actDate.Date.Add(actTime.TimeOfDay);
             if (reportScheduleInEdit.Sanitize())
             {
-                DisplayMessageInUi(null, userConfig.GetText("edit_scheduled_report"), userConfig.GetText("U0001"), true);
+                DisplayMessageInUi(null, _userConfig.GetText("edit_scheduled_report"), _userConfig.GetText("U0001"), true);
             }
             if (checkInput())
             {
@@ -313,7 +385,7 @@
         catch (Exception exception)
         {
             Log.WriteError("Edit scheduled report", "Unclassified error.", exception);
-            DisplayMessageInUi(exception, userConfig.GetText("edit_scheduled_report"), "", false);
+            DisplayMessageInUi(exception, _userConfig.GetText("edit_scheduled_report"), "", false);
         }
     }
 
@@ -333,7 +405,7 @@
         catch (Exception exception)
         {
             Log.WriteError("Delete scheduled report", "Unclassified error.", exception);
-            DisplayMessageInUi(exception, userConfig.GetText("delete_scheduled_report"), "", false);
+            DisplayMessageInUi(exception, _userConfig.GetText("delete_scheduled_report"), "", false);
         }
     }
 
@@ -341,7 +413,7 @@
     {
         if(reportScheduleInEdit.Template == null || reportScheduleInEdit.Template.Id == 0)
         {
-            DisplayMessageInUi(null, userConfig.GetText("edit_scheduled_report"), userConfig.GetText("E2001"), true);
+            DisplayMessageInUi(null, _userConfig.GetText("edit_scheduled_report"), _userConfig.GetText("E2001"), true);
             return false;
         }
         return true;

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsCompliance.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsCompliance.razor
@@ -37,12 +37,6 @@
                 </div>
             </div>
         </div>
-        <div class="form-group row" data-toggle="tooltip" title="@(userConfig.PureLine("H5804"))">
-            <label class="col-form-label col-sm-4">@(userConfig.GetText("complianceCheckMailRecipients")):</label>
-            <div class="col-sm-7" data-toggle="tooltip" title="@(userConfig.GetText("U5320"))">
-                <input type="text" @bind="configData!.ComplianceCheckMailRecipients" />
-            </div>
-        </div>
         <div class="form-group row mt-2" data-toggle="tooltip" title="@(userConfig.PureLine("H5810"))">
             <label class="col-form-label col-sm-4">@(userConfig.GetText("policy"))*:</label>
             <div class="col-sm-2">
@@ -51,24 +45,6 @@
                         @policy.Name
                     </ElementTemplate>
                 </Dropdown>
-            </div>
-        </div>
-        <div class="form-group row mt-2" data-toggle="tooltip" title="@(userConfig.PureLine("H5805"))">
-            <label class="col-form-label col-sm-4">@(userConfig.GetText("complianceCheckMailSubject")):</label>
-            <div class="col-sm-7">
-                <input type="text" @bind="configData!.ComplianceCheckMailSubject" />
-            </div>
-        </div>
-        <div class="form-group row" data-toggle="tooltip" title="@(userConfig.PureLine("H5806"))">
-            <label class="col-form-label col-sm-4">@(userConfig.GetText("complianceCheckMailBody")):</label>
-            <div class="col-sm-7">
-                <textarea rows="6" cols="60" name="text" placeholder=@(userConfig.GetText("complianceCheckMailBody")) @bind="configData!.ComplianceCheckMailBody"></textarea>
-            </div>
-        </div>
-        <div class="form-group row" data-toggle="tooltip" title="@(userConfig.PureLine("H5807"))">
-            <label class="col-form-label col-sm-4">@(userConfig.GetText("complianceCheckPersistData"))</label>
-            <div class="col-sm-7">
-                <input type="checkbox" @bind="configData!.ComplianceCheckPersistData"/>
             </div>
         </div>
         <div class="form-group row" data-toggle="tooltip" title="@(userConfig.PureLine("H5809"))">


### PR DESCRIPTION
**Features**

- Logic is separated in ComplianceCheckScheduler and ReportScheduler
- Violation data is only written for new violations
- Violations in db that are not in the current checks data are removed (i.e. get a removed date)
- CSV separator is now ','

**Notes**

- Compliance check seems to not resolve objects without ip_start and ip_end
- email sending feature is currently restricted to ComplianceReport template, because I didnt have the time to check if it works with every template