### PR TITLE
fix(api): rollback time objects

### DIFF
--- a/roles/common/files/fwo-api-calls/import/rollbackImport.graphql
+++ b/roles/common/files/fwo-api-calls/import/rollbackImport.graphql
@@ -13,11 +13,13 @@ mutation rollbackImport($importId: bigint!) {
     delete_rule_user_resolved(where: {created: {_eq: $importId}}) { affected_rows }
     delete_rule_from_zone(where: {created: {_eq: $importId}}) { affected_rows }
     delete_rule_to_zone(where: {created: {_eq: $importId}}) { affected_rows }
+    delete_rule_time(where: {created: {_eq: $importId}}) { affected_rows }
     delete_rule_enforced_on_gateway(where: {created: {_eq: $importId}}) { affected_rows }
     delete_object(where: {obj_create: {_eq: $importId}}) { affected_rows }
     delete_service(where: {svc_create: {_eq: $importId}}) { affected_rows }
     delete_usr(where: {user_create: {_eq: $importId}}) { affected_rows }
     delete_zone(where: {zone_create: {_eq: $importId}}) { affected_rows }
+    delete_time_object(where: {created: {_eq: $importId}}) { affected_rows }
     delete_rule_metadata(where: {rule_created: {_eq: $importId}}) { affected_rows }
     delete_rule(where: {rule_create: {_eq: $importId}}) { affected_rows }
     delete_rulebase_link(where: {created: {_eq: $importId}}) { affected_rows }
@@ -29,6 +31,7 @@ mutation rollbackImport($importId: bigint!) {
     update_service(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_usr(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_zone(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
+    update_time_object(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_objgrp(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_svcgrp(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_usergrp(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
@@ -43,6 +46,7 @@ mutation rollbackImport($importId: bigint!) {
     update_rule_user_resolved(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_rule_from_zone(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_rule_to_zone(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
+    update_rule_time(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     update_rule_enforced_on_gateway(where: {removed: {_eq: $importId}}, _set: {removed: null}) { affected_rows }
     delete_import_control(where: {control_id: {_eq: $importId}}) { affected_rows }            
 }


### PR DESCRIPTION
time object related tables were missing from the rollback mutation, possibly leading to inconsistent db state.