### PR TITLE
Fix/develop NullReferenceException in ChangesReport for Services with null Protocol

### DIFF
--- a/roles/lib/files/FWO.Report/Display/RuleChangeDisplayCsv.cs
+++ b/roles/lib/files/FWO.Report/Display/RuleChangeDisplayCsv.cs
@@ -344,9 +344,9 @@ namespace FWO.Ui.Display
         {
             switch (serviceChange.ChangeAction)
             {
-                case 'D': return OutputCsv(serviceChange.OldService.Protocol!.Name);
-                case 'I': return OutputCsv(serviceChange.NewService.Protocol!.Name);
-                case 'C': return OutputCsv(DisplayDiff(serviceChange.OldService.Protocol!.Name, serviceChange.NewService.Protocol!.Name));
+                case 'D': return OutputCsv(serviceChange.OldService.Protocol?.Name ?? "");
+                case 'I': return OutputCsv(serviceChange.NewService.Protocol?.Name ?? "");
+                case 'C': return OutputCsv(DisplayDiff(serviceChange.OldService.Protocol?.Name ?? "", serviceChange.NewService.Protocol?.Name ?? ""));
                 default: return "";
             }
         }

--- a/roles/lib/files/FWO.Report/Display/RuleChangeDisplayHtml.cs
+++ b/roles/lib/files/FWO.Report/Display/RuleChangeDisplayHtml.cs
@@ -407,12 +407,10 @@ namespace FWO.Ui.Display
 
         public string DisplayServiceProtocol(ServiceChange serviceChange)
         {
-
             switch (serviceChange.ChangeAction)
             {
-
-                case 'D': return OutputHtmlDeleted(serviceChange.OldService.Protocol!.Name);
-                case 'I': return OutputHtmlAdded(serviceChange.NewService.Protocol!.Name);
+                case 'D': return OutputHtmlDeleted(serviceChange.OldService.Protocol?.Name ?? "");
+                case 'I': return OutputHtmlAdded(serviceChange.NewService.Protocol?.Name ?? "");
                 case 'C': return DisplayDiff(serviceChange.OldService.Protocol?.Name ?? "", serviceChange.NewService.Protocol?.Name ?? "");
                 default: ThrowErrorUnknowChangeAction(serviceChange.ChangeAction); return "";
             }

--- a/roles/lib/files/FWO.Report/Display/RuleChangeDisplayJson.cs
+++ b/roles/lib/files/FWO.Report/Display/RuleChangeDisplayJson.cs
@@ -371,9 +371,9 @@ namespace FWO.Ui.Display
         {
             switch (serviceChange.ChangeAction)
             {
-                case 'D': return DisplayServiceProtocol(serviceChange.OldService.Protocol!.Name);
-                case 'I': return DisplayServiceProtocol(serviceChange.NewService.Protocol!.Name);
-                case 'C': return DisplayServiceProtocol(DisplayDiff(serviceChange.OldService.Protocol!.Name, serviceChange.NewService.Protocol!.Name));
+                case 'D': return DisplayServiceProtocol(serviceChange.OldService.Protocol?.Name ?? "");
+                case 'I': return DisplayServiceProtocol(serviceChange.NewService.Protocol?.Name ?? "");
+                case 'C': return DisplayServiceProtocol(DisplayDiff(serviceChange.OldService.Protocol?.Name ?? "", serviceChange.NewService.Protocol?.Name ?? ""));
                 default: return "";
             }
         }


### PR DESCRIPTION
Currently, the ChangesReport, while including Objects, leads to the “Something went wrong while loading the Component” page when a service has Protocol = null.

Due to this issue, related emails were also not sent.

