### PR TITLE
fix(ui/importer): rollback failing because of rule_zone constraints

### DIFF
--- a/roles/common/files/fwo-api-calls/import/rollbackImport.graphql
+++ b/roles/common/files/fwo-api-calls/import/rollbackImport.graphql
@@ -1,10 +1,4 @@
 mutation rollbackImport($importId: bigint!) {
-    delete_rulebase(where: {created: {_eq: $importId}}) { affected_rows }
-    delete_rulebase_link(where: {created: {_eq: $importId}}) { affected_rows }
-    delete_object(where: {obj_create: {_eq: $importId}}) { affected_rows }
-    delete_service(where: {svc_create: {_eq: $importId}}) { affected_rows }
-    delete_usr(where: {user_create: {_eq: $importId}}) { affected_rows }
-    delete_zone(where: {zone_create: {_eq: $importId}}) { affected_rows }
     delete_objgrp(where: {import_created: {_eq: $importId}}) { affected_rows }
     delete_svcgrp(where: {import_created: {_eq: $importId}}) { affected_rows }
     delete_usergrp(where: {import_created: {_eq: $importId}}) { affected_rows }
@@ -20,7 +14,13 @@ mutation rollbackImport($importId: bigint!) {
     delete_rule_from_zone(where: {created: {_eq: $importId}}) { affected_rows }
     delete_rule_to_zone(where: {created: {_eq: $importId}}) { affected_rows }
     delete_rule_enforced_on_gateway(where: {created: {_eq: $importId}}) { affected_rows }
+    delete_object(where: {obj_create: {_eq: $importId}}) { affected_rows }
+    delete_service(where: {svc_create: {_eq: $importId}}) { affected_rows }
+    delete_usr(where: {user_create: {_eq: $importId}}) { affected_rows }
+    delete_zone(where: {zone_create: {_eq: $importId}}) { affected_rows }
     delete_rule(where: {rule_create: {_eq: $importId}}) { affected_rows }
+    delete_rulebase_link(where: {created: {_eq: $importId}}) { affected_rows }
+    delete_rulebase(where: {created: {_eq: $importId}}) { affected_rows }
     update_rule(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_rulebase(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_rulebase_link(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }


### PR DESCRIPTION
the ordering of the deletes in the query matters. currently we are getting fk constraint violations because of the zones being deleted before the rule_to_zone/rule_from_zone entries.
not sure tho why we weren't getting the same with e.g. rulebase deletes coming before rulebase_link deletes...

<img width="1024" height="416" alt="1024-416-max" src="https://github.com/user-attachments/assets/cc92a178-0531-4fba-81cd-12544511991d" />
