### PR TITLE
fix/importer-rework-zone unique constraint update

### DIFF
--- a/roles/database/files/sql/creation/fworch-create-constraints.sql
+++ b/roles/database/files/sql/creation/fworch-create-constraints.sql
@@ -45,7 +45,7 @@ Alter table "rulebase_link" add CONSTRAINT unique_rulebase_link
 Alter Table "service" add Constraint "svc_altkey" UNIQUE ("mgm_id","svc_uid","svc_create");
 Alter Table "stm_dev_typ" add Constraint "Alter_Key1" UNIQUE ("dev_typ_name","dev_typ_version");
 Alter Table "usr" add Constraint "usr_altkey" UNIQUE ("mgm_id","user_name","user_create");
-Alter Table "zone" add Constraint "Alter_Key10" UNIQUE ("mgm_id","zone_name");
+CREATE UNIQUE INDEX if not exists "zone_mgm_id_zone_name_removed_is_null_unique" ON zone (mgm_id, zone_name) WHERE removed IS NULL;
 
 create unique index if not exists only_one_future_recert_per_owner_per_rule on recertification(owner_id,rule_metadata_id,recert_date)
     where recert_date IS NULL;

--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -2020,3 +2020,10 @@ DROP SEQUENCE IF EXISTS public.stm_change_type_change_type_id_seq;
 DROP SEQUENCE IF EXISTS public.stm_action_action_id_seq;
 DROP SEQUENCE IF EXISTS public.stm_dev_typ_dev_typ_id_seq;
 DROP SEQUENCE IF EXISTS public.parent_rule_type_id_seq;
+
+-- drop old mgm_id, zone_name constraint
+ALTER TABLE zone
+DROP CONSTRAINT IF EXISTS "Alter_Key10";
+
+-- add new mgm_id, zone_name constraint where just one with removed is null allowed
+CREATE UNIQUE INDEX if not exists "zone_mgm_id_zone_name_removed_is_null_unique" ON zone (mgm_id, zone_name) WHERE removed IS NULL;


### PR DESCRIPTION
- drop old "alter_key17" constraint
- add new Unique Index zone_mgm_id_zone_name_removed_is_null
- update in create constraints.sql

With this change, only one active entry per (mgm_id, zone_name) is allowed (removed IS NULL).
Other entries can exist with the same combination, but removed must be set. It doesn’t matter if multiple entries have same  removed value.

Tested in Hasura with duplicate and edited rows.