### PR TITLE
Coding challange Drechsler Christian

### DIFF
--- a/roles/Directory.Build.props
+++ b/roles/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'FWO.Middleware.Server'">
+    <NoWarn></NoWarn>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'FWO.UI'">
+    <NoWarn>$(NoWarn);CS0169</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/roles/lib/files/FWO.Api.Client/GraphQlApiConnection.cs
+++ b/roles/lib/files/FWO.Api.Client/GraphQlApiConnection.cs
@@ -12,9 +12,9 @@ namespace FWO.Api.Client
     public class GraphQlApiConnection : ApiConnection
     {
         // Server URL
-        public string ApiServerUri { get; private set; }
+        public string ApiServerUri { get; private set; } = "";
 
-        private GraphQLHttpClient graphQlClient;
+        private GraphQLHttpClient graphQlClient = null!;
 
         private string prevRole = "";
 

--- a/roles/lib/files/FWO.Api.Client/GraphQlApiSubscription.cs
+++ b/roles/lib/files/FWO.Api.Client/GraphQlApiSubscription.cs
@@ -1,4 +1,4 @@
-﻿using FWO.Logging;
+using FWO.Logging;
 using GraphQL;
 using GraphQL.Client.Http;
 using Newtonsoft.Json.Linq;
@@ -10,8 +10,8 @@ namespace FWO.Api.Client
         public delegate void SubscriptionUpdate(SubscriptionResponseType reponse);
         public event SubscriptionUpdate OnUpdate;
 
-        private IObservable<GraphQLResponse<dynamic>> subscriptionStream;
-        private IDisposable subscription;
+        private IObservable<GraphQLResponse<dynamic>> subscriptionStream = null!;
+        private IDisposable subscription = null!;
         private readonly GraphQLHttpClient graphQlClient;
         private readonly GraphQLRequest request;
         private readonly Action<Exception> internalExceptionHandler;

--- a/roles/lib/files/FWO.Basics/StringExtensionsSanitizer.cs
+++ b/roles/lib/files/FWO.Basics/StringExtensionsSanitizer.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace FWO.Basics
 {
@@ -13,7 +14,7 @@ namespace FWO.Basics
 
         public static string SanitizeMand(this string text, ref bool shortened)
         {
-            string output = RemoveSpecialChars().Replace(text, "").Trim();
+            string output = RemoveSpecialCharsMand().Replace(text, "").Trim();
             if (output.Length < text.Length)
             {
                 shortened = true;
@@ -21,7 +22,355 @@ namespace FWO.Basics
             return output;
         }
 
+        public static string? SanitizeOpt(this string? input)
+        {
+            bool shortened = false;
+            if (input != null)
+            {
+                string output = SanitizeMand(input, ref shortened);
+                return output;
+            }
+            else return null;
+        }
+
+        public static string? SanitizeOpt(this string? input, ref bool shortened)
+        {
+            if (input != null)
+            {
+                return SanitizeMand(input, ref shortened);
+            }
+            else return null;
+        }
+
+        // Ldap names: more restrictive due to Ldap restrictions. Chars not allowed (would have to be escaped in Dn):   +;,\"<>#
+        public static string SanitizeLdapNameMand(this string input)
+        {
+            bool shortened = false;
+            string output = SanitizeLdapNameMand(input, ref shortened);
+            return output;
+        }
+
+        // Ldap names: more restrictive due to Ldap restrictions. Chars not allowed (would have to be escaped in Dn):   +;,\"<>#
+        public static string SanitizeLdapNameMand(this string input, ref bool shortened)
+        {
+            string output = RemoveSpecialCharsLdapNameMand().Replace(input, "").Trim();
+            if (output.Length < input.Length)
+            {
+                shortened = true;
+            }
+            return output;
+        }
+
+        public static string? SanitizeLdapNameOpt(this string? input)
+        {
+            bool shortened = false;
+            if (input != null)
+            {
+                string output = SanitizeLdapNameMand(input, ref shortened);
+                return output;
+            }
+            else return null;
+        }
+
+        public static string? SanitizeLdapNameOpt(string? input, ref bool shortened)
+        {
+            if (input != null)
+            {
+                return SanitizeLdapNameMand(input, ref shortened);
+            }
+            else return null;
+        }
+
+        // Ldap path (Dn): Additionally needed on top of Ldap names chars:   =,
+        public static string SanitizeLdapPathMand(this string input)
+        {
+            bool shortened = false;
+            string output = SanitizeLdapPathMand(input, ref shortened);
+            return output;
+        }
+
+        // Ldap path (Dn): Additionally needed on top of Ldap names chars:   =,
+        public static string SanitizeLdapPathMand(this string input, ref bool shortened)
+        {
+            string output = RemoveSpecialLdapPathMand().Replace(input, "").Trim();
+            if (output.Length < input.Length)
+            {
+                shortened = true;
+            }
+            return output;
+        }
+
+        public static string? SanitizeLdapPathOpt(this string? input)
+        {
+            bool shortened = false;
+            if (input != null)
+            {
+                string output = SanitizeLdapPathMand(input, ref shortened);
+                return output;
+            }
+            else return null;
+        }
+
+        public static string? SanitizeLdapPathOpt(this string? input, ref bool shortened)
+        {
+            if (input != null)
+            {
+                return SanitizeLdapPathMand(input, ref shortened);
+            }
+            else return null;
+        }
+
+        // Passwords should not have Whitespaces except inner blanks
+        public static string SanitizePasswMand(this string input)
+        {
+            bool shortened = false;
+            string output = SanitizePasswMand(input, ref shortened);
+            return output;
+        }
+
+        // Passwords should not have Whitespaces except inner blanks
+        public static string SanitizePasswMand(this string input, ref bool shortened)
+        {
+            string output = RemoveSpecialPasswMand().Replace(input, "").Trim();
+            if (output.Length < input.Length)
+            {
+                shortened = true;
+            }
+            return output;
+        }
+
+        public static string? SanitizePasswOpt(this string? input)
+        {
+            bool shortened = false;
+            if (input != null)
+            {
+                string output = SanitizePasswMand(input, ref shortened);
+                return output;
+            }
+            else return null;
+        }
+
+        public static string? SanitizePasswOpt(this string? input, ref bool shortened)
+        {
+            if (input != null)
+            {
+                return SanitizePasswMand(input, ref shortened);
+            }
+            else return null;
+        }
+
+        // Keys are only trimmed
+        public static string SanitizeKeyMand(this string input)
+        {
+            bool shortened = false;
+            string output = SanitizeKeyMand(input, ref shortened);
+            return output;
+        }
+
+        // Keys are only trimmed
+        public static string SanitizeKeyMand(this string input, ref bool shortened)
+        {
+            string output = input.Trim();
+            if (output.Length < input.Length)
+            {
+                shortened = true;
+            }
+            return output;
+        }
+
+        public static string? SanitizeKeyOpt(this string? input)
+        {
+            bool shortened = false;
+            if (input != null)
+            {
+                string output = SanitizeKeyMand(input, ref shortened);
+                return output;
+            }
+            else return null;
+        }
+
+        public static string? SanitizeKeyOpt(this string? input, ref bool shortened)
+        {
+            if (input != null)
+            {
+                return SanitizeKeyMand(input, ref shortened);
+            }
+            else return null;
+        }
+
+
+        // Comments may contain everything but quotes (EOL chars are allowed)
+        public static string SanitizeCommentMand(this string input)
+        {
+            bool shortened = false;
+            string output = SanitizeCommentMand(input, ref shortened);
+            return output;
+        }
+
+        // Comments may contain everything but quotes (EOL chars are allowed)
+        public static string SanitizeCommentMand(this string input, ref bool shortened)
+        {
+            string output = RemoveSpecialCommentMand().Replace(input, "").Trim();
+            string ignorableChangeCompareString = output + "\n";
+
+            if (input!=null)
+            {
+                if (output.Length < input.Length)   // there is always an EOL char added in text fields
+                {
+                    if (ignorableChangeCompareString != input)
+                    {
+                        shortened = true;
+                    }
+                }
+            }
+            return output;
+        }
+
+
+        public static string? SanitizeCommentOpt(this string? input)
+        {
+            bool shortened = false;
+            if (input != null)
+            {
+                string output = SanitizeCommentMand(input, ref shortened);
+                return output;
+            }
+            else return null;
+        }
+
+
+        public static string? SanitizeCommentOpt(this string? input, ref bool shortened)
+        {
+            if (input != null)
+            {
+                return SanitizeCommentMand(input, ref shortened);
+            }
+            else return null;
+        }
+
+        public static string SanitizeCidrMand(this string input)
+        {
+            bool shortened = false;
+            string output = SanitizeCidrMand(input, ref shortened);
+            return output;
+        }
+
+        public static string SanitizeCidrMand(this string input, ref bool shortened)
+        {
+            string output = RemoveSpecialCidrMand().Replace(input, "").Trim();
+            if (output.Length < input.Length)
+            {
+                shortened = true;
+            }
+            return output;
+        }
+
+        public static string? SanitizeCidrOpt(this string? input)
+        {
+            bool shortened = false;
+            if (input != null)
+            {
+                string output = SanitizeCidrMand(input, ref shortened);
+                return output;
+            }
+            else return null;
+        }
+
+        public static string? SanitizeCidrOpt(this string? input, ref bool shortened)
+        {
+            if (input != null)
+            {
+                return SanitizeCidrMand(input, ref shortened);
+            }
+            else return null;
+        }
+
+        public static string SanitizeJsonMand(this string input)
+        {
+            bool shortened = false;
+            string output = SanitizeJsonMand(input, ref shortened);
+            return output;
+        }
+
+        public static string SanitizeJsonMand(this string input, ref bool shortened)
+        {
+            string output = RemoveSpecialJsonMand().Replace(input, "").Trim();
+            if (output.Length < input.Length)
+            {
+                shortened = true;
+            }
+            return output;
+        }
+
+        // not allowed: +*(){}[]?!#<>=,;'\"'/\\\t@$%^|&~ -> replaced by "_"
+        public static string SanitizeJsonFieldMand(this string input)
+        {
+            bool shortened = false;
+            string output = SanitizeJsonFieldMand(input, ref shortened);
+            return output;
+        }
+
+        public static string SanitizeJsonFieldMand(this string input, ref bool shortened)
+        {
+            string output = RemoveSpecialJsonFieldMand().Replace(input, "_").Trim();
+            if (output.Length < input.Length)
+            {
+                shortened = true;
+            }
+            return output;
+        }
+
+        public static string SanitizeEolMand(this string input)
+        {
+            bool shortened = false;
+            string output = SanitizeEolMand(input, ref shortened);
+            return output;
+        }
+
+        public static string SanitizeEolMand(this string input, ref bool shortened)
+        {
+            string output = RemoveSpecialEolMand().Replace(input, " ").Trim();
+            if (output.Length < input.Length)
+            {
+                shortened = true;
+            }
+            return output;
+        }
+
         [GeneratedRegex(@"[^\w\.\*\-\:\?@/\(\)\[\]\{\}\$\+<>#\$ ]")]
-        private static partial Regex RemoveSpecialChars();
+        private static partial Regex RemoveSpecialCharsMand();
+
+        [GeneratedRegex(@"[^\w\.\*\-\:\?@/\(\) ]")]
+        private static partial Regex RemoveSpecialCharsLdapNameMand();
+
+        [GeneratedRegex(@"[^\w\.\*\-\:\?@/\(\)\=\, \\]")]
+        private static partial Regex RemoveSpecialLdapPathMand();
+
+        [GeneratedRegex(@"[^\S ]")]
+        private static partial Regex RemoveSpecialPasswMand();
+
+        [GeneratedRegex(@"[""'']")]
+        private static partial Regex RemoveSpecialCommentMand();
+
+        [GeneratedRegex(@"[^a-fA-F0-9\.\:/]")]
+        private static partial Regex RemoveSpecialCidrMand();
+
+        [GeneratedRegex(@"[^\S ]")]
+        private static partial Regex RemoveSpecialJsonMand();
+
+        [GeneratedRegex(@"[\+\*\(\)\{\}\[\]\?\!#<>\=\,\;\/\\\t@\$\%\^\|\&\~ ]")]
+        private static partial Regex RemoveSpecialJsonFieldMand();
+
+        [GeneratedRegex(@"[\n\r]")]
+        private static partial Regex RemoveSpecialEolMand();
+
+
+
+
+
+
+
+        
+        
     }
 }

--- a/roles/lib/files/FWO.Config.Api/Config.cs
+++ b/roles/lib/files/FWO.Config.Api/Config.cs
@@ -1,4 +1,4 @@
-﻿using FWO.Api.Client;
+using FWO.Api.Client;
 using FWO.Api.Client.Queries;
 using FWO.Config.Api.Data;
 using FWO.Logging;
@@ -13,7 +13,7 @@ namespace FWO.Config.Api
         /// <summary>
         /// Internal connection to api server. Used to get/edit config data.
         /// </summary>
-        protected ApiConnection apiConnection;
+        protected ApiConnection? apiConnection;
 
         public int UserId { get; private set; }
         public bool Initialized { get; private set; } = false;

--- a/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
+++ b/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
@@ -287,7 +287,7 @@ namespace FWO.Config.Api.Data
         public DateTime ImportAppDataStartAt { get; set; } = DateTime.Now;
 
         [JsonProperty("ownerLdapId"), JsonPropertyName("ownerLdapId")]
-        public int OwnerLdapId { get; set; } = GlobalConst.kLdapInternalId;
+        public List<int> OwnerLdapIds { get; set; } = new() { GlobalConst.kLdapInternalId };
 
         [JsonProperty("manageOwnerLdapGroups"), JsonPropertyName("manageOwnerLdapGroups")]
         public bool ManageOwnerLdapGroups { get; set; } = true;

--- a/roles/lib/files/FWO.Config.Api/UserConfig.cs
+++ b/roles/lib/files/FWO.Config.Api/UserConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using FWO.Basics;
 using FWO.Logging;
 using FWO.Config.Api.Data;
@@ -195,6 +195,13 @@ namespace FWO.Config.Api
         public async Task<Dictionary<string, string>> GetCustomDict(string languageName)
         {
             Dictionary<string, string> dict = [];
+
+            if (apiConnection == null)
+            {
+                Log.WriteError("ApiConnection is null", "The ApiConnection is not initialized.");
+                return dict;
+            }
+
             try
             {
                 List<UiText> uiTexts = await apiConnection.SendQueryAsync<List<UiText>>(ConfigQueries.getCustomTextsPerLanguage, new { language = languageName });

--- a/roles/lib/files/FWO.Data/Device.cs
+++ b/roles/lib/files/FWO.Data/Device.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data
@@ -65,11 +66,11 @@ namespace FWO.Data
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeOpt(Name, ref shortened);
-            LocalRulebase = Sanitizer.SanitizeOpt(LocalRulebase, ref shortened);
-            GlobalRulebase = Sanitizer.SanitizeOpt(GlobalRulebase, ref shortened);
-            Package = Sanitizer.SanitizeOpt(Package, ref shortened);
-            Comment = Sanitizer.SanitizeCommentOpt(Comment, ref shortened);
+            Name = Name.SanitizeOpt(ref shortened);
+            LocalRulebase = LocalRulebase.SanitizeOpt(ref shortened);
+            GlobalRulebase = GlobalRulebase.SanitizeOpt( ref shortened);
+            Package = Package.SanitizeOpt(ref shortened);
+            Comment = Comment.SanitizeCommentOpt(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/DisplayBase.cs
+++ b/roles/lib/files/FWO.Data/DisplayBase.cs
@@ -10,10 +10,20 @@ namespace FWO.Data
     {
         public static StringBuilder DisplayService(NetworkService service, bool isTechReport, string? serviceName = null)
         {
-            StringBuilder result = new ();
+            StringBuilder result = new();
             string ports = service.DestinationPortEnd == null || service.DestinationPortEnd == 0 || service.DestinationPort == service.DestinationPortEnd ?
                 $"{service.DestinationPort}" : $"{service.DestinationPort}-{service.DestinationPortEnd}";
             bool displayPorts = service.Protocol != null && service.Protocol.HasPorts() && service.DestinationPort != null;
+
+            if (service.Protocol?.Id == 0 &&
+                (service.Name.Equals("any", StringComparison.OrdinalIgnoreCase) ||
+                service.Name.Equals("all", StringComparison.OrdinalIgnoreCase) ||
+                service.Protocol.Name.Equals("HOPOPT", StringComparison.OrdinalIgnoreCase)
+                ))
+            {
+                return result;
+            }
+
             if (isTechReport)
             {
                 if (displayPorts)

--- a/roles/lib/files/FWO.Data/ExternalTicketSystem.cs
+++ b/roles/lib/files/FWO.Data/ExternalTicketSystem.cs
@@ -1,4 +1,4 @@
-﻿using FWO.Basics;
+using FWO.Basics;
 using FWO.Data.Workflow;
 using Newtonsoft.Json;
 using System.Text.Json;
@@ -83,10 +83,10 @@ namespace FWO.Data
 		public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
-            Url = Sanitizer.SanitizePasswMand(Url, ref shortened);
-			TicketTemplate = Sanitizer.SanitizeJsonMand(TicketTemplate, ref shortened);
-			TasksTemplate = Sanitizer.SanitizeJsonMand(TasksTemplate, ref shortened);
+            Name = Name.SanitizeMand();
+            Url = Url.SanitizePasswMand();
+			TicketTemplate = TicketTemplate.SanitizeJsonMand();
+			TasksTemplate = TasksTemplate.SanitizeJsonMand();
 			foreach(var template in Templates)
 			{
 				shortened = template.Sanitize();
@@ -131,16 +131,16 @@ namespace FWO.Data
 		public bool Sanitize()
 		{
 			bool shortened = false;
-			TaskType = Sanitizer.SanitizeMand(TaskType, ref shortened);
-			TicketTemplate = Sanitizer.SanitizeJsonMand(TicketTemplate, ref shortened);
-			TasksTemplate = Sanitizer.SanitizeJsonMand(TasksTemplate, ref shortened);
-			ObjectTemplate = Sanitizer.SanitizeJsonMand(ObjectTemplate, ref shortened);
-			ObjectTemplateShort = Sanitizer.SanitizeJsonMand(ObjectTemplateShort, ref shortened);
-			IpTemplate = Sanitizer.SanitizeJsonMand(IpTemplate, ref shortened);
-			NwObjGroupTemplate = Sanitizer.SanitizeJsonMand(NwObjGroupTemplate, ref shortened);
-			ServiceTemplate = Sanitizer.SanitizeJsonMand(ServiceTemplate, ref shortened);
-			IcmpTemplate = Sanitizer.SanitizeJsonMand(IcmpTemplate, ref shortened);
-			IpProtocolTemplate = Sanitizer.SanitizeJsonMand(IpProtocolTemplate, ref shortened);
+			TaskType = TaskType.SanitizeMand();
+			TicketTemplate = TicketTemplate.SanitizeJsonMand();
+			TasksTemplate = TasksTemplate.SanitizeJsonMand();
+			ObjectTemplate = ObjectTemplate.SanitizeJsonMand();
+			ObjectTemplateShort = ObjectTemplateShort.SanitizeJsonMand();
+			IpTemplate = IpTemplate.SanitizeJsonMand();
+			NwObjGroupTemplate = NwObjGroupTemplate.SanitizeJsonMand();
+			ServiceTemplate = ServiceTemplate.SanitizeJsonMand();
+			IcmpTemplate = IcmpTemplate.SanitizeJsonMand();
+			IpProtocolTemplate = IpProtocolTemplate.SanitizeJsonMand();
 			return shortened;
 		}
 	}

--- a/roles/lib/files/FWO.Data/FwoOwner.cs
+++ b/roles/lib/files/FWO.Data/FwoOwner.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data
@@ -82,9 +83,9 @@ namespace FWO.Data
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            Criticality = Sanitizer.SanitizeOpt(Criticality, ref shortened);
-            ImportSource = Sanitizer.SanitizeCommentOpt(ImportSource, ref shortened);
-            LastRecertifierDn = Sanitizer.SanitizeLdapPathOpt(LastRecertifierDn, ref shortened);
+            Criticality = Criticality.SanitizeOpt(ref shortened);
+            ImportSource = ImportSource.SanitizeCommentOpt(ref shortened);
+            LastRecertifierDn = LastRecertifierDn.SanitizeLdapPathOpt(ref shortened);
             return shortened;
         }
 

--- a/roles/lib/files/FWO.Data/FwoOwnerBase.cs
+++ b/roles/lib/files/FWO.Data/FwoOwnerBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data
@@ -55,10 +56,10 @@ namespace FWO.Data
         public virtual bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
-            Dn = Sanitizer.SanitizeLdapPathMand(Dn, ref shortened);
-            GroupDn = Sanitizer.SanitizeLdapPathMand(GroupDn, ref shortened);
-            ExtAppId = Sanitizer.SanitizeCommentOpt(ExtAppId, ref shortened);
+            Name = Name.SanitizeMand();
+            Dn = Dn.SanitizeLdapPathMand();
+            GroupDn = GroupDn.SanitizeLdapPathMand();
+            ExtAppId = ExtAppId.SanitizeCommentOpt();
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/ImportCredential.cs
+++ b/roles/lib/files/FWO.Data/ImportCredential.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using FWO.Basics;
+using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 namespace FWO.Data
@@ -51,12 +52,12 @@ namespace FWO.Data
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
-            ImportUser = Sanitizer.SanitizeOpt(ImportUser, ref shortened);
-            PublicKey = Sanitizer.SanitizeKeyOpt(PublicKey, ref shortened);
-            Secret = Sanitizer.SanitizeKeyMand(Secret, ref shortened);
-            CloudClientId = Sanitizer.SanitizeOpt(CloudClientId, ref shortened);
-            CloudClientSecret = Sanitizer.SanitizeKeyOpt(CloudClientSecret, ref shortened);
+            Name = Name.SanitizeMand();
+            ImportUser = ImportUser.SanitizeOpt();
+            PublicKey = PublicKey.SanitizeKeyOpt();
+            Secret = Secret.SanitizeKeyMand();
+            CloudClientId = CloudClientId.SanitizeOpt();
+            CloudClientSecret = CloudClientSecret.SanitizeKeyOpt();
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/LdapConnectionBase.cs
+++ b/roles/lib/files/FWO.Data/LdapConnectionBase.cs
@@ -1,3 +1,4 @@
+using FWO.Basics;
 using FWO.Data.Middleware;
 using Newtonsoft.Json; 
 using System.Text.Json.Serialization; 
@@ -117,16 +118,16 @@ namespace FWO.Data
         public virtual bool Sanitize()
         {
             bool shortened = false;
-            Address = Sanitizer.SanitizeMand(Address, ref shortened);
-            SearchUser = Sanitizer.SanitizeLdapPathOpt(SearchUser, ref shortened) ?? "";
-            UserSearchPath = Sanitizer.SanitizeLdapPathOpt(UserSearchPath, ref shortened);
-            RoleSearchPath = Sanitizer.SanitizeLdapPathOpt(RoleSearchPath, ref shortened);
-            GroupSearchPath = Sanitizer.SanitizeLdapPathOpt(GroupSearchPath, ref shortened);
-            GroupWritePath = Sanitizer.SanitizeLdapPathOpt(GroupWritePath, ref shortened);
-            WriteUser = Sanitizer.SanitizeLdapPathOpt(WriteUser, ref shortened);
-            GlobalTenantName = Sanitizer.SanitizeOpt(GlobalTenantName, ref shortened);
-            SearchUserPwd = Sanitizer.SanitizePasswOpt(SearchUserPwd, ref shortened) ?? "";
-            WriteUserPwd = Sanitizer.SanitizePasswOpt(WriteUserPwd, ref shortened);
+            Address = Address.SanitizeMand();
+            SearchUser = SearchUser.SanitizeLdapPathOpt() ?? "";
+            UserSearchPath = UserSearchPath.SanitizeLdapPathOpt();
+            RoleSearchPath = RoleSearchPath.SanitizeLdapPathOpt();
+            GroupSearchPath = GroupSearchPath.SanitizeLdapPathOpt();
+            GroupWritePath = GroupWritePath.SanitizeLdapPathOpt();
+            WriteUser = WriteUser.SanitizeLdapPathOpt();
+            GlobalTenantName = GlobalTenantName.SanitizeOpt();
+            SearchUserPwd = SearchUserPwd.SanitizePasswOpt() ?? "";
+            WriteUserPwd = WriteUserPwd.SanitizePasswOpt();
             return shortened;
         }
 

--- a/roles/lib/files/FWO.Data/Management.cs
+++ b/roles/lib/files/FWO.Data/Management.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using FWO.Basics;
+using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 namespace FWO.Data
@@ -129,14 +130,14 @@ namespace FWO.Data
         public virtual bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
-            Hostname = Sanitizer.SanitizeMand(Hostname, ref shortened);
-            ConfigPath = Sanitizer.SanitizeOpt(ConfigPath, ref shortened);
-            DomainUid = Sanitizer.SanitizeOpt(DomainUid, ref shortened);
-            ImporterHostname = Sanitizer.SanitizeMand(ImporterHostname, ref shortened);
-            Comment = Sanitizer.SanitizeCommentOpt(Comment, ref shortened);
-            CloudSubscriptionId = Sanitizer.SanitizeOpt(CloudSubscriptionId, ref shortened);
-            CloudTenantId = Sanitizer.SanitizeOpt(CloudTenantId, ref shortened);
+            Name = Name.SanitizeMand();
+            Hostname = Hostname.SanitizeMand();
+            ConfigPath = ConfigPath.SanitizeOpt();
+            DomainUid = DomainUid.SanitizeOpt();
+            ImporterHostname = ImporterHostname.SanitizeMand();
+            Comment = Comment.SanitizeCommentOpt();
+            CloudSubscriptionId = CloudSubscriptionId.SanitizeOpt();
+            CloudTenantId = CloudTenantId.SanitizeOpt();
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Modelling/ModellingAppRole.cs
+++ b/roles/lib/files/FWO.Data/Modelling/ModellingAppRole.cs
@@ -104,8 +104,8 @@ namespace FWO.Data.Modelling
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            Comment = Sanitizer.SanitizeCommentOpt(Comment, ref shortened);
-            Creator = Sanitizer.SanitizeOpt(Creator, ref shortened);
+            Comment = Comment.SanitizeCommentOpt(ref shortened);
+            Creator = Creator.SanitizeOpt(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Modelling/ModellingAppServer.cs
+++ b/roles/lib/files/FWO.Data/Modelling/ModellingAppServer.cs
@@ -42,9 +42,9 @@ namespace FWO.Data.Modelling
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            Ip = Sanitizer.SanitizeCidrMand(Ip, ref shortened);
-            IpEnd = Sanitizer.SanitizeCidrMand(IpEnd, ref shortened);
-            ImportSource = Sanitizer.SanitizeMand(ImportSource, ref shortened);
+            Ip = Ip.SanitizeCidrMand();
+            IpEnd = IpEnd.SanitizeCidrMand();
+            ImportSource = ImportSource.SanitizeMand();
             return shortened;
         }
 

--- a/roles/lib/files/FWO.Data/Modelling/ModellingConnection.cs
+++ b/roles/lib/files/FWO.Data/Modelling/ModellingConnection.cs
@@ -441,11 +441,11 @@ namespace FWO.Data.Modelling
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeOpt(Name, ref shortened);
-            Reason = Sanitizer.SanitizeCommentOpt(Reason, ref shortened);
-            Creator = Sanitizer.SanitizeOpt(Creator, ref shortened);
-            Properties = Sanitizer.SanitizeKeyOpt(Properties, ref shortened);
-            ExtraParams = Sanitizer.SanitizeKeyOpt(ExtraParams, ref shortened);
+            Name = Name.SanitizeOpt(ref shortened);
+            Reason = Reason.SanitizeCommentOpt(ref shortened);
+            Creator = Creator.SanitizeOpt(ref shortened);
+            Properties = Properties.SanitizeKeyOpt(ref shortened);
+            ExtraParams = ExtraParams.SanitizeKeyOpt(ref shortened);
             return shortened;
         }
 

--- a/roles/lib/files/FWO.Data/Modelling/ModellingExtraConfig.cs
+++ b/roles/lib/files/FWO.Data/Modelling/ModellingExtraConfig.cs
@@ -34,8 +34,8 @@ namespace FWO.Data.Modelling
         public bool Sanitize()
         {
             bool shortened = false;
-            ExtraConfigType = Sanitizer.SanitizeMand(ExtraConfigType, ref shortened);
-            ExtraConfigText = Sanitizer.SanitizeMand(ExtraConfigText, ref shortened);
+            ExtraConfigType = ExtraConfigType.SanitizeMand();
+            ExtraConfigText = ExtraConfigText.SanitizeMand();
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Modelling/ModellingNetworkArea.cs
+++ b/roles/lib/files/FWO.Data/Modelling/ModellingNetworkArea.cs
@@ -95,9 +95,9 @@ namespace FWO.Data.Modelling
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
-            Ip = Sanitizer.SanitizeOpt(Ip, ref shortened);
-            IpEnd = Sanitizer.SanitizeOpt(IpEnd, ref shortened);
+            Name = Name.SanitizeMand();
+            Ip = Ip.SanitizeOpt();
+            IpEnd = IpEnd.SanitizeOpt();
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Modelling/ModellingNwGroup.cs
+++ b/roles/lib/files/FWO.Data/Modelling/ModellingNwGroup.cs
@@ -64,7 +64,7 @@ namespace FWO.Data.Modelling
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            ManagedIdString.FreePart = Sanitizer.SanitizeMand(ManagedIdString.FreePart, ref shortened);
+            ManagedIdString.FreePart = ManagedIdString.FreePart.SanitizeMand(ref shortened);
             return shortened;
         }
 

--- a/roles/lib/files/FWO.Data/Modelling/ModellingObject.cs
+++ b/roles/lib/files/FWO.Data/Modelling/ModellingObject.cs
@@ -67,7 +67,7 @@ namespace FWO.Data.Modelling
         public virtual bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
+            Name = Name.SanitizeMand(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Modelling/ModellingServiceGroup.cs
+++ b/roles/lib/files/FWO.Data/Modelling/ModellingServiceGroup.cs
@@ -59,8 +59,8 @@ namespace FWO.Data.Modelling
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            Comment = Sanitizer.SanitizeCommentOpt(Comment, ref shortened);
-            Creator = Sanitizer.SanitizeOpt(Creator, ref shortened);
+            Comment = Comment.SanitizeCommentOpt(ref shortened);
+            Creator = Creator.SanitizeOpt(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Report/ReportFile.cs
+++ b/roles/lib/files/FWO.Data/Report/ReportFile.cs
@@ -1,4 +1,5 @@
-using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 
@@ -51,7 +52,7 @@ namespace FWO.Data.Report
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
+            Name = Name.SanitizeMand(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Report/ReportSchedule.cs
+++ b/roles/lib/files/FWO.Data/Report/ReportSchedule.cs
@@ -1,4 +1,5 @@
-using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 
@@ -39,7 +40,7 @@ namespace FWO.Data.Report
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
+            Name = Name.SanitizeMand(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Report/ReportTemplate.cs
+++ b/roles/lib/files/FWO.Data/Report/ReportTemplate.cs
@@ -1,4 +1,5 @@
-using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data.Report
@@ -42,8 +43,8 @@ namespace FWO.Data.Report
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
-            Comment = Sanitizer.SanitizeMand(Comment, ref shortened);
+            Name = Name.SanitizeMand(ref shortened);
+            Comment = Comment.SanitizeMand(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Sanitizer.cs
+++ b/roles/lib/files/FWO.Data/Sanitizer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 
 namespace FWO.Data
 {

--- a/roles/lib/files/FWO.Data/Tenant.cs
+++ b/roles/lib/files/FWO.Data/Tenant.cs
@@ -1,4 +1,5 @@
-﻿using FWO.Data.Middleware;
+using FWO.Basics;
+using FWO.Data.Middleware;
 using Newtonsoft.Json;
 using System.Text.Json.Serialization; 
 
@@ -77,9 +78,9 @@ namespace FWO.Data
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeLdapNameMand(Name, ref shortened);
-            Comment = Sanitizer.SanitizeOpt(Comment, ref shortened);
-            Project = Sanitizer.SanitizeOpt(Project, ref shortened);
+            Name = Name.SanitizeLdapNameMand(ref shortened);
+            Comment = Comment.SanitizeOpt(ref shortened);
+            Project = Project.SanitizeOpt(ref shortened);
             return shortened;
         }
 

--- a/roles/lib/files/FWO.Data/UiLdapConnection.cs
+++ b/roles/lib/files/FWO.Data/UiLdapConnection.cs
@@ -1,3 +1,4 @@
+using FWO.Basics;
 using FWO.Data.Middleware;
 using Newtonsoft.Json;
 using System.Text.Json.Serialization; 
@@ -38,7 +39,7 @@ namespace FWO.Data
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            Name = Sanitizer.SanitizeMand(Name, ref shortened);
+            Name = Name.SanitizeMand(ref shortened);
             return shortened;
         }
 

--- a/roles/lib/files/FWO.Data/UiUser.cs
+++ b/roles/lib/files/FWO.Data/UiUser.cs
@@ -1,4 +1,5 @@
-﻿using FWO.Data.Middleware;
+using FWO.Basics;
+using FWO.Data.Middleware;
 using Newtonsoft.Json;
 using System.Text.Json.Serialization; 
 
@@ -106,11 +107,11 @@ namespace FWO.Data
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeLdapNameMand(Name, ref shortened);
-            Email = Sanitizer.SanitizeOpt(Email, ref shortened);
-            Firstname = Sanitizer.SanitizeOpt(Firstname, ref shortened);
-            Lastname = Sanitizer.SanitizeOpt(Lastname, ref shortened);
-            Password = Sanitizer.SanitizePasswMand(Password, ref shortened);
+            Name = Name.SanitizeLdapNameMand(ref shortened);
+            Email = Email.SanitizeOpt(ref shortened);
+            Firstname = Firstname.SanitizeOpt(ref shortened);
+            Lastname = Lastname.SanitizeOpt(ref shortened);
+            Password = Password.SanitizePasswMand(ref shortened);
             return shortened;
         }
 

--- a/roles/lib/files/FWO.Data/UserGroup.cs
+++ b/roles/lib/files/FWO.Data/UserGroup.cs
@@ -1,4 +1,6 @@
-﻿namespace FWO.Data
+using FWO.Basics;
+
+namespace FWO.Data
 {
     public class UserGroup
     {
@@ -38,7 +40,7 @@
         public bool Sanitize()
         {
             bool shortened = false;
-            Name = Sanitizer.SanitizeLdapNameMand(Name, ref shortened);
+            Name = Name.SanitizeLdapNameMand(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Workflow/WfApprovalBase.cs
+++ b/roles/lib/files/FWO.Data/Workflow/WfApprovalBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data.Workflow
@@ -47,8 +48,8 @@ namespace FWO.Data.Workflow
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            ApproverGroup = Sanitizer.SanitizeLdapPathOpt(ApproverGroup, ref shortened);
-            ApproverDn = Sanitizer.SanitizeLdapPathOpt(ApproverDn, ref shortened);
+            ApproverGroup = ApproverGroup.SanitizeLdapPathOpt(ref shortened);
+            ApproverDn = ApproverDn.SanitizeLdapPathOpt(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Workflow/WfCommentBase.cs
+++ b/roles/lib/files/FWO.Data/Workflow/WfCommentBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data.Workflow
@@ -36,8 +37,8 @@ namespace FWO.Data.Workflow
         public virtual bool Sanitize()
         {
             bool shortened = false;
-            Scope = Sanitizer.SanitizeMand(Scope, ref shortened);
-            CommentText = Sanitizer.SanitizeMand(CommentText, ref shortened);
+            Scope = Scope.SanitizeMand(ref shortened);
+            CommentText = CommentText.SanitizeMand(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Workflow/WfElementBase.cs
+++ b/roles/lib/files/FWO.Data/Workflow/WfElementBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data.Workflow
@@ -88,12 +89,12 @@ namespace FWO.Data.Workflow
         public virtual bool Sanitize()
         {
             bool shortened = false;
-            IpString = Sanitizer.SanitizeOpt(IpString, ref shortened);
-            IpEnd = Sanitizer.SanitizeOpt(IpEnd, ref shortened);
-            Field = Sanitizer.SanitizeMand(Field, ref shortened);
-            RuleUid = Sanitizer.SanitizeOpt(RuleUid, ref shortened);
-            GroupName = Sanitizer.SanitizeOpt(GroupName, ref shortened);
-            Name = Sanitizer.SanitizeOpt(Name, ref shortened);
+            IpString = IpString.SanitizeOpt(ref shortened);
+            IpEnd = IpEnd.SanitizeOpt(ref shortened);
+            Field = Field.SanitizeMand(ref shortened);
+            RuleUid = RuleUid.SanitizeOpt(ref shortened);
+            GroupName = GroupName.SanitizeOpt(ref shortened);
+            Name = Name.SanitizeOpt(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Workflow/WfReqTaskBase.cs
+++ b/roles/lib/files/FWO.Data/Workflow/WfReqTaskBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data.Workflow
@@ -148,7 +149,7 @@ namespace FWO.Data.Workflow
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            Reason = Sanitizer.SanitizeOpt(Reason, ref shortened);
+            Reason = Reason.SanitizeOpt(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Workflow/WfStatefulObject.cs
+++ b/roles/lib/files/FWO.Data/Workflow/WfStatefulObject.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data.Workflow
@@ -88,8 +89,8 @@ namespace FWO.Data.Workflow
         public virtual bool Sanitize()
         {
             bool shortened = false;
-            optComment = Sanitizer.SanitizeOpt(optComment, ref shortened);
-            AssignedGroup = Sanitizer.SanitizeLdapPathOpt(AssignedGroup, ref shortened);
+            optComment = optComment.SanitizeOpt(ref shortened);
+            AssignedGroup = AssignedGroup.SanitizeLdapPathOpt(ref shortened);
             return shortened;
         }
 

--- a/roles/lib/files/FWO.Data/Workflow/WfTaskBase.cs
+++ b/roles/lib/files/FWO.Data/Workflow/WfTaskBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data.Workflow
@@ -90,8 +91,8 @@ namespace FWO.Data.Workflow
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            Title = Sanitizer.SanitizeMand(Title, ref shortened);
-            FreeText = Sanitizer.SanitizeOpt(FreeText, ref shortened);
+            Title = Title.SanitizeMand(ref shortened);
+            FreeText = FreeText.SanitizeOpt(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.Data/Workflow/WfTicketBase.cs
+++ b/roles/lib/files/FWO.Data/Workflow/WfTicketBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization; 
+using System.Text.Json.Serialization;
+using FWO.Basics;
 using Newtonsoft.Json;
 
 namespace FWO.Data.Workflow
@@ -67,11 +68,11 @@ namespace FWO.Data.Workflow
         public override bool Sanitize()
         {
             bool shortened = base.Sanitize();
-            Title = Sanitizer.SanitizeMand(Title, ref shortened);
-            RequesterDn = Sanitizer.SanitizeLdapPathOpt(RequesterDn, ref shortened);
-            RequesterGroup = Sanitizer.SanitizeLdapPathOpt(RequesterGroup, ref shortened);
-            Reason = Sanitizer.SanitizeOpt(Reason, ref shortened);
-            ExternalTicketId = Sanitizer.SanitizeOpt(ExternalTicketId, ref shortened);
+            Title = Title.SanitizeMand(ref shortened);
+            RequesterDn = RequesterDn.SanitizeLdapPathOpt(ref shortened);
+            RequesterGroup = RequesterGroup.SanitizeLdapPathOpt(ref shortened);
+            Reason = Reason.SanitizeOpt(ref shortened);
+            ExternalTicketId = ExternalTicketId.SanitizeOpt(ref shortened);
             return shortened;
         }
     }

--- a/roles/lib/files/FWO.ExternalSystems/Tufin.SecureChange/SCNetworkObjectModifyTicketTask.cs
+++ b/roles/lib/files/FWO.ExternalSystems/Tufin.SecureChange/SCNetworkObjectModifyTicketTask.cs
@@ -35,7 +35,7 @@ namespace FWO.ExternalSystems.Tufin.SecureChange
 				System.Text.Json.JsonSerializer.Deserialize<ExtMgtData>(ReqTask.OnManagement?.ExtMgtData ?? "{}") : new();
 			bool shortened = false;
 			TaskText = template.TasksTemplate
-				.Replace(Placeholder.GROUPNAME, Sanitizer.SanitizeJsonFieldMand(ReqTask.GetAddInfoValue(AdditionalInfoKeys.GrpName), ref shortened))
+				.Replace(Placeholder.GROUPNAME, ReqTask.GetAddInfoValue(AdditionalInfoKeys.GrpName).SanitizeJsonFieldMand(ref shortened))
 				.Replace(Placeholder.MANAGEMENT_ID, extMgt.ExtId ?? "0")
 				.Replace(Placeholder.MANAGEMENT_NAME, extMgt.ExtName)
 				.Replace(Placeholder.CHANGEACTION, ChangeAction)

--- a/roles/lib/files/FWO.ExternalSystems/Tufin.SecureChange/SCTicket.cs
+++ b/roles/lib/files/FWO.ExternalSystems/Tufin.SecureChange/SCTicket.cs
@@ -277,7 +277,7 @@ namespace FWO.ExternalSystems.Tufin.SecureChange
 				.Replace(Placeholder.APPID, appId)
 				.Replace(Placeholder.TASKS, string.Join(",", TicketTasks));
 			bool shortened = false;
-			TicketText = Sanitizer.SanitizeEolMand(TicketText, ref shortened);
+			TicketText = TicketText.SanitizeEolMand(ref shortened);
 			CheckForProperJson(TicketText);
 		}
 

--- a/roles/lib/files/FWO.ExternalSystems/Tufin.SecureChange/SCTicketTask.cs
+++ b/roles/lib/files/FWO.ExternalSystems/Tufin.SecureChange/SCTicketTask.cs
@@ -95,7 +95,7 @@ namespace FWO.ExternalSystems.Tufin.SecureChange
 			bool shortened = false;
 			return template.ObjectTemplate
 				.Replace(Placeholder.TYPE, type)
-				.Replace(Placeholder.OBJECTNAME, Sanitizer.SanitizeJsonFieldMand(objInfo.Name, ref shortened))
+				.Replace(Placeholder.OBJECTNAME, objInfo.Name.SanitizeJsonFieldMand(ref shortened))
 				.Replace(Placeholder.OBJECT_TYPE, objInfo.Type)
 				.Replace(Placeholder.OBJECT_DETAILS, objInfo.Details)
 				.Replace(Placeholder.COMMENT, objInfo.Comment)
@@ -115,7 +115,7 @@ namespace FWO.ExternalSystems.Tufin.SecureChange
 		{
 			bool shortened = false;
 			return template.ObjectTemplateShort
-				.Replace(Placeholder.OBJECTNAME, Sanitizer.SanitizeJsonFieldMand(objName, ref shortened))
+				.Replace(Placeholder.OBJECTNAME, objName.SanitizeJsonFieldMand(ref shortened))
 				.Replace(Placeholder.STATUS, status)
 				.Replace(Placeholder.OBJUPDSTATUS, objUpdStatus)
 				.Replace(Placeholder.MANAGEMENT_ID, mgmId);

--- a/roles/lib/files/FWO.Services/AppServerHelper.cs
+++ b/roles/lib/files/FWO.Services/AppServerHelper.cs
@@ -1,4 +1,4 @@
-﻿using FWO.Data;
+using FWO.Data;
 using FWO.Data.Modelling;
 using FWO.Basics;
 using System.Net;
@@ -41,7 +41,7 @@ namespace FWO.Services
         public static string ConstructSanitizedAppServerName(ModellingAppServer appServer, ModellingNamingConvention namingConvention, bool overwriteExistingNames=false)
         {
             bool shortened = false;
-            return Sanitizer.SanitizeJsonFieldMand(ConstructAppServerName(appServer, namingConvention, overwriteExistingNames), ref shortened);
+            return ConstructAppServerName(appServer, namingConvention, overwriteExistingNames).SanitizeJsonFieldMand(ref shortened);
         }
 
         public static string ConstructAppServerName(ModellingAppServer appServer, ModellingNamingConvention namingConvention, bool overwriteExistingNames=false)

--- a/roles/lib/files/FWO.Services/EventMediator/Events/CollectionChangedEvent.cs
+++ b/roles/lib/files/FWO.Services/EventMediator/Events/CollectionChangedEvent.cs
@@ -2,8 +2,11 @@ using FWO.Services.EventMediator.Interfaces;
 
 namespace FWO.Services.EventMediator.Events
 {
+
+#pragma warning disable CS9113 // Der Parameter ist ungelesen.
     public class CollectionChangedEvent(CollectionChangedEventArgs? eventArgs = default) : IEvent
     {
         IEventArgs? IEvent.EventArgs { get; set; }
     }
+#pragma warning restore CS9113 // Der Parameter ist ungelesen.
 }

--- a/roles/lib/files/FWO.Services/ModellingVarianceAnalysisObjectsForRequest.cs
+++ b/roles/lib/files/FWO.Services/ModellingVarianceAnalysisObjectsForRequest.cs
@@ -1,4 +1,4 @@
-﻿using FWO.Basics;
+using FWO.Basics;
 using FWO.Data;
 using FWO.Data.Modelling;
 using FWO.Data.Workflow;
@@ -274,7 +274,7 @@ namespace FWO.Services
             Log.WriteDebug($"Search {nwGroupType}", $"Name: {appRole.Name}, IdString: {appRole.IdString}, Management: {mgt.Name}");
 
             bool shortened = false;
-            string sanitizedARName = Sanitizer.SanitizeJsonFieldMand(appRole.IdString, ref shortened);
+            string sanitizedARName = appRole.IdString.SanitizeJsonFieldMand(ref shortened);
             if (allProdAppRoles.ContainsKey(mgt.Id))
             {
                 existingAppRole = allProdAppRoles[mgt.Id].FirstOrDefault(a => a.Name == appRole.IdString || a.Name == sanitizedARName);

--- a/roles/middleware/files/FWO.Middleware.Server/AppDataImport.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/AppDataImport.cs
@@ -13,219 +13,220 @@ using System.Text.Json;
 
 namespace FWO.Middleware.Server
 {
-	/// <summary>
-	/// Class handling the App Data Import
-	/// </summary>
-	public class AppDataImport : DataImportBase
-	{
-		private List<ModellingImportAppData> importedApps = [];
-		private List<FwoOwner> existingApps = [];
-		private List<ModellingAppServer> existingAppServers = [];
+    /// <summary>
+    /// Class handling the App Data Import
+    /// </summary>
+    public class AppDataImport : DataImportBase
+    {
+        private List<ModellingImportAppData> importedApps = [];
+        private List<FwoOwner> existingApps = [];
+        private List<ModellingAppServer> existingAppServers = [];
 
-		private Ldap internalLdap = new();
-		private Ldap ownerGroupLdap = new();
+        private Ldap internalLdap = new();
+        private List<Ldap> ownerGroupLdaps = new();
 
-		private List<Ldap> connectedLdaps = [];
-		private string modellerRoleDn = "";
-		private string requesterRoleDn = "";
-		private string implementerRoleDn = "";
-		private string reviewerRoleDn = "";
-		private string? ownerGroupLdapPath = "";
-		private List<GroupGetReturnParameters> allGroups = [];
-		private List<GroupGetReturnParameters> allInternalGroups = [];
-		private ModellingNamingConvention NamingConvention = new();
-		private UserConfig userConfig = new();
-		private const string LogMessageTitle = "Import App Data";
-		private const string LevelFile = "Import File";
-		private const string LevelApp = "App";
-		private const string LevelAppServer = "App Server";
+        private List<Ldap> connectedLdaps = [];
+        private string modellerRoleDn = "";
+        private string requesterRoleDn = "";
+        private string implementerRoleDn = "";
+        private string reviewerRoleDn = "";
+        private List<string?> ownerGroupLdapPaths = new();
+        private List<GroupGetReturnParameters> allGroups = [];
+        private List<GroupGetReturnParameters> allInternalGroups = [];
+        private ModellingNamingConvention NamingConvention = new();
+        private UserConfig userConfig = new();
+        private const string LogMessageTitle = "Import App Data";
+        private const string LevelFile = "Import File";
+        private const string LevelApp = "App";
+        private const string LevelAppServer = "App Server";
 
-		/// <summary>
-		/// Constructor for App Data Import
-		/// </summary>
-		public AppDataImport(ApiConnection apiConnection, GlobalConfig globalConfig) : base(apiConnection, globalConfig)
-		{ }
+        /// <summary>
+        /// Constructor for App Data Import
+        /// </summary>
+        public AppDataImport(ApiConnection apiConnection, GlobalConfig globalConfig) : base(apiConnection, globalConfig)
+        { }
 
-		/// <summary>
-		/// Run the App Data Import
-		/// </summary>
-		public async Task<List<string>> Run()
-		{
-			NamingConvention = JsonSerializer.Deserialize<ModellingNamingConvention>(globalConfig.ModNamingConvention) ?? new();
-			List<string> importfilePathAndNames = JsonSerializer.Deserialize<List<string>>(globalConfig.ImportAppDataPath) ?? throw new JsonException("Config Data could not be deserialized.");
-			userConfig = new(globalConfig);
-			userConfig.User.Name = Roles.MiddlewareServer;
-			userConfig.AutoReplaceAppServer = globalConfig.AutoReplaceAppServer;
-			await InitLdap();
-			List<string> failedImports = [];
-			foreach (var importfilePathAndName in importfilePathAndNames)
-			{
-				if (!RunImportScript(importfilePathAndName + ".py"))
-				{
-					Log.WriteInfo(LogMessageTitle, $"Script {importfilePathAndName}.py failed but trying to import from existing file.");
-				}
-				await ImportSingleSource(importfilePathAndName + ".json", failedImports);
-			}
-			return failedImports;
-		}
+        /// <summary>
+        /// Run the App Data Import
+        /// </summary>
+        public async Task<List<string>> Run()
+        {
+            NamingConvention = JsonSerializer.Deserialize<ModellingNamingConvention>(globalConfig.ModNamingConvention) ?? new();
+            List<string> importfilePathAndNames = JsonSerializer.Deserialize<List<string>>(globalConfig.ImportAppDataPath) ?? throw new JsonException("Config Data could not be deserialized.");
+            userConfig = new(globalConfig);
+            userConfig.User.Name = Roles.MiddlewareServer;
+            userConfig.AutoReplaceAppServer = globalConfig.AutoReplaceAppServer;
+            await InitLdap();
+            List<string> failedImports = [];
+            foreach (var importfilePathAndName in importfilePathAndNames)
+            {
+                if (!RunImportScript(importfilePathAndName + ".py"))
+                {
+                    Log.WriteInfo(LogMessageTitle, $"Script {importfilePathAndName}.py failed but trying to import from existing file.");
+                }
+                await ImportSingleSource(importfilePathAndName + ".json", failedImports);
+            }
+            return failedImports;
+        }
 
-		private async Task InitLdap()
-		{
-			connectedLdaps = await apiConnection.SendQueryAsync<List<Ldap>>(AuthQueries.getLdapConnections);
-			internalLdap = connectedLdaps.FirstOrDefault(x => x.IsInternal() && x.HasGroupHandling()) ?? throw new KeyNotFoundException("No internal Ldap with group handling found.");
-			ownerGroupLdap = connectedLdaps.FirstOrDefault(x => x.Id == globalConfig.OwnerLdapId) ?? throw new KeyNotFoundException("Ldap with group handling not found.");
-			modellerRoleDn = $"cn=modeller,{internalLdap.RoleSearchPath}";
-			requesterRoleDn = $"cn=requester,{internalLdap.RoleSearchPath}";
-			implementerRoleDn = $"cn=implementer,{internalLdap.RoleSearchPath}";
-			reviewerRoleDn = $"cn=reviewer,{internalLdap.RoleSearchPath}";
-			allInternalGroups = await internalLdap.GetAllInternalGroups();
-            ownerGroupLdapPath = ownerGroupLdap.GroupWritePath;
-			if (globalConfig.OwnerLdapId == GlobalConst.kLdapInternalId)
+        private async Task InitLdap()
+        {
+            connectedLdaps = await apiConnection.SendQueryAsync<List<Ldap>>(AuthQueries.getLdapConnections);
+            internalLdap = connectedLdaps.FirstOrDefault(x => x.IsInternal() && x.HasGroupHandling()) ?? throw new KeyNotFoundException("No internal Ldap with group handling found.");
+            ownerGroupLdaps = connectedLdaps.Where(x => globalConfig.OwnerLdapIds.Contains(x.Id)).ToList() ?? throw new KeyNotFoundException("Ldap with group handling not found.");
+            modellerRoleDn = $"cn=modeller,{internalLdap.RoleSearchPath}";
+            requesterRoleDn = $"cn=requester,{internalLdap.RoleSearchPath}";
+            implementerRoleDn = $"cn=implementer,{internalLdap.RoleSearchPath}";
+            reviewerRoleDn = $"cn=reviewer,{internalLdap.RoleSearchPath}";
+            allInternalGroups = await internalLdap.GetAllInternalGroups();
+            ownerGroupLdapPaths = ownerGroupLdaps.Select(ladp => ladp.GroupWritePath).ToList();
+            if (globalConfig.OwnerLdapIds.Contains(GlobalConst.kLdapInternalId))
             {
                 allGroups = allInternalGroups;  // TODO: check if ref is ok here
             }
             else
             {
-                allGroups = await ownerGroupLdap.GetAllGroupObjects(globalConfig.OwnerLdapGroupNames.
+                allGroups = (await Task.WhenAll(ownerGroupLdaps.Select(ldap => ldap.GetAllGroupObjects(
+                    globalConfig.OwnerLdapGroupNames.
                     Replace(Placeholder.AppId, "*").
                     Replace(Placeholder.ExternalAppId, "*").
-                    Replace(Placeholder.AppPrefix, "*"));
+                    Replace(Placeholder.AppPrefix, "*"))))).SelectMany(g => g).ToList();
             }
-		}
+        }
 
-		private async Task ImportSingleSource(string importfileName, List<string> failedImports)
-		{
-			try
-			{
-				ReadFile(importfileName);
-				ModellingImportOwnerData? importedOwnerData = JsonSerializer.Deserialize<ModellingImportOwnerData>(importFile) ?? throw new JsonException("File could not be parsed.");
-				if (importedOwnerData != null && importedOwnerData.Owners != null)
-				{
-					importedApps = importedOwnerData.Owners;
-					await ImportApps(importfileName);
-				}
-			}
-			catch (Exception exc)
-			{
-				string errorText = $"File {importfileName} could not be processed.";
-				Log.WriteError(LogMessageTitle, errorText, exc);
-				await AddLogEntry(2, LevelFile, errorText);
-				failedImports.Add(importfileName);
-			}
-		}
+        private async Task ImportSingleSource(string importfileName, List<string> failedImports)
+        {
+            try
+            {
+                ReadFile(importfileName);
+                ModellingImportOwnerData? importedOwnerData = JsonSerializer.Deserialize<ModellingImportOwnerData>(importFile) ?? throw new JsonException("File could not be parsed.");
+                if (importedOwnerData != null && importedOwnerData.Owners != null)
+                {
+                    importedApps = importedOwnerData.Owners;
+                    await ImportApps(importfileName);
+                }
+            }
+            catch (Exception exc)
+            {
+                string errorText = $"File {importfileName} could not be processed.";
+                Log.WriteError(LogMessageTitle, errorText, exc);
+                await AddLogEntry(2, LevelFile, errorText);
+                failedImports.Add(importfileName);
+            }
+        }
 
-		private async Task ImportApps(string importfileName)
-		{
-			int successCounter = 0;
-			int failCounter = 0;
-			int deleteCounter = 0;
-			int deleteFailCounter = 0;
+        private async Task ImportApps(string importfileName)
+        {
+            int successCounter = 0;
+            int failCounter = 0;
+            int deleteCounter = 0;
+            int deleteFailCounter = 0;
 
-			if (!(globalConfig.OwnerLdapGroupNames.Contains(Placeholder.AppId) ||
+            if (!(globalConfig.OwnerLdapGroupNames.Contains(Placeholder.AppId) ||
                 globalConfig.OwnerLdapGroupNames.Contains(Placeholder.ExternalAppId)))
             {
                 Log.WriteWarning(LogMessageTitle, $"Owner group pattern does not contain any of the placeholders {Placeholder.AppId} or {Placeholder.ExternalAppId}.");
-			}
-			else
-			{
-				existingApps = await apiConnection.SendQueryAsync<List<FwoOwner>>(OwnerQueries.getOwners);
-				foreach (var incomingApp in importedApps)
-				{
-					if (await SaveApp(incomingApp))
-					{
-						++successCounter;
-					}
-					else
-					{
-						++failCounter;
-					}
-				}
-				string? importSource = importedApps.FirstOrDefault()?.ImportSource;
-				if(importSource != null)
-				{
-					foreach (var existingApp in existingApps.Where(x => x.ImportSource == importSource && x.Active))
-					{
-						if (importedApps.FirstOrDefault(x => x.ExtAppId == existingApp.ExtAppId) == null)
-						{
-							if (await DeactivateApp(existingApp))
-							{
-								++deleteCounter;
-							}
-							else
-							{
-								++deleteFailCounter;
-							}
-						}
-					}
-				}
-				string messageText = $"Imported from {importfileName}: {successCounter} apps, {failCounter} failed. Deactivated {deleteCounter} apps, {deleteFailCounter} failed.";
-				Log.WriteInfo(LogMessageTitle, messageText);
-				await AddLogEntry(0, LevelFile, messageText);
-			}
-		}
+            }
+            else
+            {
+                existingApps = await apiConnection.SendQueryAsync<List<FwoOwner>>(OwnerQueries.getOwners);
+                foreach (var incomingApp in importedApps)
+                {
+                    if (await SaveApp(incomingApp))
+                    {
+                        ++successCounter;
+                    }
+                    else
+                    {
+                        ++failCounter;
+                    }
+                }
+                string? importSource = importedApps.FirstOrDefault()?.ImportSource;
+                if (importSource != null)
+                {
+                    foreach (var existingApp in existingApps.Where(x => x.ImportSource == importSource && x.Active))
+                    {
+                        if (importedApps.FirstOrDefault(x => x.ExtAppId == existingApp.ExtAppId) == null)
+                        {
+                            if (await DeactivateApp(existingApp))
+                            {
+                                ++deleteCounter;
+                            }
+                            else
+                            {
+                                ++deleteFailCounter;
+                            }
+                        }
+                    }
+                }
+                string messageText = $"Imported from {importfileName}: {successCounter} apps, {failCounter} failed. Deactivated {deleteCounter} apps, {deleteFailCounter} failed.";
+                Log.WriteInfo(LogMessageTitle, messageText);
+                await AddLogEntry(0, LevelFile, messageText);
+            }
+        }
 
-		private async Task<bool> SaveApp(ModellingImportAppData incomingApp)
-		{
-			try
-			{
-				string userGroupDn;
-				FwoOwner? existingApp = existingApps.FirstOrDefault(x => x.ExtAppId == incomingApp.ExtAppId);
+        private async Task<bool> SaveApp(ModellingImportAppData incomingApp)
+        {
+            try
+            {
+                string userGroupDn;
+                FwoOwner? existingApp = existingApps.FirstOrDefault(x => x.ExtAppId == incomingApp.ExtAppId);
 
-				if (existingApp == null)
-				{
-					userGroupDn = await NewApp(incomingApp);
-				}
-				else
-				{
-					userGroupDn = await UpdateApp(incomingApp, existingApp);
-				}
-				// in order to store email addresses of users in the group in UiUser for email notification:
-				await AddAllGroupMembersToUiUser(userGroupDn);
-			}
-			catch (Exception exc)
-			{
-				string errorText = $"App {incomingApp.Name} could not be processed.";
-				Log.WriteError(LogMessageTitle, errorText, exc);
-				await AddLogEntry(2, LevelApp, errorText);
-				return false;
-			}
-			return true;
-		}
+                if (existingApp == null)
+                {
+                    userGroupDn = await NewApp(incomingApp);
+                }
+                else
+                {
+                    userGroupDn = await UpdateApp(incomingApp, existingApp);
+                }
+                // in order to store email addresses of users in the group in UiUser for email notification:
+                await AddAllGroupMembersToUiUser(userGroupDn);
+            }
+            catch (Exception exc)
+            {
+                string errorText = $"App {incomingApp.Name} could not be processed.";
+                Log.WriteError(LogMessageTitle, errorText, exc);
+                await AddLogEntry(2, LevelApp, errorText);
+                return false;
+            }
+            return true;
+        }
 
-		private async Task<string> NewApp(ModellingImportAppData incomingApp)
-		{
-			string userGroupDn = globalConfig.ManageOwnerLdapGroups ? await CreateUserGroup(incomingApp) : GetGroupDn(incomingApp.ExtAppId);
+        private async Task<string> NewApp(ModellingImportAppData incomingApp)
+        {
+            string userGroupDn = globalConfig.ManageOwnerLdapGroups ? await CreateUserGroup(incomingApp) : GetGroupDn(incomingApp.ExtAppId);
 
-			var variables = new
-			{
-				name = incomingApp.Name,
-				dn = incomingApp.MainUser ?? "",
-				groupDn = userGroupDn,
-				appIdExternal = incomingApp.ExtAppId,
-				criticality = incomingApp.Criticality,
-				recertInterval = incomingApp.RecertInterval,
-				importSource = incomingApp.ImportSource,
-				commSvcPossible = false
-			};
-			ReturnId[]? returnIds = (await apiConnection.SendQueryAsync<ReturnIdWrapper>(OwnerQueries.newOwner, variables)).ReturnIds;
-			if (returnIds != null)
-			{
-				if(incomingApp.MainUser != null && incomingApp.MainUser != "")
-				{
-					await UpdateRoles(incomingApp.MainUser);
-				}
-				int appId = returnIds[0].NewId;
-				foreach (var appServer in incomingApp.AppServers)
-				{
-					await NewAppServer(appServer, appId, incomingApp.ImportSource);
-				}
-			}
-			return userGroupDn;
-		}
+            var variables = new
+            {
+                name = incomingApp.Name,
+                dn = incomingApp.MainUser ?? "",
+                groupDn = userGroupDn,
+                appIdExternal = incomingApp.ExtAppId,
+                criticality = incomingApp.Criticality,
+                recertInterval = incomingApp.RecertInterval,
+                importSource = incomingApp.ImportSource,
+                commSvcPossible = false
+            };
+            ReturnId[]? returnIds = (await apiConnection.SendQueryAsync<ReturnIdWrapper>(OwnerQueries.newOwner, variables)).ReturnIds;
+            if (returnIds != null)
+            {
+                if (incomingApp.MainUser != null && incomingApp.MainUser != "")
+                {
+                    await UpdateRoles(incomingApp.MainUser);
+                }
+                int appId = returnIds[0].NewId;
+                foreach (var appServer in incomingApp.AppServers)
+                {
+                    await NewAppServer(appServer, appId, incomingApp.ImportSource);
+                }
+            }
+            return userGroupDn;
+        }
 
-		private async Task<string> UpdateApp(ModellingImportAppData incomingApp, FwoOwner existingApp)
-		{
-			string userGroupDn = GetGroupDn(incomingApp.ExtAppId);
+        private async Task<string> UpdateApp(ModellingImportAppData incomingApp, FwoOwner existingApp)
+        {
+            string userGroupDn = GetGroupDn(incomingApp.ExtAppId);
             if (globalConfig.ManageOwnerLdapGroups)
             {
                 if (string.IsNullOrEmpty(existingApp.GroupDn) && allGroups.FirstOrDefault(x => x.GroupDn == userGroupDn) == null)
@@ -245,511 +246,511 @@ namespace FWO.Middleware.Server
             else
             {
                 // add necessary roles for user group
-				foreach (string role in new List<string> { modellerRoleDn, requesterRoleDn, implementerRoleDn, reviewerRoleDn })
-				{
-					await internalLdap.AddUserToEntry(userGroupDn, role);
-				}
+                foreach (string role in new List<string> { modellerRoleDn, requesterRoleDn, implementerRoleDn, reviewerRoleDn })
+                {
+                    await internalLdap.AddUserToEntry(userGroupDn, role);
+                }
             }
 
-			var Variables = new
-			{
-				id = existingApp.Id,
-				name = incomingApp.Name,
-				dn = incomingApp.MainUser ?? "",
-				groupDn = userGroupDn,
-			    appIdExternal = string.IsNullOrEmpty(incomingApp.ExtAppId) ? null : incomingApp.ExtAppId,
-				criticality = incomingApp.Criticality,
-				recertInterval = incomingApp.RecertInterval,
-				commSvcPossible = existingApp.CommSvcPossible
-			};
-			await apiConnection.SendQueryAsync<ReturnIdWrapper>(OwnerQueries.updateOwner, Variables);
-			if(incomingApp.MainUser != null && incomingApp.MainUser != "")
-			{
-				await UpdateRoles(incomingApp.MainUser);
-			}
-			await ImportAppServers(incomingApp, existingApp.Id);
-			return userGroupDn;
-		}
+            var Variables = new
+            {
+                id = existingApp.Id,
+                name = incomingApp.Name,
+                dn = incomingApp.MainUser ?? "",
+                groupDn = userGroupDn,
+                appIdExternal = string.IsNullOrEmpty(incomingApp.ExtAppId) ? null : incomingApp.ExtAppId,
+                criticality = incomingApp.Criticality,
+                recertInterval = incomingApp.RecertInterval,
+                commSvcPossible = existingApp.CommSvcPossible
+            };
+            await apiConnection.SendQueryAsync<ReturnIdWrapper>(OwnerQueries.updateOwner, Variables);
+            if (incomingApp.MainUser != null && incomingApp.MainUser != "")
+            {
+                await UpdateRoles(incomingApp.MainUser);
+            }
+            await ImportAppServers(incomingApp, existingApp.Id);
+            return userGroupDn;
+        }
 
-		private async Task<bool> DeactivateApp(FwoOwner app)
-		{
-			try
-			{
-				await apiConnection.SendQueryAsync<ReturnIdWrapper>(OwnerQueries.deactivateOwner, new { id = app.Id });
-			}
-			catch (Exception exc)
-			{
-				string errorText = $"Outdated App {app.Name} could not be deactivated.";
-				Log.WriteError(LogMessageTitle, errorText, exc);
-				await AddLogEntry(1, LevelApp, errorText);
-				return false;
-			}
-			return true;
-		}
+        private async Task<bool> DeactivateApp(FwoOwner app)
+        {
+            try
+            {
+                await apiConnection.SendQueryAsync<ReturnIdWrapper>(OwnerQueries.deactivateOwner, new { id = app.Id });
+            }
+            catch (Exception exc)
+            {
+                string errorText = $"Outdated App {app.Name} could not be deactivated.";
+                Log.WriteError(LogMessageTitle, errorText, exc);
+                await AddLogEntry(1, LevelApp, errorText);
+                return false;
+            }
+            return true;
+        }
 
-		private string GetGroupName(string extAppIdString)
-		{
+        private string GetGroupName(string extAppIdString)
+        {
             // hard-coded GlobalConst.kAppIdSeparator could be moved to settings
 
             if (globalConfig.OwnerLdapGroupNames.Contains(Placeholder.ExternalAppId))
             {
-    			return globalConfig.OwnerLdapGroupNames.Replace(Placeholder.ExternalAppId, extAppIdString);
+                return globalConfig.OwnerLdapGroupNames.Replace(Placeholder.ExternalAppId, extAppIdString);
             }
-            
-            if (globalConfig.OwnerLdapGroupNames.Contains(Placeholder.AppPrefix) && 
+
+            if (globalConfig.OwnerLdapGroupNames.Contains(Placeholder.AppPrefix) &&
                 globalConfig.OwnerLdapGroupNames.Contains(Placeholder.AppId))
             {
-				string[] parts = extAppIdString.Split(GlobalConst.kAppIdSeparator);
-				string appPrefix = parts.Length > 0 ? parts[0] : "";
-				string appId = parts.Length > 1 ? parts[1] : "";
-				return globalConfig.OwnerLdapGroupNames.Replace(Placeholder.AppPrefix, appPrefix).Replace(Placeholder.AppId, appId);
-			}
-			Log.WriteInfo(LogMessageTitle, $"Could not find ayn placeholders in group name pattern \"{globalConfig.OwnerLdapGroupNames}\" " +
-				$"({Placeholder.ExternalAppId}, {Placeholder.AppPrefix}, {Placeholder.AppId} ");
-			return globalConfig.OwnerLdapGroupNames;
-		}
-
-		private string GetGroupDn(string extAppIdString)
-		{
-            if (ownerGroupLdapPath == null)
-            {
-				throw new ArgumentNullException(nameof(ownerGroupLdapPath));
+                string[] parts = extAppIdString.Split(GlobalConst.kAppIdSeparator);
+                string appPrefix = parts.Length > 0 ? parts[0] : "";
+                string appId = parts.Length > 1 ? parts[1] : "";
+                return globalConfig.OwnerLdapGroupNames.Replace(Placeholder.AppPrefix, appPrefix).Replace(Placeholder.AppId, appId);
             }
-			return $"cn={GetGroupName(extAppIdString)},{ownerGroupLdapPath}";
-		}
+            Log.WriteInfo(LogMessageTitle, $"Could not find ayn placeholders in group name pattern \"{globalConfig.OwnerLdapGroupNames}\" " +
+                $"({Placeholder.ExternalAppId}, {Placeholder.AppPrefix}, {Placeholder.AppId} ");
+            return globalConfig.OwnerLdapGroupNames;
+        }
+
+        private string GetGroupDn(string extAppIdString)
+        {
+            if (ownerGroupLdapPaths == null || !ownerGroupLdapPaths.Any())
+            {
+                throw new ArgumentException("ownerGroupLdapPaths is null or empty", nameof(ownerGroupLdapPaths));
+            }
+            return $"cn={GetGroupName(extAppIdString)},{ownerGroupLdapPaths.First()}";
+        }
 
 
-		/// <summary>
-		/// for each user of a remote ldap group create a user in uiuser
-		/// this is necessary in order to get details like email address for users
-		/// which have never logged in but who need to be notified via email
-		/// </summary>
-		private async Task AddAllGroupMembersToUiUser(string userGroupDn)
-		{
-			foreach (Ldap ldap in connectedLdaps)
-			{
-				foreach (string memberDn in await ldap.GetGroupMembers(userGroupDn))
-				{
-					UiUser? uiUser = await ConvertLdapToUiUser(memberDn);
-					if(uiUser != null)
-					{
-						await UiUserHandler.UpsertUiUser(apiConnection, uiUser, false);
-					}
-				}
-			}
-		}
+        /// <summary>
+        /// for each user of a remote ldap group create a user in uiuser
+        /// this is necessary in order to get details like email address for users
+        /// which have never logged in but who need to be notified via email
+        /// </summary>
+        private async Task AddAllGroupMembersToUiUser(string userGroupDn)
+        {
+            foreach (Ldap ldap in connectedLdaps)
+            {
+                foreach (string memberDn in await ldap.GetGroupMembers(userGroupDn))
+                {
+                    UiUser? uiUser = await ConvertLdapToUiUser(memberDn);
+                    if (uiUser != null)
+                    {
+                        await UiUserHandler.UpsertUiUser(apiConnection, uiUser, false);
+                    }
+                }
+            }
+        }
 
-		private async Task<UiUser?> ConvertLdapToUiUser(string userDn)
-		{
-			// add the modelling user to local uiuser table for later ref to email address
-			// find the user in all connected ldaps
-			foreach (Ldap ldap in connectedLdaps)
-			{
-				if (!string.IsNullOrEmpty(ldap.UserSearchPath) && userDn.ToLower().Contains(ldap.UserSearchPath!.ToLower()))
-				{
-					LdapEntry? ldapUser = await ldap.GetUserDetailsFromLdap(userDn);
+        private async Task<UiUser?> ConvertLdapToUiUser(string userDn)
+        {
+            // add the modelling user to local uiuser table for later ref to email address
+            // find the user in all connected ldaps
+            foreach (Ldap ldap in connectedLdaps)
+            {
+                if (!string.IsNullOrEmpty(ldap.UserSearchPath) && userDn.ToLower().Contains(ldap.UserSearchPath!.ToLower()))
+                {
+                    LdapEntry? ldapUser = await ldap.GetUserDetailsFromLdap(userDn);
 
-					if (ldapUser != null)
-					{
-						// add data from ldap entry to uiUser
-						return new()
-						{
-							LdapConnection = new UiLdapConnection(){ Id = ldap.Id },
-							Dn = ldapUser.Dn,
-							Name = Ldap.GetName(ldapUser),
-							Firstname = Ldap.GetFirstName(ldapUser),
-							Lastname = Ldap.GetLastName(ldapUser),
-							Email = Ldap.GetEmail(ldapUser),
-							Tenant = await DeriveTenantFromLdap(ldap, ldapUser)							
-						};
-					}
-				}
-			}
-			return null;
-		}
+                    if (ldapUser != null)
+                    {
+                        // add data from ldap entry to uiUser
+                        return new()
+                        {
+                            LdapConnection = new UiLdapConnection() { Id = ldap.Id },
+                            Dn = ldapUser.Dn,
+                            Name = Ldap.GetName(ldapUser),
+                            Firstname = Ldap.GetFirstName(ldapUser),
+                            Lastname = Ldap.GetLastName(ldapUser),
+                            Email = Ldap.GetEmail(ldapUser),
+                            Tenant = await DeriveTenantFromLdap(ldap, ldapUser)
+                        };
+                    }
+                }
+            }
+            return null;
+        }
 
-		private async Task<Tenant> DeriveTenantFromLdap(Ldap ldap, LdapEntry ldapUser)
-		{
-			// try to derive the the user's tenant from the ldap settings
-			Tenant tenant = new()
-			{
-				Id = GlobalConst.kTenant0Id  // default: tenant0 (id=1)
-			};
+        private async Task<Tenant> DeriveTenantFromLdap(Ldap ldap, LdapEntry ldapUser)
+        {
+            // try to derive the the user's tenant from the ldap settings
+            Tenant tenant = new()
+            {
+                Id = GlobalConst.kTenant0Id  // default: tenant0 (id=1)
+            };
 
-			string tenantName = "";
+            string tenantName = "";
 
-			// can we derive the users tenant purely from its ldap?
-			if (!string.IsNullOrEmpty(ldap.GlobalTenantName) || ldap.TenantLevel > 0)
-			{
-				if (ldap.TenantLevel > 0)
-				{
-					// getting tenant via tenant level setting from distinguished name
-					tenantName = ldap.GetTenantName(ldapUser);
-				}
-				else
-				{
-					if (!string.IsNullOrEmpty(ldap.GlobalTenantName))
-					{
-						tenantName = ldap.GlobalTenantName ?? "";
-					}
-				}
+            // can we derive the users tenant purely from its ldap?
+            if (!string.IsNullOrEmpty(ldap.GlobalTenantName) || ldap.TenantLevel > 0)
+            {
+                if (ldap.TenantLevel > 0)
+                {
+                    // getting tenant via tenant level setting from distinguished name
+                    tenantName = ldap.GetTenantName(ldapUser);
+                }
+                else
+                {
+                    if (!string.IsNullOrEmpty(ldap.GlobalTenantName))
+                    {
+                        tenantName = ldap.GlobalTenantName ?? "";
+                    }
+                }
 
-				var variables = new { tenant_name = tenantName };
-				Tenant[] tenants = await apiConnection.SendQueryAsync<Tenant[]>(AuthQueries.getTenantId, variables, "getTenantId");
-				if (tenants.Length == 1)
-				{
-					tenant.Id = tenants[0].Id;
-				}
-			}
-			return tenant;
-		}
+                var variables = new { tenant_name = tenantName };
+                Tenant[] tenants = await apiConnection.SendQueryAsync<Tenant[]>(AuthQueries.getTenantId, variables, "getTenantId");
+                if (tenants.Length == 1)
+                {
+                    tenant.Id = tenants[0].Id;
+                }
+            }
+            return tenant;
+        }
 
-		private async Task<string> CreateUserGroup(ModellingImportAppData incomingApp)
-		{
-			string groupDn = "";
-			if (incomingApp.Modellers != null && incomingApp.Modellers.Count > 0
-				|| incomingApp.ModellerGroups != null && incomingApp.ModellerGroups.Count > 0)
-			{
-				string groupName = GetGroupName(incomingApp.ExtAppId);
-				groupDn = await internalLdap.AddGroup(groupName, true);
-				if (incomingApp.Modellers != null)
-				{
-					foreach (var modeller in incomingApp.Modellers)
-					{
-						// add user to internal group:
-						await internalLdap.AddUserToEntry(modeller, groupDn);
-					}
-				}
-				if (incomingApp.ModellerGroups != null)
-				{
-					foreach (var modellerGrp in incomingApp.ModellerGroups)
-					{
-						await internalLdap.AddUserToEntry(modellerGrp, groupDn);
-					}
-				}
-				await internalLdap.AddUserToEntry(groupDn, modellerRoleDn);
-				await internalLdap.AddUserToEntry(groupDn, requesterRoleDn);
-				await internalLdap.AddUserToEntry(groupDn, implementerRoleDn);
-				await internalLdap.AddUserToEntry(groupDn, reviewerRoleDn);
-			}
-			return groupDn;
-		}
+        private async Task<string> CreateUserGroup(ModellingImportAppData incomingApp)
+        {
+            string groupDn = "";
+            if (incomingApp.Modellers != null && incomingApp.Modellers.Count > 0
+                || incomingApp.ModellerGroups != null && incomingApp.ModellerGroups.Count > 0)
+            {
+                string groupName = GetGroupName(incomingApp.ExtAppId);
+                groupDn = await internalLdap.AddGroup(groupName, true);
+                if (incomingApp.Modellers != null)
+                {
+                    foreach (var modeller in incomingApp.Modellers)
+                    {
+                        // add user to internal group:
+                        await internalLdap.AddUserToEntry(modeller, groupDn);
+                    }
+                }
+                if (incomingApp.ModellerGroups != null)
+                {
+                    foreach (var modellerGrp in incomingApp.ModellerGroups)
+                    {
+                        await internalLdap.AddUserToEntry(modellerGrp, groupDn);
+                    }
+                }
+                await internalLdap.AddUserToEntry(groupDn, modellerRoleDn);
+                await internalLdap.AddUserToEntry(groupDn, requesterRoleDn);
+                await internalLdap.AddUserToEntry(groupDn, implementerRoleDn);
+                await internalLdap.AddUserToEntry(groupDn, reviewerRoleDn);
+            }
+            return groupDn;
+        }
 
-		private async Task<string> UpdateUserGroup(ModellingImportAppData incomingApp, string groupDn)
-		{
-			List<string> existingMembers = (allGroups.FirstOrDefault(x => x.GroupDn == groupDn) ?? throw new KeyNotFoundException($"Group with DN '{groupDn}' could not be found.")).Members;
-			await AddUsersToEntry(incomingApp.Modellers, existingMembers, groupDn);
-			await AddUsersToEntry(incomingApp.ModellerGroups, existingMembers, groupDn);
-			foreach (var member in existingMembers)
-			{
-				if ((incomingApp.Modellers == null || incomingApp.Modellers.FirstOrDefault(x => x.Equals(member, StringComparison.OrdinalIgnoreCase)) == null)
-					&& (incomingApp.ModellerGroups == null || incomingApp.ModellerGroups.FirstOrDefault(x => x.Equals(member, StringComparison.OrdinalIgnoreCase)) == null))
-				{
-					await internalLdap.RemoveUserFromEntry(member, groupDn);
-				}
-			}
-			await UpdateRoles(groupDn);
-			return groupDn;
-		}
+        private async Task<string> UpdateUserGroup(ModellingImportAppData incomingApp, string groupDn)
+        {
+            List<string> existingMembers = (allGroups.FirstOrDefault(x => x.GroupDn == groupDn) ?? throw new KeyNotFoundException($"Group with DN '{groupDn}' could not be found.")).Members;
+            await AddUsersToEntry(incomingApp.Modellers, existingMembers, groupDn);
+            await AddUsersToEntry(incomingApp.ModellerGroups, existingMembers, groupDn);
+            foreach (var member in existingMembers)
+            {
+                if ((incomingApp.Modellers == null || incomingApp.Modellers.FirstOrDefault(x => x.Equals(member, StringComparison.OrdinalIgnoreCase)) == null)
+                    && (incomingApp.ModellerGroups == null || incomingApp.ModellerGroups.FirstOrDefault(x => x.Equals(member, StringComparison.OrdinalIgnoreCase)) == null))
+                {
+                    await internalLdap.RemoveUserFromEntry(member, groupDn);
+                }
+            }
+            await UpdateRoles(groupDn);
+            return groupDn;
+        }
 
-		private async Task AddUsersToEntry(List<string>? members, List<string> existingMembers, string groupDn)
-		{
-			if (members != null)
-			{
-				foreach (var member in members)
-				{
-					if (existingMembers.FirstOrDefault(x => x.Equals(member, StringComparison.OrdinalIgnoreCase)) == null)
-					{
-						await internalLdap.AddUserToEntry(member, groupDn);
-					}
-				}
-			}
-		}
+        private async Task AddUsersToEntry(List<string>? members, List<string> existingMembers, string groupDn)
+        {
+            if (members != null)
+            {
+                foreach (var member in members)
+                {
+                    if (existingMembers.FirstOrDefault(x => x.Equals(member, StringComparison.OrdinalIgnoreCase)) == null)
+                    {
+                        await internalLdap.AddUserToEntry(member, groupDn);
+                    }
+                }
+            }
+        }
 
-		private async Task UpdateRoles(string dn)
-		{
-			List<string> roles = await internalLdap.GetRoles([dn]);
-			if (!roles.Contains(Roles.Modeller))
-			{
-				await internalLdap.AddUserToEntry(dn, modellerRoleDn);
-			}
-			if (!roles.Contains(Roles.Requester))
-			{
-				await internalLdap.AddUserToEntry(dn, requesterRoleDn);
-			}
-			if (!roles.Contains(Roles.Implementer))
-			{
-				await internalLdap.AddUserToEntry(dn, implementerRoleDn);
-			}
-			if (!roles.Contains(Roles.Reviewer))
-			{
-				await internalLdap.AddUserToEntry(dn, reviewerRoleDn);
-			}
-		}
+        private async Task UpdateRoles(string dn)
+        {
+            List<string> roles = await internalLdap.GetRoles([dn]);
+            if (!roles.Contains(Roles.Modeller))
+            {
+                await internalLdap.AddUserToEntry(dn, modellerRoleDn);
+            }
+            if (!roles.Contains(Roles.Requester))
+            {
+                await internalLdap.AddUserToEntry(dn, requesterRoleDn);
+            }
+            if (!roles.Contains(Roles.Implementer))
+            {
+                await internalLdap.AddUserToEntry(dn, implementerRoleDn);
+            }
+            if (!roles.Contains(Roles.Reviewer))
+            {
+                await internalLdap.AddUserToEntry(dn, reviewerRoleDn);
+            }
+        }
 
-		private async Task ImportAppServers(ModellingImportAppData incomingApp, int applId)
-		{
-			int successCounter = 0;
-			int failCounter = 0;
-			int deleteCounter = 0;
-			int deleteFailCounter = 0;
+        private async Task ImportAppServers(ModellingImportAppData incomingApp, int applId)
+        {
+            int successCounter = 0;
+            int failCounter = 0;
+            int deleteCounter = 0;
+            int deleteFailCounter = 0;
 
-			var Variables = new
-			{
-				importSource = incomingApp.ImportSource,
-				appId = applId
-			};
-			existingAppServers = await apiConnection.SendQueryAsync<List<ModellingAppServer>>(ModellingQueries.getAppServersBySource, Variables);
-			foreach (var incomingAppServer in incomingApp.AppServers)
-			{
-				if (await SaveAppServer(incomingAppServer, applId, incomingApp.ImportSource))
-				{
-					++successCounter;
-				}
-				else
-				{
-					++failCounter;
-				}
-			}
-			foreach (var existingAppServer in existingAppServers.Where(e => !e.IsDeleted).ToList())
-			{
-				if (incomingApp.AppServers.FirstOrDefault(x => x.Ip.IpAsCidr() == existingAppServer.Ip.IpAsCidr() && x.IpEnd.IpAsCidr() == existingAppServer.IpEnd.IpAsCidr()) == null)
-				{
-					if (await MarkDeletedAppServer(existingAppServer))
-					{
-						++deleteCounter;
-					}
-					else
-					{
-						++deleteFailCounter;
-					}
-				}
-			}
-			Log.WriteDebug(LogMessageTitle, $"for App {incomingApp.Name}: Imported {successCounter} app servers, {failCounter} failed. {deleteCounter} app servers marked as deleted, {deleteFailCounter} failed.");
-		}
+            var Variables = new
+            {
+                importSource = incomingApp.ImportSource,
+                appId = applId
+            };
+            existingAppServers = await apiConnection.SendQueryAsync<List<ModellingAppServer>>(ModellingQueries.getAppServersBySource, Variables);
+            foreach (var incomingAppServer in incomingApp.AppServers)
+            {
+                if (await SaveAppServer(incomingAppServer, applId, incomingApp.ImportSource))
+                {
+                    ++successCounter;
+                }
+                else
+                {
+                    ++failCounter;
+                }
+            }
+            foreach (var existingAppServer in existingAppServers.Where(e => !e.IsDeleted).ToList())
+            {
+                if (incomingApp.AppServers.FirstOrDefault(x => x.Ip.IpAsCidr() == existingAppServer.Ip.IpAsCidr() && x.IpEnd.IpAsCidr() == existingAppServer.IpEnd.IpAsCidr()) == null)
+                {
+                    if (await MarkDeletedAppServer(existingAppServer))
+                    {
+                        ++deleteCounter;
+                    }
+                    else
+                    {
+                        ++deleteFailCounter;
+                    }
+                }
+            }
+            Log.WriteDebug(LogMessageTitle, $"for App {incomingApp.Name}: Imported {successCounter} app servers, {failCounter} failed. {deleteCounter} app servers marked as deleted, {deleteFailCounter} failed.");
+        }
 
-		private async Task<bool> SaveAppServer(ModellingImportAppServer incomingAppServer, int appID, string impSource)
-		{
-			try
-			{
-				if(incomingAppServer.IpEnd == "")
-				{
-					incomingAppServer.IpEnd = incomingAppServer.Ip;
-				}
-				if(globalConfig.DnsLookup)
-				{
-					incomingAppServer.Name = await BuildAppServerName(incomingAppServer);
-				}
-				ModellingAppServer? existingAppServer = existingAppServers.FirstOrDefault(x => x.Ip.IpAsCidr() == incomingAppServer.Ip.IpAsCidr() && x.IpEnd.IpAsCidr() == incomingAppServer.IpEnd.IpAsCidr());
-				if (existingAppServer == null)
-				{
-					return await NewAppServer(incomingAppServer, appID, impSource);
-				}
+        private async Task<bool> SaveAppServer(ModellingImportAppServer incomingAppServer, int appID, string impSource)
+        {
+            try
+            {
+                if (incomingAppServer.IpEnd == "")
+                {
+                    incomingAppServer.IpEnd = incomingAppServer.Ip;
+                }
+                if (globalConfig.DnsLookup)
+                {
+                    incomingAppServer.Name = await BuildAppServerName(incomingAppServer);
+                }
+                ModellingAppServer? existingAppServer = existingAppServers.FirstOrDefault(x => x.Ip.IpAsCidr() == incomingAppServer.Ip.IpAsCidr() && x.IpEnd.IpAsCidr() == incomingAppServer.IpEnd.IpAsCidr());
+                if (existingAppServer == null)
+                {
+                    return await NewAppServer(incomingAppServer, appID, impSource);
+                }
 
-				if (existingAppServer.IsDeleted)
-				{
-					if (!await ReactivateAppServer(existingAppServer))
-					{
-						return false;
-					}
-				}
-				else
-				{
-					// in case there are still active appservers from other sources (resulting e.g. from older revisions)
-					await AppServerHelper.DeactivateOtherSources(apiConnection, userConfig, existingAppServer);
-				}
-				if (!existingAppServer.Name.Equals(incomingAppServer.Name))
-				{
-					if (!await UpdateAppServerName(existingAppServer, incomingAppServer.Name))
-					{
-						return false;
-					}
-				}
-				if (existingAppServer.CustomType == null)
-				{
-					if (!await UpdateAppServerType(existingAppServer))
-					{
-						return false;
-					}
-				}
-				return true;
-			}
-			catch (Exception exc)
-			{
-				string errorText = $"App Server {incomingAppServer.Name} could not be processed.";
-				Log.WriteError(LogMessageTitle, errorText, exc);
-				await AddLogEntry(1, LevelAppServer, errorText);
-				return false;
-			}
-		}
+                if (existingAppServer.IsDeleted)
+                {
+                    if (!await ReactivateAppServer(existingAppServer))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    // in case there are still active appservers from other sources (resulting e.g. from older revisions)
+                    await AppServerHelper.DeactivateOtherSources(apiConnection, userConfig, existingAppServer);
+                }
+                if (!existingAppServer.Name.Equals(incomingAppServer.Name))
+                {
+                    if (!await UpdateAppServerName(existingAppServer, incomingAppServer.Name))
+                    {
+                        return false;
+                    }
+                }
+                if (existingAppServer.CustomType == null)
+                {
+                    if (!await UpdateAppServerType(existingAppServer))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            catch (Exception exc)
+            {
+                string errorText = $"App Server {incomingAppServer.Name} could not be processed.";
+                Log.WriteError(LogMessageTitle, errorText, exc);
+                await AddLogEntry(1, LevelAppServer, errorText);
+                return false;
+            }
+        }
 
-		private async Task<string> BuildAppServerName(ModellingImportAppServer appServer)
-		{
-			try
-			{
-				return await AppServerHelper.ConstructAppServerNameFromDns(appServer.ToModellingAppServer(), NamingConvention, globalConfig.OverwriteExistingNames, true);
-			}
-			catch (Exception exc)
-			{
-				string errorText = $"App Server name {appServer.Name} could not be set according to naming conventions.";
-				Log.WriteError(LogMessageTitle, errorText, exc);
-				await AddLogEntry(1, LevelAppServer, errorText);
-			}
-			return appServer.Name;
-		}
+        private async Task<string> BuildAppServerName(ModellingImportAppServer appServer)
+        {
+            try
+            {
+                return await AppServerHelper.ConstructAppServerNameFromDns(appServer.ToModellingAppServer(), NamingConvention, globalConfig.OverwriteExistingNames, true);
+            }
+            catch (Exception exc)
+            {
+                string errorText = $"App Server name {appServer.Name} could not be set according to naming conventions.";
+                Log.WriteError(LogMessageTitle, errorText, exc);
+                await AddLogEntry(1, LevelAppServer, errorText);
+            }
+            return appServer.Name;
+        }
 
-		private async Task<bool> NewAppServer(ModellingImportAppServer incomingAppServer, int appID, string impSource)
-		{
-			try
-			{
-				var Variables = new
-				{
-					name = incomingAppServer.Name,
-					appId = appID,
-					ip = incomingAppServer.Ip.IpAsCidr(),
-					ipEnd = incomingAppServer.IpEnd != "" ? incomingAppServer.IpEnd.IpAsCidr() : incomingAppServer.Ip.IpAsCidr(),
-					importSource = impSource,
-					customType = 0
-				};
-				ReturnId[]? returnIds = (await apiConnection.SendQueryAsync<ReturnIdWrapper>(ModellingQueries.newAppServer, Variables)).ReturnIds;
-				if(returnIds != null && returnIds.Length > 0)
-				{
-					ModellingAppServer newModAppServer = new(incomingAppServer.ToModellingAppServer()){ Id = returnIds[0].NewIdLong, ImportSource = impSource, AppId = appID};
-					await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Insert, ModellingTypes.ModObjectType.AppServer, newModAppServer.Id,
+        private async Task<bool> NewAppServer(ModellingImportAppServer incomingAppServer, int appID, string impSource)
+        {
+            try
+            {
+                var Variables = new
+                {
+                    name = incomingAppServer.Name,
+                    appId = appID,
+                    ip = incomingAppServer.Ip.IpAsCidr(),
+                    ipEnd = incomingAppServer.IpEnd != "" ? incomingAppServer.IpEnd.IpAsCidr() : incomingAppServer.Ip.IpAsCidr(),
+                    importSource = impSource,
+                    customType = 0
+                };
+                ReturnId[]? returnIds = (await apiConnection.SendQueryAsync<ReturnIdWrapper>(ModellingQueries.newAppServer, Variables)).ReturnIds;
+                if (returnIds != null && returnIds.Length > 0)
+                {
+                    ModellingAppServer newModAppServer = new(incomingAppServer.ToModellingAppServer()) { Id = returnIds[0].NewIdLong, ImportSource = impSource, AppId = appID };
+                    await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Insert, ModellingTypes.ModObjectType.AppServer, newModAppServer.Id,
                         $"New App Server: {newModAppServer.Display()}", apiConnection, userConfig, newModAppServer.AppId, DefaultInit.DoNothing, null, newModAppServer.ImportSource);
-					await AppServerHelper.DeactivateOtherSources(apiConnection, userConfig, newModAppServer);
-				}
-			}
-			catch (Exception exc)
-			{
-				string errorText = $"App Server {incomingAppServer.Name} could not be processed.";
-				Log.WriteError(LogMessageTitle, errorText, exc);
-				await AddLogEntry(1, LevelAppServer, errorText);
-				return false;
-			}
-			return true;
-		}
+                    await AppServerHelper.DeactivateOtherSources(apiConnection, userConfig, newModAppServer);
+                }
+            }
+            catch (Exception exc)
+            {
+                string errorText = $"App Server {incomingAppServer.Name} could not be processed.";
+                Log.WriteError(LogMessageTitle, errorText, exc);
+                await AddLogEntry(1, LevelAppServer, errorText);
+                return false;
+            }
+            return true;
+        }
 
-		private async Task<bool> ReactivateAppServer(ModellingAppServer appServer)
-		{
-			try
-			{
-				var Variables = new
-				{
-					id = appServer.Id,
-					deleted = false
-				};
-				await apiConnection.SendQueryAsync<ReturnIdWrapper>(ModellingQueries.setAppServerDeletedState, Variables);
-				await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Reactivate, ModellingTypes.ModObjectType.AppServer, appServer.Id,
+        private async Task<bool> ReactivateAppServer(ModellingAppServer appServer)
+        {
+            try
+            {
+                var Variables = new
+                {
+                    id = appServer.Id,
+                    deleted = false
+                };
+                await apiConnection.SendQueryAsync<ReturnIdWrapper>(ModellingQueries.setAppServerDeletedState, Variables);
+                await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Reactivate, ModellingTypes.ModObjectType.AppServer, appServer.Id,
                     $"Reactivate App Server: {appServer.Display()}", apiConnection, userConfig, appServer.AppId, DefaultInit.DoNothing, null, appServer.ImportSource);
-				await AppServerHelper.DeactivateOtherSources(apiConnection, userConfig, appServer);
-			}
-			catch (Exception exc)
-			{
-				string errorText = $"App Server {appServer.Name} could not be reactivated.";
-				Log.WriteError(LogMessageTitle, errorText, exc);
-				await AddLogEntry(1, LevelAppServer, errorText);
-				return false;
-			}
-			return true;
-		}
+                await AppServerHelper.DeactivateOtherSources(apiConnection, userConfig, appServer);
+            }
+            catch (Exception exc)
+            {
+                string errorText = $"App Server {appServer.Name} could not be reactivated.";
+                Log.WriteError(LogMessageTitle, errorText, exc);
+                await AddLogEntry(1, LevelAppServer, errorText);
+                return false;
+            }
+            return true;
+        }
 
-		private async Task<bool> UpdateAppServerType(ModellingAppServer appServer)
-		{
-			try
-			{
-				var Variables = new
-				{
-					id = appServer.Id,
-					customType = 0
-				};
-				await apiConnection.SendQueryAsync<ReturnIdWrapper>(ModellingQueries.setAppServerType, Variables);
-				await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Update, ModellingTypes.ModObjectType.AppServer, appServer.Id,
+        private async Task<bool> UpdateAppServerType(ModellingAppServer appServer)
+        {
+            try
+            {
+                var Variables = new
+                {
+                    id = appServer.Id,
+                    customType = 0
+                };
+                await apiConnection.SendQueryAsync<ReturnIdWrapper>(ModellingQueries.setAppServerType, Variables);
+                await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Update, ModellingTypes.ModObjectType.AppServer, appServer.Id,
                     $"Update App Server Type: {appServer.Display()}", apiConnection, userConfig, appServer.AppId, DefaultInit.DoNothing, null, appServer.ImportSource);
-			}
-			catch (Exception exc)
-			{
-				string errorText = $"Type of App Server {appServer.Name} could not be set.";
-				Log.WriteError(LogMessageTitle, errorText, exc);
-				await AddLogEntry(1, LevelAppServer, errorText);
-				return false;
-			}
-			return true;
-		}
+            }
+            catch (Exception exc)
+            {
+                string errorText = $"Type of App Server {appServer.Name} could not be set.";
+                Log.WriteError(LogMessageTitle, errorText, exc);
+                await AddLogEntry(1, LevelAppServer, errorText);
+                return false;
+            }
+            return true;
+        }
 
-		private async Task<bool> UpdateAppServerName(ModellingAppServer appServer, string newName)
-		{
-			if (appServer.Name != newName)
-			{
-				try
-				{
-					var Variables = new
-					{
-						newName,
-						id = appServer.Id,
-					};
-					await apiConnection.SendQueryAsync<ReturnId>(ModellingQueries.setAppServerName, Variables);
-					await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Update, ModellingTypes.ModObjectType.AppServer, appServer.Id,
-                    	$"Update App Server Name: {appServer.Display()}", apiConnection, userConfig, appServer.AppId, DefaultInit.DoNothing, null, appServer.ImportSource);
-					Log.WriteWarning(LogMessageTitle, $"Name of App Server changed from {appServer.Name} changed to {newName}");
-				}
-				catch (Exception exc)
-				{
-					string errorText = $"Name of App Server {appServer.Name} could not be set to {newName}.";
-					Log.WriteError(LogMessageTitle, errorText, exc);
-					await AddLogEntry(1, LevelAppServer, errorText);
-					return false;
-				}
-			}
-			return true;
-		}
+        private async Task<bool> UpdateAppServerName(ModellingAppServer appServer, string newName)
+        {
+            if (appServer.Name != newName)
+            {
+                try
+                {
+                    var Variables = new
+                    {
+                        newName,
+                        id = appServer.Id,
+                    };
+                    await apiConnection.SendQueryAsync<ReturnId>(ModellingQueries.setAppServerName, Variables);
+                    await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Update, ModellingTypes.ModObjectType.AppServer, appServer.Id,
+                        $"Update App Server Name: {appServer.Display()}", apiConnection, userConfig, appServer.AppId, DefaultInit.DoNothing, null, appServer.ImportSource);
+                    Log.WriteWarning(LogMessageTitle, $"Name of App Server changed from {appServer.Name} changed to {newName}");
+                }
+                catch (Exception exc)
+                {
+                    string errorText = $"Name of App Server {appServer.Name} could not be set to {newName}.";
+                    Log.WriteError(LogMessageTitle, errorText, exc);
+                    await AddLogEntry(1, LevelAppServer, errorText);
+                    return false;
+                }
+            }
+            return true;
+        }
 
-		private async Task<bool> MarkDeletedAppServer(ModellingAppServer appServer)
-		{
-			try
-			{
-				var Variables = new
-				{
-					id = appServer.Id,
-					deleted = true
-				};
-				await apiConnection.SendQueryAsync<ReturnIdWrapper>(ModellingQueries.setAppServerDeletedState, Variables);
-				await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Update, ModellingTypes.ModObjectType.AppServer, appServer.Id,
+        private async Task<bool> MarkDeletedAppServer(ModellingAppServer appServer)
+        {
+            try
+            {
+                var Variables = new
+                {
+                    id = appServer.Id,
+                    deleted = true
+                };
+                await apiConnection.SendQueryAsync<ReturnIdWrapper>(ModellingQueries.setAppServerDeletedState, Variables);
+                await ModellingHandlerBase.LogChange(ModellingTypes.ChangeType.Update, ModellingTypes.ModObjectType.AppServer, appServer.Id,
                     $"Deactivate App Server: {appServer.Display()}", apiConnection, userConfig, appServer.AppId, DefaultInit.DoNothing, null, appServer.ImportSource);
-				await AppServerHelper.ReactivateOtherSource(apiConnection, userConfig, appServer);
-			}
-			catch (Exception exc)
-			{
-				string errorText = $"Outdated AppServer {appServer.Name} could not be marked as deleted.";
-				Log.WriteError(LogMessageTitle, errorText, exc);
-				await AddLogEntry(1, LevelAppServer, errorText);
-				return false;
-			}
-			return true;
-		}
-		
-		private async Task AddLogEntry(int severity, string level, string description)
-	    {
-	        try
-	        {
-	            var Variables = new
-	            {
-					user = 0,
-					source = GlobalConst.kImportAppData,
-	                severity = severity,
-	                suspectedCause = level,
-	                description = description
-	            };
-	            ReturnId[]? returnIds = (await apiConnection.SendQueryAsync<ReturnIdWrapper>(MonitorQueries.addDataImportLogEntry, Variables)).ReturnIds;
-	            if (returnIds == null)
-	            {
-	                Log.WriteError("Write Log", "Log could not be written to database");
-	            }
-	        }
-	        catch (Exception exc)
-	        {
-	            Log.WriteError("Write Log", $"Could not write log: ", exc);
-	        }
-	    }
-	}
+                await AppServerHelper.ReactivateOtherSource(apiConnection, userConfig, appServer);
+            }
+            catch (Exception exc)
+            {
+                string errorText = $"Outdated AppServer {appServer.Name} could not be marked as deleted.";
+                Log.WriteError(LogMessageTitle, errorText, exc);
+                await AddLogEntry(1, LevelAppServer, errorText);
+                return false;
+            }
+            return true;
+        }
+
+        private async Task AddLogEntry(int severity, string level, string description)
+        {
+            try
+            {
+                var Variables = new
+                {
+                    user = 0,
+                    source = GlobalConst.kImportAppData,
+                    severity = severity,
+                    suspectedCause = level,
+                    description = description
+                };
+                ReturnId[]? returnIds = (await apiConnection.SendQueryAsync<ReturnIdWrapper>(MonitorQueries.addDataImportLogEntry, Variables)).ReturnIds;
+                if (returnIds == null)
+                {
+                    Log.WriteError("Write Log", "Log could not be written to database");
+                }
+            }
+            catch (Exception exc)
+            {
+                Log.WriteError("Write Log", $"Could not write log: ", exc);
+            }
+        }
+    }
 }

--- a/roles/middleware/files/FWO.Middleware.Server/Program.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Program.cs
@@ -166,9 +166,6 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapControllers();
-});
+app.MapControllers();
 
 app.Run();

--- a/roles/tests-unit/files/FWO.Test/SanitizerTest.cs
+++ b/roles/tests-unit/files/FWO.Test/SanitizerTest.cs
@@ -1,6 +1,7 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using FWO.Data;
+using FWO.Basics;
 
 namespace FWO.Test
 {
@@ -48,9 +49,9 @@ namespace FWO.Test
             ClassicAssert.AreEqual(false, shortened);
             ClassicAssert.AreEqual(OkText, Sanitizer.SanitizeOpt(OkText, ref shortened));
             ClassicAssert.AreEqual(false, shortened);
-            ClassicAssert.AreEqual(OkText, Sanitizer.SanitizeMand(OkText, ref shortened));
+            ClassicAssert.AreEqual(OkText, OkText.SanitizeMand());
             ClassicAssert.AreEqual(false, shortened);
-            ClassicAssert.AreEqual(ShortenedText, Sanitizer.SanitizeMand(TextToShorten, ref shortened));
+            ClassicAssert.AreEqual(ShortenedText, TextToShorten.SanitizeMand());
             ClassicAssert.AreEqual(true, shortened);
 
             shortened = false;

--- a/roles/ui/files/FWO.UI/Pages/Certification.razor
+++ b/roles/ui/files/FWO.UI/Pages/Certification.razor
@@ -317,7 +317,7 @@
     private async Task ExecuteSelected()
     {
         bool shortened = false;
-        actComment = Sanitizer.SanitizeMand(actComment, ref shortened);
+        actComment = actComment.SanitizeMand();
         if(shortened)
         {
             DisplayMessageInUi(null, userConfig.GetText("execute_selected"), userConfig.GetText("U0001"), true);

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/NetworkModelling.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/NetworkModelling.razor
@@ -213,7 +213,7 @@ else
     private bool firstErrorMessage = true;
     private bool workInProgress = false;
     private bool InitDone = false;
-    
+
 
     protected override async Task OnInitializedAsync()
     {
@@ -485,15 +485,14 @@ else
     {
         try
         {
-            List<ExternalRequest> lastRequests = await apiConnection.SendQueryAsync<List<ExternalRequest>>(ExtRequestQueries.getLastRequest, new{ticketId = intTicket.Id});
-            if(lastRequests != null && lastRequests.Count > 0)
+            List<ExternalRequest> lastRequests = await apiConnection.SendQueryAsync<List<ExternalRequest>>(ExtRequestQueries.getLastRequest, new { ticketId = intTicket.Id });
+            if (lastRequests != null && lastRequests.Count > 0)
             {
                 bool shortened = false;
-                return Sanitizer.SanitizeCommentOpt(!string.IsNullOrEmpty(lastRequests.First().LastProcessingResponse) ? 
-                    lastRequests.First().LastProcessingResponse : lastRequests.First().LastCreationResponse, ref shortened);
+                return (!string.IsNullOrEmpty(lastRequests.First().LastProcessingResponse) ? lastRequests.First().LastProcessingResponse : lastRequests.First().LastCreationResponse).SanitizeCommentOpt(ref shortened);
             }
         }
-        catch(Exception exc)
+        catch (Exception exc)
         {
             Log.WriteError("Get Last Response", exc.Message);
         }

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/ChangesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/ChangesReport.razor
@@ -1,4 +1,4 @@
-﻿@using FWO.Ui.Display
+@using FWO.Ui.Display
 @using FWO.Config.Api
 @using FWO.Report
 @using FWO.Report.Filter

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsGroups.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsGroups.razor
@@ -236,7 +236,7 @@
         try
         {
             bool shortened = false;
-            newGroupName = Sanitizer.SanitizeMand(newGroupName, ref shortened);
+            newGroupName = newGroupName.SanitizeMand();
             if(shortened)
             {
                 DisplayMessageInUi(null, userConfig.GetText("save_group"), userConfig.GetText("U0001"), true);

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsModelling.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsModelling.razor
@@ -231,7 +231,7 @@
         <div class="form-group row mt-2" data-toggle="tooltip" title="@(userConfig.PureLine("H5640"))">
             <label class="col-sm-4 col-form-label col-form-label">@(userConfig.GetText("ownerGroupLdap")):</label>
             <div class="col-sm-2">
-                <Dropdown ElementType="UiLdapConnection" ElementToString="@(l => l.Name)" @bind-SelectedElement="selectedLdap" Elements="connectedLdaps">
+                <Dropdown ElementType="UiLdapConnection" ElementToString="@(l => l.Name)" SelectedElements="selectedLdaps" Elements="connectedLdaps" Multiselect="true">
                     <ElementTemplate Context="ldap">
                         @ldap.Name
                     </ElementTemplate>
@@ -522,7 +522,7 @@ else
     private DateTime varAnalysisDate = DateTime.Today;
     private DateTime varAnalysisTime = DateTime.Now.AddSeconds(-DateTime.Now.Second);
     private List<UiLdapConnection> connectedLdaps = [];
-    private UiLdapConnection selectedLdap = new();
+    private List<UiLdapConnection> selectedLdaps = new();
     private RuleRecognitionOption ruleRecognitionOption = new();
 
     private bool initComplete = false;
@@ -589,7 +589,7 @@ else
             connectedLdaps = await apiConnection.SendQueryAsync<List<UiLdapConnection>>(AuthQueries.getAllLdapConnections);
 
             // get config value of selected ldap connection for owner data (both groups and main responsible user), default value = 1 = internal ldap
-            selectedLdap = connectedLdaps.FirstOrDefault(x => x.Id == configData.OwnerLdapId) ?? new();
+            selectedLdaps = connectedLdaps.Where(x => configData.OwnerLdapIds.Contains(x.Id)).ToList();
 
             ruleRecognitionOption = string.IsNullOrEmpty(configData.RuleRecognitionOption) ? new() : JsonSerializer.Deserialize<RuleRecognitionOption>(configData.RuleRecognitionOption) ?? new();
             initComplete = true;
@@ -755,7 +755,7 @@ else
         configData!.ImportAppDataStartAt = appDataDate.Date.Add(appDataTime.TimeOfDay);
         configData!.ImportSubnetDataStartAt = subnetDataDate.Date.Add(subnetDataTime.TimeOfDay);
         configData!.VarianceAnalysisStartAt = varAnalysisDate.Date.Add(varAnalysisTime.TimeOfDay);
-        configData!.OwnerLdapId = selectedLdap.Id;
+        configData!.OwnerLdapIds = selectedLdaps.Select(x => x.Id).ToList();
         configData!.RuleRecognitionOption = JsonSerializer.Serialize(ruleRecognitionOption);
     }
 

--- a/roles/ui/files/FWO.UI/Shared/Dropdown.razor
+++ b/roles/ui/files/FWO.UI/Shared/Dropdown.razor
@@ -324,7 +324,7 @@
 
     public void Dispose()
     {
-        if(eventService is not null && eventService.Initialized)
+        if (eventService is not null && eventService.Initialized)
         {
             eventService.OnGlobalResize -= OnGlobalResize;
             eventService.OnGlobalScroll -= OnGlobalScroll;
@@ -333,7 +333,10 @@
 
         if (jsRuntime is not null)
         {
+#pragma warning disable CS8625
             jsRuntime = null;
+#pragma warning restore CS8625
+
             JsDisposed = true;
         }
     }

--- a/roles/ui/files/FWO.UI/Shared/EditNotifications.razor
+++ b/roles/ui/files/FWO.UI/Shared/EditNotifications.razor
@@ -1,4 +1,4 @@
-﻿@using FWO.Api.Client
+@using FWO.Api.Client
 @using FWO.Api.Client.Queries
 @using FWO.Basics
 @using FWO.Data
@@ -263,7 +263,7 @@
     private void AddToAddress()
     {
         bool shortened = false;
-        actToAddress = Sanitizer.SanitizeMand(actToAddress, ref shortened);
+        actToAddress = actCcAddress.SanitizeMand();
         ToAddressesToAdd.Add(actToAddress);
         actToAddress = "";
         if(shortened)
@@ -275,7 +275,7 @@
     private void AddCcAddress()
     {
         bool shortened = false;
-        actCcAddress = Sanitizer.SanitizeMand(actCcAddress, ref shortened);
+        actCcAddress = actCcAddress.SanitizeMand();
         CcAddressesToAdd.Add(actCcAddress);
         actCcAddress = "";
         if(shortened)

--- a/roles/ui/files/FWO.UI/Shared/IpAddressInput.razor
+++ b/roles/ui/files/FWO.UI/Shared/IpAddressInput.razor
@@ -1,4 +1,4 @@
-﻿@using NetTools;
+@using NetTools;
 
 @inject UserConfig userConfig
 
@@ -11,6 +11,7 @@
 
 	private IPAddressRange? ipRange;
 
+#pragma warning disable BL0007
 	[Parameter]
 	public IPAddressRange? IpRange
 	{
@@ -24,6 +25,7 @@
 			}
 		}
 	}
+#pragma warning restore BL0007
 
 	[Parameter]
 	public EventCallback<IPAddressRange?> IpRangeChanged { get; set; }

--- a/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
+++ b/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
@@ -39,7 +39,7 @@
                                 Data="managementsReportObjects"
                                 NameExtractor="man => man.Name"
                                 NetworkObjectExtractor="man => man.ReportObjects"
-                                NetworkServiceExtractor="man => man.ReportServices"
+                                NetworkServiceExtractor="man => man.ReportServices.Where(s => IsValidServiceForRSB(s))"
                                 NetworkUserExtractor="man => man.ReportUsers" />
                             </div>
                         </Tab>
@@ -62,7 +62,7 @@
                             </div>
                         </Tab>
                     }
-                    @if (CurrentReport?.ReportData.OwnerData.Count > 0 && (bool)CurrentReport?.ReportType.IsOwnerRelatedReport())
+                    @if (CurrentReport?.ReportData.OwnerData.Count > 0 && CurrentReport?.ReportType.IsOwnerRelatedReport() == true)
                     {
                         <Tab Title="@(CurrentReport?.ReportType == ReportType.VarianceAnalysis ? userConfig.GetText("modelled_objects") : userConfig.GetText("used_objects"))" StartSelected="true">
                             <div class="d-md-flex justify-content-md-end sticky-marker-45">
@@ -70,12 +70,12 @@
                             </div>
                             <div class="mt-2">
                                 <ObjectGroupCollection PageSize="PageSize" FetchObjects="FetchContent" Recert="Recert" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="OwnerReport"
-                                Data="@(PrepareObjects(CurrentReport.ReportData.OwnerData))"
+                                Data="@(CurrentReport != null ? PrepareObjects(CurrentReport.ReportData.OwnerData) : new List<OwnerReport>())"
                                 NameExtractor="own => own.Name"
                                 NetworkObjectExtractor="own => own.GetAllNetworkObjects(true, userConfig.ResolveNetworkAreas)"
                                 NetworkServiceExtractor="own => own.GetAllServices(true)" />
                                 <ObjectGroupCollection PageSize="PageSize" FetchObjects="FetchContent" Recert="Recert" Tab="RsbTab.usedObj" StartCollapsed="false" InputDataType="GlobalCommonSvcReport"
-                                Data="CurrentReport.ReportData.GlobalComSvc"
+                                Data="CurrentReport?.ReportData.GlobalComSvc"
                                 NameExtractor="glbComSvc => glbComSvc.Name"
                                 NetworkObjectExtractor="glbComSvc => glbComSvc.GetAllNetworkObjects(true, userConfig.ResolveNetworkAreas)"
                                 NetworkServiceExtractor="glbComSvc => glbComSvc.GetAllServices(true)" />
@@ -90,36 +90,36 @@
 
 @code
 {
-    [CascadingParameter]
-    Action<Exception?, string, string, bool> DisplayMessageInUi { get; set; } = DefaultInit.DoNothing;
+        [CascadingParameter]
+        Action<Exception?, string, string, bool> DisplayMessageInUi { get; set; } = DefaultInit.DoNothing;
 
-    [Parameter]
-    public int Width { get; set; }
+        [Parameter]
+        public int Width { get; set; }
 
-    [Parameter]
-    public EventCallback<int> WidthChanged { get; set; }
+        [Parameter]
+        public EventCallback<int> WidthChanged { get; set; }
 
 
-    [Parameter]
-    public ReportBase? CurrentReport { get; set; }
+        [Parameter]
+        public ReportBase? CurrentReport { get; set; }
 
-    [Parameter]
-    public List<Rule> SelectedRules { get; set; } = [];
+        [Parameter]
+        public List<Rule> SelectedRules { get; set; } = [];
 
-    [Parameter]
-    public EventCallback<List<Rule>> SelectedRulesChanged { get; set; }
+        [Parameter]
+        public EventCallback<List<Rule>> SelectedRulesChanged { get; set; }
 
-    [Parameter]
-    public bool AllTabVisible { get; set; } = true;
+        [Parameter]
+        public bool AllTabVisible { get; set; } = true;
 
-    [Parameter]
-    public ReportType SelectedReportType { get; set; } = ReportType.Rules;
+        [Parameter]
+        public ReportType SelectedReportType { get; set; } = ReportType.Rules;
 
-    [Parameter]
-    public TimeFilter LSBTime { get; set; } = new();
+        [Parameter]
+        public TimeFilter LSBTime { get; set; } = new();
 
-    [Parameter]
-    public bool Recert { get; set; } = false;
+        [Parameter]
+        public bool Recert { get; set; } = false;
 
     private FWO.Ui.Shared.TabSet tabset = new();
     private FWO.Ui.Shared.AnchorNavToRSB anchorNavToRSB = new();
@@ -203,7 +203,7 @@
                 [QueryVar.ImportIdEnd] = import_id_end.Values.Max(),
             };
             var mgmResult = await apiConnection.SendQueryAsync<List<ManagementReport>>(ObjectQueries.getAllObjectDetails, queryVars);
-            managementsAllObjects = mgmResult.Where(m => m.Objects.Count() > 0 || m.Services.Count() > 0 || m.Users.Count() > 0).ToList();
+            managementsAllObjects = mgmResult.Where(m => m.Objects.Count() > 0 || m.Services.Count() > 0 || m.Users.Count() > 0).ToList();            
             collapseInRSB.Collapse("all");
             await InvokeAsync(StateHasChanged);
         }
@@ -241,6 +241,23 @@
         }
 
         return prevStart != rsbTimeStart || prevEnd != rsbTimeEnd;
+    }
+
+    private bool IsValidServiceForRSB(NetworkService s)
+    {
+        if (s.Protocol == null || s.Protocol.Id == 0)
+            return false;
+
+        string protocolName = s.Protocol.Name?.Trim() ?? "";
+        string serviceName = s.Name?.Trim() ?? "";
+
+        if (protocolName.Equals("HOPOPT", StringComparison.OrdinalIgnoreCase) ||
+                serviceName.Equals("any", StringComparison.OrdinalIgnoreCase) ||
+                serviceName.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        return true;
     }
 
     private async Task<Dictionary<int, long>> GetImportIds(string time, int? mgmId = null)

--- a/roles/ui/files/FWO.UI/wwwroot/js/scrollIntoView.js
+++ b/roles/ui/files/FWO.UI/wwwroot/js/scrollIntoView.js
@@ -3,7 +3,12 @@ function scrollIntoRSBView(htmlObjId) {
   let obj =  document.getElementById(htmlObjId)?.parentElement?.parentElement; // gets the tr element containing the obj
   if (!obj)
     return false;
-  obj.scrollIntoView({behavior: "smooth", block: "center"});
+  obj.scrollIntoView({ behavior: "smooth", block: "center" });
+  // Expand row
+  let toggleLink = obj.previousElementSibling.querySelector("a");
+  if (toggleLink) {
+      toggleLink.click();
+  }
   // Highlight the row
   obj.style.transition = "background-color 500ms linear";
   obj.style.backgroundColor = "#a4d7f5";


### PR DESCRIPTION
##############
Reporting - Suppress protocol output for Any/All Service #3688
##############

Changes:
File: roles/lib/files/FWO.Data/DisplayBase.cs

Protocol output is now suppressed when:
protocol ID is 0, and the service name is "any" or "all", or the protocol name is "HOPOPT".

- Enhancement -
File: RightSidebar.razor
Updated NetworkServiceExtractor:
Before:
man => man.ReportServices
After:
man => man.ReportServices.Where(s => IsValidServiceForRSB(s))

Helper method IsValidServiceForRSB suppress output where appropriate.

Notes:
Some time was needed to get oriented within the Right Sidebar structure.
A NullReferenceException related to the protocol


##############
Reporting - expand an object in the RSB when clicking on a link #3309
##############

Changes:
File: scrollIntoView.js

Added logic to expand the row of the target object when a link is clicked by simulating a click on the related toggle link.

Notes:
Took some time to locate the relevant logic - was implemented in JavaScript. 
Might add a check for aria-expanded to avoid unintended toggle on repeated link clicks.


##############
Migrate C# Sanitizer to StringExtensions #3592
##############

Changes:

- Moved all sanitizer methods from FWO.Data/Sanitizer.cs to FWO.Basics/StringExtensionsSanitizer.cs.
- Updated all usages across the codebase like in Example: Log.cs (WriteInColor())

Notes:
No Problems

##############
Fix current warnings in mw and ui #3544
##############


Changes:

- Resolved all build-time warnings in the Middleware and UI projects to ensure new Warnings are seen.

-Suppressed warnings using #pragma warning disable, e.g.:
CS9113 (unused parameter)

- Added centralized suppression in Directory.Build.props:
Suppressed CS0169 (unused private field) for FWO.UI, as it could not be consistently suppressed via #pragma.

Notes:
Some warnings required investigation



##############
Modelling Auth - Enhance Owner Group lookup #3517
##############

Changes:
- SettingsModelling.razor now Dropdown multiselect
AppDataImport.cs:
Now reads OwnerLdapIds from config and builds ownerGroupLdaps and ownerGroupLdapPaths

Notes:
- Current implementation uses only the first GroupWritePath when constructing group DNs.
- Final integration into GetGroupDn() and related logic is not yet complete.
- Did not reach out for support in time, partially due to time constraints – will do so earlier in future when stuck.


##############
Reporting Settings - new parameter visible rule columns per report type #2991
##############

no Changes:

Entries in ChangesReport.razor are "RuleChange"s
RuleChange objects are being processed via RuleChangeDisplayHtml to manage the visibility 

Did not manage to complete task 