### PR TITLE
fix/develop delete management rule_x_zone 

### DIFF
--- a/roles/database/files/sql/creation/fworch-create-foreign-keys.sql
+++ b/roles/database/files/sql/creation/fworch-create-foreign-keys.sql
@@ -110,8 +110,8 @@ Alter table "rulebase_link" add CONSTRAINT fk_rulebase_link_created_import_contr
 Alter table "rulebase_link" add CONSTRAINT fk_rulebase_link_removed_import_control_control_id 
 	foreign key ("removed") references "import_control" ("control_id") on update restrict on delete cascade;
 
-ALTER TABLE "rule_from_zone" ADD CONSTRAINT fk_rule_from_zone_rule_id_rule_rule_id FOREIGN KEY ("rule_id") REFERENCES "rule" ("rule_id");
-ALTER TABLE "rule_from_zone" ADD CONSTRAINT fk_rule_from_zone_zone_id_zone_zone_id FOREIGN KEY ("zone_id") REFERENCES "zone" ("zone_id");
+ALTER TABLE "rule_from_zone" ADD CONSTRAINT fk_rule_from_zone_rule_id_rule_rule_id FOREIGN KEY ("rule_id") REFERENCES "rule" ("rule_id") on update restrict on delete cascade;
+ALTER TABLE "rule_from_zone" ADD CONSTRAINT fk_rule_from_zone_zone_id_zone_zone_id FOREIGN KEY ("zone_id") REFERENCES "zone" ("zone_id") on update restrict on delete cascade;
 
 Alter table "rule_from" add foreign key ("obj_id") references "object" ("obj_id") on update restrict on delete cascade;
 Alter table "rule_from" add foreign key ("rf_create") references "import_control" ("control_id") on update restrict on delete cascade;
@@ -153,8 +153,8 @@ Alter table "rule_to" add  foreign key ("rt_last_seen") references "import_contr
 Alter table "rule_to" add  foreign key ("rule_id") references "rule" ("rule_id") on update restrict on delete cascade;
 Alter table "rule_to" add constraint rule_to_user_id_usr_user_id FOREIGN KEY ("user_id") references "usr" ("user_id") on update restrict on delete cascade;
 
-ALTER TABLE "rule_to_zone" ADD CONSTRAINT fk_rule_to_zone_rule_id_rule_rule_id FOREIGN KEY ("rule_id") REFERENCES "rule" ("rule_id");
-ALTER TABLE "rule_to_zone" ADD CONSTRAINT fk_rule_to_zone_zone_id_zone_zone_id FOREIGN KEY ("zone_id") REFERENCES "zone" ("zone_id");
+ALTER TABLE "rule_to_zone" ADD CONSTRAINT fk_rule_to_zone_rule_id_rule_rule_id FOREIGN KEY ("rule_id") REFERENCES "rule" ("rule_id") on update restrict on delete cascade;
+ALTER TABLE "rule_to_zone" ADD CONSTRAINT fk_rule_to_zone_zone_id_zone_zone_id FOREIGN KEY ("zone_id") REFERENCES "zone" ("zone_id") on update restrict on delete cascade;
 
 Alter table "rule_user_resolved" add foreign key ("user_id") references "usr" ("user_id") on update restrict on delete cascade;
 Alter table "rule_user_resolved" add foreign key ("rule_id") references "rule" ("rule_id") on update restrict on delete cascade;

--- a/roles/database/files/upgrade/9.0.sql
+++ b/roles/database/files/upgrade/9.0.sql
@@ -1933,3 +1933,41 @@ ALTER TABLE "rule_svc_resolved" DROP CONSTRAINT IF EXISTS "rule_svc_resolved_pke
 ALTER TABLE "rule_svc_resolved" ADD PRIMARY KEY ("mgm_id", "rule_id", "svc_id", "created");
 ALTER TABLE "rule_user_resolved" DROP CONSTRAINT IF EXISTS "rule_user_resolved_pkey";
 ALTER TABLE "rule_user_resolved" ADD PRIMARY KEY ("mgm_id", "rule_id", "user_id", "created");
+
+-- rule_to_zone
+ALTER TABLE "rule_to_zone"
+DROP CONSTRAINT IF EXISTS fk_rule_to_zone_rule_id_rule_rule_id;
+
+ALTER TABLE "rule_to_zone"
+ADD CONSTRAINT fk_rule_to_zone_rule_id_rule_rule_id
+FOREIGN KEY ("rule_id") REFERENCES "rule" ("rule_id")
+ON UPDATE RESTRICT
+ON DELETE CASCADE;
+
+ALTER TABLE "rule_to_zone"
+DROP CONSTRAINT IF EXISTS fk_rule_to_zone_zone_id_zone_zone_id;
+
+ALTER TABLE "rule_to_zone"
+ADD CONSTRAINT fk_rule_to_zone_zone_id_zone_zone_id
+FOREIGN KEY ("zone_id") REFERENCES "zone" ("zone_id")
+ON UPDATE RESTRICT
+ON DELETE CASCADE;
+
+-- rule_from_zone
+ALTER TABLE "rule_from_zone"
+DROP CONSTRAINT IF EXISTS fk_rule_from_zone_rule_id_rule_rule_id;
+
+ALTER TABLE "rule_from_zone"
+ADD CONSTRAINT fk_rule_from_zone_rule_id_rule_rule_id
+FOREIGN KEY ("rule_id") REFERENCES "rule" ("rule_id")
+ON UPDATE RESTRICT
+ON DELETE CASCADE;
+
+ALTER TABLE "rule_from_zone"
+DROP CONSTRAINT IF EXISTS fk_rule_from_zone_zone_id_zone_zone_id;
+
+ALTER TABLE "rule_from_zone"
+ADD CONSTRAINT fk_rule_from_zone_zone_id_zone_zone_id
+FOREIGN KEY ("zone_id") REFERENCES "zone" ("zone_id")
+ON UPDATE RESTRICT
+ON DELETE CASCADE;


### PR DESCRIPTION
update foreign key constraints in `rule_to_zone` and `rule_from_zone` to enforce ON DELETE CASCADE

ref #4202
