### PR TITLE
fix: Dependabot runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
     target-branch: "develop"
     schedule:
       interval: "daily"
+    registries:
+      - private-github


### PR DESCRIPTION
Requires a new secret `PRIVATE_SUBMODULE_TOKEN` to be added to the repo that has access to the submodule(s).