### PR TITLE
add expiration time to csv export of compliance report

### DIFF
--- a/roles/lib/files/FWO.Data/FwoNotification.cs
+++ b/roles/lib/files/FWO.Data/FwoNotification.cs
@@ -9,10 +9,10 @@ namespace FWO.Data
         Recertification = 1,
         ImportChange = 2,
         Compliance = 3,
-		InterfaceRequest = 4,
-		RuleTimer = 5,
-		AppDecomm = 6
-	}
+        InterfaceRequest = 4,
+        RuleTimer = 5,
+        AppDecomm = 6
+    }
 
     public enum NotificationChannel
     {
@@ -23,10 +23,10 @@ namespace FWO.Data
     {
         None = 0,
         RecertDate = 1,
-		RequestDate = 2,
-		RuleExpiry = 3,
-		DecommissionDate = 4
-	}
+        RequestDate = 2,
+        RuleExpiry = 3,
+        DecommissionDate = 4
+    }
 
     public class FwoNotification
     {

--- a/roles/lib/files/FWO.Report/Data/ViewData/RuleViewData.cs
+++ b/roles/lib/files/FWO.Report/Data/ViewData/RuleViewData.cs
@@ -31,6 +31,11 @@ namespace FWO.Report.Data.ViewData
         public string RulebaseName { get; set; } = "";
         public string Enabled { get; set; } = "";
         public string RuleTime { get; set; } = "";
+        public string ExpirationTime
+        {
+            get => RuleTime;
+            set => RuleTime = value;
+        }
 
         public Rule? DataObject { get; set; }
         public bool Show { get; set; } = true;

--- a/roles/lib/files/FWO.Report/ReportCompliance.cs
+++ b/roles/lib/files/FWO.Report/ReportCompliance.cs
@@ -404,6 +404,7 @@ namespace FWO.Report
                 "AdoITID",
                 "Comment",
                 "LastModified",
+                "ExpirationTime",
                 "RulebaseId",
                 "RulebaseName",
                 "Enabled"

--- a/roles/tests-unit/files/FWO.Test/ReportComplianceTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ReportComplianceTest.cs
@@ -1,5 +1,6 @@
 using FWO.Config.Api;
 using FWO.Data;
+using FWO.Report.Data.ViewData;
 using FWO.Test.Mocks;
 using FWO.Api.Client.Queries;
 using NUnit.Framework;
@@ -176,6 +177,46 @@ namespace FWO.Test
 
             Assert.That(queryVariables.ContainsKey("mgm_ids"), Is.True);
             Assert.That((List<int>)queryVariables["mgm_ids"], Is.EqualTo(new List<int> { 3, 4 }));
+        }
+
+        [Test]
+        public void ExportToCsv_IncludesExpirationTimeColumnAndValue()
+        {
+            MockReportCompliance report = new(new(""), new(), Basics.ReportType.ComplianceReport);
+            report.RuleViewData =
+            [
+                new RuleViewData
+                {
+                    MgmtId = "1",
+                    MgmtName = "Mgmt",
+                    Uid = "uid-1",
+                    Name = "Rule 1",
+                    Source = "src",
+                    SourceShort = "src-short",
+                    Destination = "dst",
+                    DestinationShort = "dst-short",
+                    Services = "svc",
+                    ServicesShort = "svc-short",
+                    Action = "accept",
+                    InstallOn = "fw1",
+                    Compliance = "FALSE",
+                    ViolationDetails = "detail",
+                    ChangeID = "chg-1",
+                    AdoITID = "ado-1",
+                    Comment = "comment",
+                    LastModified = "2026-03-24",
+                    ExpirationTime = "2026-12-24 11:22:33",
+                    RulebaseId = "7",
+                    RulebaseName = "rb",
+                    Enabled = "TRUE",
+                    Show = true
+                }
+            ];
+
+            string csv = report.ExportToCsv();
+
+            Assert.That(csv, Does.Contain("\"ExpirationTime\""));
+            Assert.That(csv, Does.Contain("\"2026-12-24 11:22:33\""));
         }
 
         private List<Rule>[] BuildFixedRuleChunksParallel(int numberOfChunks, int numberOfRulesPerChunk, int startRuleId = 1, int? maxDegreeOfParallelism = null)


### PR DESCRIPTION
Found something missing. The expiration time was in the dynamic report, but not in the csv export. Now it is.