### PR TITLE
importer-rework adding missing api permissions reporting

### DIFF
--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -15390,6 +15390,19 @@
                   "comment": ""
                 },
                 {
+                  "role": "auditor",
+                  "permission": {
+                    "columns": [
+                      "created",
+                      "removed",
+                      "dev_id",
+                      "rule_id"
+                    ],
+                    "filter": {}
+                  },
+                  "comment": ""
+                },
+                {
                   "role": "middleware-server",
                   "permission": {
                     "columns": [


### PR DESCRIPTION
In 9.0 we will replace all *_last_seen fields with new "removed" fields.
Most roles had no permission to access newly added field "removed".
Also adding perms for rulebase_links and rulebases.
