### PR TITLE
feat/importer-rework-delete rule_metadata with no entrie in rule

### DIFF
--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -1882,9 +1882,9 @@ DECLARE
     rec RECORD;
     v_do_not_import_true_count INT;
     v_do_not_import_false_count INT;
-	missing_uids TEXT;
-	too_many_mgm_ids_on_uid_and_no_resolve TEXT;
-	all_errors_with_no_resolve TEXT := '';
+    missing_uids TEXT;
+    too_many_mgm_ids_on_uid_and_no_resolve TEXT;
+    all_errors_with_no_resolve TEXT := '';
 
 BEGIN
 --Check rule_metadata has entries in rule
@@ -1896,15 +1896,15 @@ BEGIN
 
     IF missing_uids IS NOT NULL THEN
         RAISE NOTICE 'Missing rule(s): %', missing_uids;
-		DELETE FROM rule_metadata
-			WHERE rule_uid IN (
-				SELECT rm.rule_uid
-				FROM rule_metadata rm
-				LEFT JOIN rule r ON rm.rule_uid = r.rule_uid
-				WHERE r.rule_uid IS NULL
-		);		
-    END IF;	
-	
+        DELETE FROM rule_metadata
+            WHERE rule_uid IN (
+                SELECT rm.rule_uid
+                FROM rule_metadata rm
+                LEFT JOIN rule r ON rm.rule_uid = r.rule_uid
+                WHERE r.rule_uid IS NULL
+        );
+    END IF;
+
     -- Constraints droppen
     ALTER TABLE rule DROP CONSTRAINT IF EXISTS rule_metadatum;
     ALTER TABLE rule DROP CONSTRAINT IF EXISTS rule_rule_metadata_rule_uid_f_key;


### PR DESCRIPTION
Orphaned rule_metadata entrie.s are now automatically deleted.

Tested on importer-rework (09.12.2025):
- Cloned and modified some rule_metadata
- Entries without matching rule_uid were correctly removed