### PR TITLE
hotfix: compare appserver name case-insensitive

### DIFF
--- a/roles/lib/files/FWO.Services/AppServerComparer.cs
+++ b/roles/lib/files/FWO.Services/AppServerComparer.cs
@@ -35,7 +35,7 @@ namespace FWO.Services
 
         public int GetHashCode(ModellingAppServer appServer)
         {
-            string appServerName = AppServerHelper.ConstructSanitizedAppServerName(appServer, NamingConvention).Trim();
+            string appServerName = AppServerHelper.ConstructSanitizedAppServerName(appServer, NamingConvention).ToLower().Trim();
             return HashCode.Combine(appServerName);
         }
     }


### PR DESCRIPTION
we have seen same errors with already existing appservers which  might be linked to the comparison being case-sensitive.
@abarz722 - any veto from your side to switching this to case-insensitive?
