### PR TITLE
fix(db): _resolved table pkey constraint

### DIFF
--- a/roles/database/files/sql/creation/fworch-create-tables.sql
+++ b/roles/database/files/sql/creation/fworch-create-tables.sql
@@ -215,7 +215,7 @@ Create table "rule_svc_resolved"
 	"svc_id" BIGINT NOT NULL,
 	"created" BIGINT NOT NULL,
 	"removed" BIGINT,
- primary key ("mgm_id","rule_id","svc_id")
+ primary key ("mgm_id","rule_id","svc_id","created")
 );
 
 Create table "rule_nwobj_resolved"
@@ -225,7 +225,7 @@ Create table "rule_nwobj_resolved"
 	"obj_id" BIGINT NOT NULL,
 	"created" BIGINT NOT NULL,
 	"removed" BIGINT,
- primary key ("mgm_id","rule_id","obj_id")
+ primary key ("mgm_id","rule_id","obj_id","created")
 );
 
 Create table "rule_user_resolved"
@@ -235,7 +235,7 @@ Create table "rule_user_resolved"
 	"user_id" BIGINT NOT NULL,
 	"created" BIGINT NOT NULL,
 	"removed" BIGINT,
- primary key ("mgm_id","rule_id","user_id")
+ primary key ("mgm_id","rule_id","user_id","created")
 );
 
 Create table "rule_from"

--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -2214,3 +2214,12 @@ END$$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS owner_responsible_owner_dn_type_unique ON owner_responsible(owner_id, dn, responsible_type);
 CREATE INDEX IF NOT EXISTS owner_responsible_dn_idx ON owner_responsible(dn);
+
+-- Changing primary key of *_resolved tables to include created timestamp
+-- This is necessary to store multiple resolutions for the same object/rule over time
+ALTER TABLE "rule_nwobj_resolved" DROP CONSTRAINT IF EXISTS "rule_nwobj_resolved_pkey";
+ALTER TABLE "rule_nwobj_resolved" ADD PRIMARY KEY ("mgm_id", "rule_id", "obj_id", "created");
+ALTER TABLE "rule_svc_resolved" DROP CONSTRAINT IF EXISTS "rule_svc_resolved_pkey";
+ALTER TABLE "rule_svc_resolved" ADD PRIMARY KEY ("mgm_id", "rule_id", "svc_id", "created");
+ALTER TABLE "rule_user_resolved" DROP CONSTRAINT IF EXISTS "rule_user_resolved_pkey";
+ALTER TABLE "rule_user_resolved" ADD PRIMARY KEY ("mgm_id", "rule_id", "user_id", "created");


### PR DESCRIPTION
Previous constraint would lead to an error in the following scenario:
```
============ import_id 1
- rule a
  - group
    - obj x
    - obj y
(a, x)
(a, y, create=1)
============ import_id 2
- rule a
  - group
    - obj x
(a, x)
(a, y, create=1, removed=2)
============ import_id 3
- rule a
  - group
    - obj x
    - obj y
(a, x)
(a, y, create=1, removed=2)
(a, y, create=3) =>>> ERROR already exists
```

closes #4192 