### PR TITLE
fix(importer): cp 108 login

### DIFF
--- a/roles/importer/files/importer/model_controllers/management_controller.py
+++ b/roles/importer/files/importer/model_controllers/management_controller.py
@@ -113,10 +113,7 @@ class ManagementController(Management):
             sub_managers=[cls.from_json(subManager) for subManager in json_dict["subManagers"]],
         )
 
-        domain_info = DomainInfo(
-            domain_name=replace_none_with_empty(json_dict.get("configPath", "")),
-            domain_uid=replace_none_with_empty(json_dict.get("domainUid", "")),
-        )
+        domain_info = DomainInfo(domain_name=json_dict["configPath"], domain_uid=json_dict["domainUid"])
 
         return cls(
             mgm_id=json_dict["id"],


### PR DESCRIPTION
Reverted a change which lead to the cp import not working anymore. please check the reason for the initial change and re-implement it in a safe way if necessary. commit: https://github.com/CactuseSecurity/firewall-orchestrator/commit/29c14364bec518b096dfd2bd502f038439d1e4a4

The problem was:

domain_uid being "" changed in management_controller to `"<EMPTY>"`

management_controller ln148:
```
def get_domain_string(self) -> str:
    return self.domain_uid if self.domain_uid is not None else self.domain_name
```
-> `"<EMPTY>"`
leads to login in cp_getter ln57 with payload `{'user': '....', 'password': '......', 'domain': '<EMPTY>'}` leads to
`{'code': 'err_login_failed', 'message': 'Authentication to server failed.'}`