### PR TITLE
Nuget Updates

### DIFF
--- a/roles/lib/files/FWO.Basics/FWO.Basics.csproj
+++ b/roles/lib/files/FWO.Basics/FWO.Basics.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DnsClient" Version="1.8.0" />
     <PackageReference Include="IPAddressRange" Version="6.3.0" />
-    <PackageReference Include="IPNetwork2" Version="4.0.2" />
+    <PackageReference Include="IPNetwork2" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Config.File/FWO.Config.File.csproj
+++ b/roles/lib/files/FWO.Config.File/FWO.Config.File.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Report/FWO.Report.csproj
+++ b/roles/lib/files/FWO.Report/FWO.Report.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-	  <PackageReference Include="PuppeteerSharp" Version="21.1.1" />
+	  <PackageReference Include="PuppeteerSharp" Version="24.40.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -10,11 +10,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="21.1.1" />
-    <PackageReference Include="Quartz" Version="3.16.1" />
-    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.16.1" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.16.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageReference Include="PuppeteerSharp" Version="24.40.0" />
+    <PackageReference Include="Quartz" Version="3.17.1" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.17.1" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.17.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
+++ b/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="2.6.2" />
+    <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="PuppeteerSharp" Version="21.1.1" />
+    <PackageReference Include="PuppeteerSharp" Version="24.40.0" />
     <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>

--- a/roles/ui/files/FWO.UI/FWO.Ui.csproj
+++ b/roles/ui/files/FWO.UI/FWO.Ui.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="IPAddressRange" Version="6.3.0" />
 		<PackageReference Include="BlazorTable" Version="1.17.0" />
-		<PackageReference Include="PuppeteerSharp" Version="21.1.1" />
+		<PackageReference Include="PuppeteerSharp" Version="24.40.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Update PuppeteerSharp from 21.1.1 to 24.40.0
Update NUnit3TestAdapter from 6.1.0 to 6.2.0
Update Microsoft.NET.Test.Sdk from 18.3.0 to 18.4.0 Update IPNetwork2 from 4.0.2 to 4.2.0
Update bunit from 2.6.2 to 2.7.2

The changes for Puppeteer include some memory usage enhancements which is nice even when the puppeteer instance only lives for several seconds during PDF creation. Memory usage and PDF creation time shouldn't spike as much on very large PDF exports.

Tested Upgrade, Unit Tests, PDF creation manual and scheduled report and tested if the scheduler job still fire.