### PR TITLE
include empty groups group objects in assessability check

### DIFF
--- a/roles/lib/files/FWO.Report/ReportCompliance.cs
+++ b/roles/lib/files/FWO.Report/ReportCompliance.cs
@@ -645,7 +645,9 @@ namespace FWO.Report
                 {
                     foreach (GroupFlat<NetworkObject> groupFlat in networkLocation.Object.ObjectGroupFlats)
                     {
-                        if (groupFlat.Object != null && groupFlat.Object.Type.Name != "group")
+                        // excludes group objects, that are filled, to prevent false positives on objects without ip, but excludes empty groups
+                        
+                        if (groupFlat.Object != null && (groupFlat.Object.Type.Name != "group" || groupFlat.Object.ObjectGroupFlats.Count() == 0))
                         {
                             allObjects.Add(groupFlat.Object);
                         }


### PR DESCRIPTION
This is a hotfix. In the process of cleaning the code for that feature this issue will be tackled in a more sophisticated way.