### PR TITLE
Nuget Bumps

### DIFF
--- a/roles/lib/files/FWO.Config.File/FWO.Config.File.csproj
+++ b/roles/lib/files/FWO.Config.File/FWO.Config.File.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Mail/FWO.Mail.csproj
+++ b/roles/lib/files/FWO.Mail/FWO.Mail.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.11.0" />
-    <PackageReference Include="MimeKit" Version="4.11.0" />
+    <PackageReference Include="MailKit" Version="4.13.0" />
+    <PackageReference Include="MimeKit" Version="4.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="9.0.8" />
   </ItemGroup>

--- a/roles/lib/files/FWO.Mail/FWO.Mail.csproj
+++ b/roles/lib/files/FWO.Mail/FWO.Mail.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="MailKit" Version="4.11.0" />
     <PackageReference Include="MimeKit" Version="4.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.4" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Report/FWO.Report.csproj
+++ b/roles/lib/files/FWO.Report/FWO.Report.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
-	  <PackageReference Include="PuppeteerSharp" Version="20.1.3" />
+	  <PackageReference Include="HtmlAgilityPack" Version="1.12.2" />
+	  <PackageReference Include="PuppeteerSharp" Version="20.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="20.1.3" />
+    <PackageReference Include="PuppeteerSharp" Version="20.2.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
 

--- a/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
+++ b/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.39.5" />
-    <PackageReference Include="PuppeteerSharp" Version="20.1.3" />
+    <PackageReference Include="bunit" Version="1.40.0" />
+    <PackageReference Include="PuppeteerSharp" Version="20.2.2" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
   </ItemGroup>
 

--- a/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
+++ b/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
@@ -10,10 +10,10 @@
   <ItemGroup>
     <PackageReference Include="bunit" Version="1.39.5" />
     <PackageReference Include="PuppeteerSharp" Version="20.1.3" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.8.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/ui/files/FWO.UI/FWO.Ui.csproj
+++ b/roles/ui/files/FWO.UI/FWO.Ui.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="IPAddressRange" Version="6.2.0" />
 		<PackageReference Include="BlazorTable" Version="1.17.0" />
-		<PackageReference Include="PuppeteerSharp" Version="20.1.3" />
+		<PackageReference Include="PuppeteerSharp" Version="20.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
[~] Updated System.Text.Encodings.Web to 9.0.8
[~] Updated NUnit to 4.4.0 and NUnit3TestAdapter to 5.1.0
[~] Updated Microsoft.IdentityModel.Tokens to 8.14.0
[~] FWO.Report.csproj: Upgrade HtmlAgilityPack to 1.12.2
[~] FWO.Report.csproj: Upgrade PuppeteerSharp to 20.2.2
[~] FWO.Middleware.Server.csproj: Upgrade PuppeteerSharp to 20.2.2
[~] FWO.Test.csproj: Upgrade bunit to 1.40.0
[~] FWO.Test.csproj: Upgrade Microsoft.NET.Test.Sdk to 17.14.1
[~] FWO.Ui.csproj: Upgrade PuppeteerSharp to 20.2.2

All tests passed. Test Email was sent. PDF/HTML reports tested.