### PR TITLE
fix/develop - restore GraphQL query for statistics report 

### DIFF
--- a/roles/lib/files/FWO.Data/ObjectStatistics.cs
+++ b/roles/lib/files/FWO.Data/ObjectStatistics.cs
@@ -7,6 +7,21 @@ namespace FWO.Data
     {
         [JsonProperty("aggregate"), JsonPropertyName("aggregate")]
         public ObjectAggregate ObjectAggregate { get; set; } = new ObjectAggregate();
+
+        
+        [JsonProperty("rules_aggregate"), JsonPropertyName("rules_aggregate")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used by JSON deserialization")]
+        private ObjectStatistics RulesAggregateWrapper
+        {
+            get => default!;
+            set
+            {
+                if (value != null && value.ObjectAggregate != null)
+                {
+                    ObjectAggregate = value.ObjectAggregate;
+                }
+            }
+        }
     }
 
     public class ObjectAggregate

--- a/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
+++ b/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
@@ -145,12 +145,12 @@ namespace FWO.Report.Filter
                         usrs_aggregate(where: {{ {query.UserObjWhereStatement} }}) {{ aggregate {{ count }} }}
                         rules_aggregate(where: {{ {query.RuleWhereStatement} }}) {{ aggregate {{ count }} }}
                         unusedRules_Count: rules_aggregate(where: {{ {unusedRulesWhereStatement}}}) {{ aggregate {{ count }} }}
-                        devices( {{ devWhereStringDefault }} )
+                        devices( {devWhereStringDefault} )
                         {{
                             name: dev_name
                             id: dev_id
-                            rules_aggregate(where: {{ {query.RuleWhereStatement} }}) {{ aggregate {{ count }} }}
-                            unusedRules_Count: rules_aggregate(where: {{ {unusedRulesWhereStatement}}}) {{ aggregate {{ count }} }}
+                            rules_aggregate: management {{ rules_aggregate(where: {{ {query.RuleWhereStatement} }}) {{ aggregate {{ count }} }} }}
+                            unusedRules_Count: management {{ rules_aggregate(where: {{ {unusedRulesWhereStatement} }}) {{ aggregate {{ count }} }} }}
                         }}
                     }}
                 }}";


### PR DESCRIPTION
fix: update GraphQL query for statistics report

- rules_aggregate for device now retrieved via management (device no longer has its own)
- added small wrapper in ObjectStatistics to support device -> management -> rules_aggregate

ref #4186
