### PR TITLE
fix unnecessary rendering

### DIFF
--- a/roles/lib/files/FWO.Report/ReportRules.cs
+++ b/roles/lib/files/FWO.Report/ReportRules.cs
@@ -35,7 +35,7 @@ namespace FWO.Report
         protected bool UseAdditionalFilter = false;
         private bool VarianceMode = false;
 
-        private static Dictionary<(int deviceId, int managementId), List<Rule>> _rulesCache = new();
+        private static Dictionary<(int deviceId, int managementId), Rule[]> _rulesCache = new();
 
         public override async Task Generate(int elementsPerFetch, ApiConnection apiConnection, Func<ReportData, Task> callback, CancellationToken ct)
         {
@@ -110,12 +110,13 @@ namespace FWO.Report
                         }
                     }
 
-                    _rulesCache[(deviceReport.Id, managementReport.Id)] = allRules;
+                    Rule[] rulesArray = allRules.ToArray();
+                    _rulesCache[(deviceReport.Id, managementReport.Id)] = rulesArray;
 
                     // Add all rule ids to ReportedRuleIds of management, that are not already in that list
 
                     managementReport.ReportedRuleIds.AddRange(
-                        allRules.Select(r => r.Id).Except(managementReport.ReportedRuleIds)
+                        rulesArray.Select(r => r.Id).Except(managementReport.ReportedRuleIds)
                     );
                 }
             }
@@ -265,13 +266,13 @@ namespace FWO.Report
 
         public static Rule[] GetAllRulesOfGateway(DeviceReportController deviceReport, ManagementReport managementReport)
         {
-            if (_rulesCache.TryGetValue((deviceReport.Id, managementReport.Id), out List<Rule>? allRules))
+            if (_rulesCache.TryGetValue((deviceReport.Id, managementReport.Id), out Rule[]? allRules))
             {
-                return allRules.ToArray();
+                return allRules;
             }
             else
             {
-                return [];
+                return Array.Empty<Rule>();
             }
         }
 


### PR DESCRIPTION
Report Rendering Speed (ai generated)

- Rendering was slow because every render of RulesReport asked ReportRules.GetAllRulesOfGateway() for its data, and that method always cloned the cached rule list via .ToArray(). With thousands of rules this amounted to O(n) copying for every UI redraw, so the UI spent most of its time reallocating arrays instead of drawing (roles/lib/files/FWO.Report/ReportRules.cs:32-125,267-276). 
- _rulesCache now stores the rules as Rule[] instead of List<Rule>, and the list-to-array conversion happens exactly once per device/management pair when the report data is generated (roles/lib/files/FWO.Report/ReportRules.cs (lines 38-125)). The cached array is returned directly to the UI (roles/lib/files/FWO.Report/ReportRules.cs (lines 267-276)), and the reported-rule bookkeeping reuses the same array, eliminating the repeated allocations during rendering.