### PR TITLE
Issue 3796   sync unit tests

### DIFF
--- a/roles/tests-unit/tasks/main.yml
+++ b/roles/tests-unit/tasks/main.yml
@@ -1,36 +1,45 @@
 - block:
-    - name: sync test files to frontend target
-      synchronize:
-        src: FWO.Test
-        dest: "{{ test_dir }}/csharp"
-        rsync_opts:
-          - "--chown={{ fworch_user }}:{{ fworch_group }}"
-          - "--delete"
-      become: true
+      - name: ensure test_dir exists
+        file:
+            path: "{{ test_dir }}/csharp"
+            state: directory
+            owner: "{{ fworch_user }}"
+            group: "{{ fworch_group }}"
+            mode: "0755"
+        become: true
 
-    - name: run csharp tests
-      command: dotnet test
-      args:
-        chdir: "{{ csharp_test_start_dir }}"
-      become: true
-      become_user: "{{ fworch_user }}"
-      register: csharp_tests
-      ignore_errors: false
-      environment: "{{ proxy_env }}"
+      - name: sync test files to frontend target
+        synchronize:
+            src: FWO.Test
+            dest: "{{ test_dir }}/csharp"
+            rsync_opts:
+                - "--chown={{ fworch_user }}:{{ fworch_group }}"
+                - "--delete"
+        become: true
 
-    - name: show csharp test results in case of errors
-      debug:
-        var: csharp_tests
-      when: csharp_tests.rc != 0
+      - name: run csharp tests
+        command: dotnet test
+        args:
+            chdir: "{{ csharp_test_start_dir }}"
+        become: true
+        become_user: "{{ fworch_user }}"
+        register: csharp_tests
+        ignore_errors: false
+        environment: "{{ proxy_env }}"
+
+      - name: show csharp test results in case of errors
+        debug:
+            var: csharp_tests
+        when: csharp_tests.rc != 0
 
   when: "'frontends' in group_names"
   # run only once (on frontends)
 
 - block:
-    - name: Run importer Python unit tests
-      environment:
-        PYTHONPATH: "/usr/local/fworch/importer"
-      args:
-        chdir: "/usr/local/fworch/importer/test"
-      command: >
-        {{ importer_venv_dir }}/bin/python3 -m unittest discover -s . -p "test_*.py" -v
+      - name: Run importer Python unit tests
+        environment:
+            PYTHONPATH: "/usr/local/fworch/importer"
+        args:
+            chdir: "/usr/local/fworch/importer/test"
+        command: >
+            {{ importer_venv_dir }}/bin/python3 -m unittest discover -s . -p "test_*.py" -v


### PR DESCRIPTION
Fixes #3796 in importer-rework

For the python unit tests this is not necessary, because in the importer role all old importer code gets deleted before copying the current sources on disk (see task "remove importer dir for cleaning up all old code")