### PR TITLE
PR for #3550 and other stuff

### DIFF
--- a/roles/database/files/sql/creation/fworch-fill-stm.sql
+++ b/roles/database/files/sql/creation/fworch-fill-stm.sql
@@ -145,6 +145,7 @@ insert into config (config_key, config_value, config_user) VALUES ('complianceCh
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckStartAt', '00:00:00', 0);
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckPolicy', '0', 0);
 insert into config (config_key, config_value, config_user) VALUES ('complianceCheckMaxPrintedViolations', '0', 0);
+insert into config (config_key, config_value, config_user) VALUES ('complianceCheckSortMatrixByID', 'false', 0);
 insert into config (config_key, config_value, config_user) VALUES ('availableModules', '[1,2,3,4,5,6]', 0);
 insert into config (config_key, config_value, config_user) VALUES ('debugConfig', '{"debugLevel":8, "extendedLogComplianceCheck":true, "extendedLogReportGeneration":true, "extendedLogScheduler":true}', 0);
 insert into config (config_key, config_value, config_user) VALUES ('reportSchedulerConfig', '', 0);

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -2523,6 +2523,8 @@ INSERT INTO txt VALUES ('complianceCheckInternetZoneObject','German', 'Internetz
 INSERT INTO txt VALUES ('complianceCheckInternetZoneObject','English','Internet zone');
 INSERT INTO txt VALUES ('complianceCheckMaxPrintedViolations','German', 'Maximale Anzahl gedruckter Verst&ouml;&szlig;e pro Regel');
 INSERT INTO txt VALUES ('complianceCheckMaxPrintedViolations','English','Maximum number of printed violations per rule');
+INSERT INTO txt VALUES ('complianceCheckSortMatrixByID', 'German', 'Matrixsortierung nach Zonen-ID');
+INSERT INTO txt VALUES ('complianceCheckSortMatrixByID', 'English', 'Matrix sorting by zone ID');
 INSERT INTO txt VALUES ('availableModules',     'German', 	'Verf&uuml;gbare Module');
 INSERT INTO txt VALUES ('availableModules',     'English', 	'Available Modules');
 
@@ -5662,6 +5664,8 @@ INSERT INTO txt VALUES ('H5813', 'German',  'Definition vom Kriterien mit fixem 
 INSERT INTO txt VALUES ('H5813', 'English', 'Definition of Criteria with fixed content. ');
 INSERT INTO txt VALUES ('H5814', 'German',  'Maximal Anzahl von Violations die im Compliance Report pro Rule angezeigt werden. Bei 0 keine Beschränkung.');
 INSERT INTO txt VALUES ('H5814', 'English', 'Maximum number of violations shown in the compliance report per rule. If set to 0, no limitation is applied.');
+INSERT INTO txt VALUES ('H5815', 'German',  'Wenn aktiviert, werden Netzwerkzonenmatrizen nach Zonen-ID sortiert (Default: Sortierung nach Name).');
+INSERT INTO txt VALUES ('H5815', 'English', 'When enabled, network zone matrices are sorted by zone ID (default: sorted by name).');
 
 INSERT INTO txt VALUES ('H6001', 'German',  'Firewall Orchestrator verf&uuml;gt &uuml;ber zwei APIs:
     <ul>

--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -1122,6 +1122,12 @@ INSERT INTO config (config_key, config_value, config_user)
 VALUES ('reportSchedulerConfig', '', 0)
 ON CONFLICT (config_key, config_user) DO NOTHING;
 
+-- add parameter to choose order by column of network matrix between name and id
+
+INSERT INTO config (config_key, config_value, config_user) 
+VALUES ('complianceCheckSortMatrixByID', 'false', 0)
+ON CONFLICT (config_key, config_user) DO NOTHING;
+
 -- adding labels (simple version without mapping tables and without foreign keys)
 
 -- CREATE TABLE label (

--- a/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
@@ -298,7 +298,6 @@ namespace FWO.Compliance
         private async Task CheckRuleComplianceForAllRules()
         {
             int nonCompliantRules = 0;
-            int nonEvaluableRules = 0;
 
             Log.TryWriteLog(LogType.Info, "Compliance Check", $"Checking compliance for every rule.", _debugConfig.ExtendedLogComplianceCheck);
 

--- a/roles/lib/files/FWO.Compliance/ComplianceExtensions.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceExtensions.cs
@@ -9,7 +9,7 @@ namespace FWO.Compliance
             return violationType switch
             {
                 ComplianceViolationType.None => "Compliant",
-                ComplianceViolationType.NotEvaluable => "Not evaluable",
+                ComplianceViolationType.NotAssessable => "Not assessable",
                 ComplianceViolationType.MatrixViolation => "Matrix violation",
                 ComplianceViolationType.ServiceViolation => "Service violation",
                 ComplianceViolationType.MultipleViolations => "Multiple violations",

--- a/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
+++ b/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
@@ -425,6 +425,9 @@ namespace FWO.Config.Api.Data
         [JsonProperty("complianceCheckMaxPrintedViolations"), JsonPropertyName("complianceCheckMaxPrintedViolations")]
         public int ComplianceCheckMaxPrintedViolations { get; set; } = 0;
         
+        [JsonProperty("complianceCheckSortMatrixByID"), JsonPropertyName("complianceCheckSortMatrixByID")]
+        public bool ComplianceCheckSortMatrixByID { get; set; } = false;
+        
         [JsonProperty("reportSchedulerConfig"), JsonPropertyName("reportSchedulerConfig")]
         public string ReportSchedulerConfig { get; set; } = "";
 

--- a/roles/lib/files/FWO.Data/ComplianceViolationType.cs
+++ b/roles/lib/files/FWO.Data/ComplianceViolationType.cs
@@ -3,7 +3,7 @@ namespace FWO.Data
     public enum ComplianceViolationType
     {
         None, // rule is compliant
-        NotEvaluable, // compliance cant be evaluated (e.g. zone internet)
+        NotAssessable, // compliance cant be evaluated (e.g. zone internet)
         MatrixViolation,
         ServiceViolation,
         MultipleViolations

--- a/roles/lib/files/FWO.Report/Data/ViewData/RuleViewData.cs
+++ b/roles/lib/files/FWO.Report/Data/ViewData/RuleViewData.cs
@@ -40,7 +40,7 @@ namespace FWO.Report.Data.ViewData
             Name                = SafeCall(rule, "Name",() => rule.Name ?? "");
             Source              = SafeCall(rule, "Source",() => natRuleDisplayHtml.DisplaySource(rule, outputLocation, ReportType.Compliance));
             Destination         = SafeCall(rule, "Destination",() => natRuleDisplayHtml.DisplayDestination(rule, outputLocation, ReportType.Compliance));
-            Services            = SafeCall(rule, "Services",() => ResolveServices(rule));
+            Services            = SafeCall(rule, "Services",() => natRuleDisplayHtml.DisplayServices(rule, outputLocation, ReportType.Compliance));
             Action              = SafeCall(rule, "Action",() => rule.Action);
             InstallOn           = SafeCall(rule, "InstallOn",() => ResolveInstallOn(rule, devices ?? []));
             Compliance          = SafeCall(rule, "Compliance",() => ResolveCompliance(rule.Compliance));

--- a/roles/lib/files/FWO.Report/Data/ViewData/RuleViewData.cs
+++ b/roles/lib/files/FWO.Report/Data/ViewData/RuleViewData.cs
@@ -54,10 +54,9 @@ namespace FWO.Report.Data.ViewData
 
         private string ResolveCompliance(Rule rule, ComplianceViolationType? complianceViolationType)
         {
-
             return (complianceViolationType ?? rule.Compliance) switch
             {
-                ComplianceViolationType.NotEvaluable => "NOT EVALUABLE",
+                ComplianceViolationType.NotAssessable => "NOT ASSESSABLE",
                 ComplianceViolationType.None => "TRUE",
                 _ => "FALSE"
             };

--- a/roles/lib/files/FWO.Report/Data/ViewData/RuleViewData.cs
+++ b/roles/lib/files/FWO.Report/Data/ViewData/RuleViewData.cs
@@ -29,7 +29,7 @@ namespace FWO.Report.Data.ViewData
         public Rule? DataObject { get; set; }
         public bool Show { get; set; } = true;
 
-        public RuleViewData(Rule rule, NatRuleDisplayHtml natRuleDisplayHtml, OutputLocation outputLocation, bool show, List<Device>? devices = null, List<Management>? managements = null)
+        public RuleViewData(Rule rule, NatRuleDisplayHtml natRuleDisplayHtml, OutputLocation outputLocation, bool show, List<Device>? devices = null, List<Management>? managements = null, ComplianceViolationType? complianceViolationType = null)
         {
             DataObject = rule;
             Show = show;
@@ -43,7 +43,7 @@ namespace FWO.Report.Data.ViewData
             Services            = SafeCall(rule, "Services",() => natRuleDisplayHtml.DisplayServices(rule, outputLocation, ReportType.Compliance));
             Action              = SafeCall(rule, "Action",() => rule.Action);
             InstallOn           = SafeCall(rule, "InstallOn",() => ResolveInstallOn(rule, devices ?? []));
-            Compliance          = SafeCall(rule, "Compliance",() => ResolveCompliance(rule.Compliance));
+            Compliance          = SafeCall(rule, "Compliance",() => ResolveCompliance(rule, complianceViolationType));
             ViolationDetails    = SafeCall(rule, "ViolationDetails",() => rule.ViolationDetails);
             ChangeID            = SafeCall(rule, "ChangeID",() => GetFromCustomField(rule, "field-2"));
             AdoITID             = SafeCall(rule, "AdoITID",() => GetFromCustomField(rule, "field-3"));
@@ -52,15 +52,10 @@ namespace FWO.Report.Data.ViewData
             RulebaseName        = SafeCall(rule, "RulebaseName",() => rule.Rulebase?.Name ?? "");
         }
 
-        private string ResolveServices(Rule rule)
+        private string ResolveCompliance(Rule rule, ComplianceViolationType? complianceViolationType)
         {
-            var services = rule.Services.Select(s => s.Content.Name).ToList();
-            return string.Join(" | ", services);
-        }
 
-        private string ResolveCompliance(ComplianceViolationType complianceViolationType)
-        {
-            return complianceViolationType switch
+            return (complianceViolationType ?? rule.Compliance) switch
             {
                 ComplianceViolationType.NotEvaluable => "NOT EVALUABLE",
                 ComplianceViolationType.None => "TRUE",

--- a/roles/lib/files/FWO.Report/Display/RuleDisplayBase.cs
+++ b/roles/lib/files/FWO.Report/Display/RuleDisplayBase.cs
@@ -31,7 +31,7 @@ namespace FWO.Ui.Display
 
         public static string DisplayIsCompliant(Rule rule, OutputLocation location)
         {
-            if (rule.Compliance != ComplianceViolationType.NotEvaluable)
+            if (rule.Compliance != ComplianceViolationType.NotAssessable)
             {
                 bool isCompliant = true;
 

--- a/roles/lib/files/FWO.Report/Display/RuleDisplayBase.cs
+++ b/roles/lib/files/FWO.Report/Display/RuleDisplayBase.cs
@@ -202,6 +202,12 @@ namespace FWO.Ui.Display
                         collectedServices.Add(nwService.Object);
                     }
                 }
+
+                if (!service.Content.ServiceGroupFlats.Any())
+                {
+                    collectedServices.Add(service.Content);
+                }
+
             }
             List<NetworkService> serviceList = [.. collectedServices];
             serviceList.Sort(delegate (NetworkService x, NetworkService y) { return x.Name.CompareTo(y.Name); });

--- a/roles/lib/files/FWO.Report/Display/RuleDisplayHtml.cs
+++ b/roles/lib/files/FWO.Report/Display/RuleDisplayHtml.cs
@@ -35,6 +35,7 @@ namespace FWO.Ui.Display
             {
                 result.AppendJoin("<br>", Array.ConvertAll(rule.Services, service => ServiceToHtml(service.Content, rule.MgmtId, chapterNumber, location, style, reportType)));
             }
+            
             return result.ToString();
         }
 

--- a/roles/lib/files/FWO.Report/ReportCompliance.cs
+++ b/roles/lib/files/FWO.Report/ReportCompliance.cs
@@ -379,8 +379,16 @@ namespace FWO.Report
 
             (List<Rule> processed, List<RuleViewData> viewData, Dictionary<Rule, List<NetworkObject>> networkObjects)[]? results = await Task.WhenAll(tasks);
 
-            // Gather results.
+            return await GatherReportData(results);
+        }
 
+
+        #endregion
+
+        #region Methods - Private
+
+        private Task<List<Rule>> GatherReportData((List<Rule> processed, List<RuleViewData> viewData, Dictionary<Rule, List<NetworkObject>> networkObjects)[]? results)
+        {
             RuleViewData.Capacity = results.Sum(r => r.viewData.Count);
             List<Rule> processedRulesFlat = new(results.Sum(r => r.processed.Count));
             Dictionary<Rule, List<NetworkObject>> networkObjectsDict = new();
@@ -398,13 +406,8 @@ namespace FWO.Report
 
             RuleNetworkObjectMap = networkObjectsDict.ToFrozenDictionary();
 
-            return processedRulesFlat;
+            return Task.FromResult(processedRulesFlat);
         }
-        
-
-        #endregion
-
-        #region Methods - Private
 
         private Dictionary<string, object> CreateQueryVariables(int offset, int limit, string query)
         {

--- a/roles/ui/files/FWO.UI/Pages/Compliance/ZonesMatrix.razor
+++ b/roles/ui/files/FWO.UI/Pages/Compliance/ZonesMatrix.razor
@@ -21,7 +21,7 @@
                 <thead>
                     <tr>
                         <th></th>
-                        @foreach (var destinationZone in networkZoneService.NetworkZones)
+                        @foreach (var destinationZone in GetSortedNetworkzones())
                         {
                             <th @onclick="() => ExecuteZoneAction(destinationZone)" class="zone-header-rotated">
                                 <div class="zone-name text-rotated">@(destinationZone.Name)</div>
@@ -30,7 +30,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @foreach (var sourceZone in networkZoneService.NetworkZones)
+                    @foreach (var sourceZone in GetSortedNetworkzones())
                     {
                         <tr>
                             <th @onclick="() => ExecuteZoneAction(sourceZone)" class="zone-header">
@@ -109,5 +109,17 @@
         {
             // Jump to communication
         }
+    }
+
+    private List<ComplianceNetworkZone> GetSortedNetworkzones()
+    {
+        List<ComplianceNetworkZone> complianceNetworkZones = networkZoneService.NetworkZones;
+
+        if(userConfig.GlobalConfig!.ComplianceCheckSortMatrixByID)
+        {
+            complianceNetworkZones = complianceNetworkZones.OrderBy(zone => zone.Id).ToList();
+        }
+
+        return complianceNetworkZones;
     }
 }

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsCompliance.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsCompliance.razor
@@ -77,6 +77,14 @@
                 <input type="text" @bind="configData!.ComplianceCheckMaxPrintedViolations"/>
             </div>
         </div>
+        <div class="form-group row" data-toggle="tooltip" title="@(userConfig.PureLine("H5815"))">
+            <label class="col-form-label col-sm-4">@(userConfig.GetText("complianceCheckSortMatrixByID"))</label>
+            <div class="col-sm-7">
+                <input type="checkbox" @bind="configData!.ComplianceCheckSortMatrixByID"/>
+            </div>
+        </div>
+
+        
     </form>
     <hr />
     <AuthorizeView Roles="@Roles.Admin">


### PR DESCRIPTION
- [x] https://github.com/CactuseSecurity/firewall-orchestrator/issues/3550
   - [x] Create rule - network object - map in compliance report 
   - [x] Set non evaluable compliance state for rules with objects that do not have an ip
   - [x] Set non evaluable state for 0.0.0.0/32 and 255.255.255.255/32
   - [x] Write Non evaluable state reasons in violation details
   - [x] Change non evaluable to not assessable (naming
- [x] fixes resolving services in resolved reports
- [x] Order of network zone matrix configurable to either by name or by id.