### PR TITLE
fix(importer): cp timestamps

### DIFF
--- a/documentation/revision-history-main.md
+++ b/documentation/revision-history-main.md
@@ -607,3 +607,8 @@ A complete 80K lines rework of FWO, including
 # 9.0.21 - 21.04.2026 MAIN
 - bug fixing
 - dependency updates (notably closing mailkit and pytest vulnerabilities)
+
+# 9.0.22 - 26.04.2026 MAIN
+- fixes missing source or destination in rule expiry notification report
+- fixes time zone issues with checkpoint time objects
+- fixes python tests failing on python 3.10

--- a/documentation/revision-history-main.md
+++ b/documentation/revision-history-main.md
@@ -612,3 +612,4 @@ A complete 80K lines rework of FWO, including
 - fixes missing source or destination in rule expiry notification report
 - fixes time zone issues with checkpoint time objects
 - fixes python tests failing on python 3.10
+- fixes owner import from custom file

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ### general settings
-product_version: "9.0.21"
+product_version: "9.0.22"
 ansible_user: "{{ lookup('env', 'USER') }}"
 ansible_become_method: sudo
 ansible_python_interpreter: /usr/bin/python3

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -12874,6 +12874,7 @@
                   "permission": {
                     "columns": [
                       "active",
+                      "additional_info",
                       "app_id_external",
                       "common_service_possible",
                       "criticality",

--- a/roles/common/files/fwo-api-calls/rule/fragments/ruleDetails.graphql
+++ b/roles/common/files/fwo-api-calls/rule/fragments/ruleDetails.graphql
@@ -30,7 +30,13 @@ fragment ruleDetails on rule {
   rule_installon
   rule_custom_fields
   rule_time
-  rule_times{
+  rule_times(where: {
+    created: { _lte: $import_id_end }
+    _or: [
+      { removed: { _is_null: true } }
+      { removed: { _gt: $import_id_start } }
+    ]
+  }, order_by:{ time_object: { time_obj_name: asc } }) {
     rule_time_id
     rule_id
     time_obj_id

--- a/roles/importer/files/importer/fw_modules/checkpointR8x/cp_network.py
+++ b/roles/importer/files/importer/fw_modules/checkpointR8x/cp_network.py
@@ -1,5 +1,6 @@
 import ipaddress
 import json
+from datetime import datetime, timezone
 from typing import Any
 
 import fwo_const
@@ -271,6 +272,22 @@ def make_host(ip_in: str) -> str | None:
     return None
 
 
+def convert_timestamp(timestamp: str) -> str:
+    """
+    In CP, time objects' time stamps are interpreted per-gateway for their local time zone. This means, the timestamps
+    we get from api, even though with explicit utc time zone, will not necessarily match the actual point-in-time used
+    after installation on gw. We assume the gw time zone is the same as the importer time zone and convert all timestamps
+    to utc based on that assumption.
+    """
+    try:
+        local_time = datetime.fromisoformat(timestamp)  # interpret timestamp in local timezone
+        utc_time = local_time.astimezone(timezone.utc)
+        return utc_time.isoformat()
+    except ValueError:
+        FWOLogger.warning(f"Failed to parse timestamp '{timestamp}', leaving it unchanged")
+        return timestamp
+
+
 def normalize_time_objects(full_config: dict[str, Any], config2import: dict[str, Any]):
     time_objects: list[dict[str, Any]] = []
 
@@ -282,8 +299,8 @@ def normalize_time_objects(full_config: dict[str, Any], config2import: dict[str,
                 TimeObject(
                     time_obj_uid=obj["uid"],
                     time_obj_name=obj["name"],
-                    start_time=None if obj["start-now"] else obj["start"]["iso-8601"],
-                    end_time=None if obj["end-never"] else obj["end"]["iso-8601"],
+                    start_time=None if obj["start-now"] else convert_timestamp(obj["start"]["iso-8601"]),
+                    end_time=None if obj["end-never"] else convert_timestamp(obj["end"]["iso-8601"]),
                 ).model_dump()  # TODO: rework dicts to models everywhere
                 for obj in chunk.get("objects", [])
             )

--- a/roles/importer/files/importer/fwo_api_call.py
+++ b/roles/importer/files/importer/fwo_api_call.py
@@ -407,7 +407,7 @@ class FwoApiCall:
         )
         import_result += ", ERRORS: " + exception_message if exception_message is not None else ""
 
-        if import_state.stats.get_change_details() != {} and FWOLogger.is_debug_level(4) and exception is None:
+        if import_state.stats.get_change_details() != {} and exception is None:
             import_result += ", change details: " + str(import_state.stats.get_change_details())
 
         if exception is not None:

--- a/roles/importer/files/importer/models/time_object.py
+++ b/roles/importer/files/importer/models/time_object.py
@@ -21,7 +21,7 @@ class TimeObject(BaseModel):
         try:
             parsed_time = cls._parse_iso_timestamp(value)
             if parsed_time.tzinfo is None:
-                return parsed_time.isoformat(timespec="seconds")
+                parsed_time = parsed_time.replace(tzinfo=timezone.utc)
             return parsed_time.astimezone(timezone.utc).isoformat(timespec="seconds")
         except ValueError:
             raise ValueError(

--- a/roles/importer/files/importer/models/time_object.py
+++ b/roles/importer/files/importer/models/time_object.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timezone
 
 from pydantic import BaseModel, field_validator
@@ -18,13 +19,26 @@ class TimeObject(BaseModel):
         if value is None:
             return value
         try:
-            normalized_value = value.replace("Z", "+00:00")
-            parsed_time = datetime.fromisoformat(normalized_value)
+            parsed_time = cls._parse_iso_timestamp(value)
             if parsed_time.tzinfo is None:
-                parsed_time = parsed_time.replace(tzinfo=timezone.utc)
+                return parsed_time.isoformat(timespec="seconds")
             return parsed_time.astimezone(timezone.utc).isoformat(timespec="seconds")
         except ValueError:
-            raise ValueError(f"Time value '{value}' does not match format 'YYYY-MM-DDTHH:MM:SS+HH:MM'") from None
+            raise ValueError(
+                f"Time value '{value}' does not match supported ISO formats "
+                "'YYYY-MM-DDTHH:MM:SS', 'YYYY-MM-DDTHH:MM:SSZ', 'YYYY-MM-DDTHH:MM:SS+HH:MM', or 'YYYY-MM-DDTHH:MM:SS+HHMM'."
+            ) from None
+
+    @staticmethod
+    def _parse_iso_timestamp(value: str) -> datetime:
+        normalized_value = value.strip().replace("Z", "+00:00")
+
+        # Python 3.10 is stricter and does not always parse offsets like +0000.
+        # Convert +HHMM / -HHMM to +HH:MM / -HH:MM before parsing.
+        if re.search(r"[+-]\d{4}$", normalized_value):
+            normalized_value = f"{normalized_value[:-5]}{normalized_value[-5:-2]}:{normalized_value[-2:]}"
+
+        return datetime.fromisoformat(normalized_value)
 
 
 class TimeObjectForImport(BaseModel):

--- a/roles/importer/files/importer/test/test_fortiadom5ff.py
+++ b/roles/importer/files/importer/test/test_fortiadom5ff.py
@@ -11,10 +11,9 @@ from pytest_mock import MockerFixture
 class TestToTimeObject:
     @staticmethod
     def _expected_as_utc(date_part: str, time_part: str) -> str:
-        local_tz = datetime.now().astimezone().tzinfo
         return (
             datetime.strptime(f"{date_part} {time_part}", "%Y/%m/%d %H:%M")
-            .replace(tzinfo=local_tz)
+            .astimezone()
             .astimezone(timezone.utc)
             .isoformat(timespec="seconds")
         )

--- a/scripts/customizing/app_data_import/test_app_data_import.py
+++ b/scripts/customizing/app_data_import/test_app_data_import.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import sys
 import tempfile
@@ -677,13 +678,7 @@ class AppDataImportTests(unittest.TestCase):
             config_path: Path = Path(tmpdir) / "customizingConfig.json"
             expected_repo_dir: str = str(Path(tmpdir) / "fworch-custom-repos")
             with open(config_path, "w", encoding="utf-8") as fh:
-                fh.write(
-                    f"""
-                    {{
-                      "localRepoBaseDir": "{expected_repo_dir}"
-                    }}
-                    """
-                )
+                json.dump({"localRepoBaseDir": expected_repo_dir}, fh)
 
             resolved: str = resolve_local_repo_base_dir(str(config_path), None, self.logger)
 
@@ -695,13 +690,7 @@ class AppDataImportTests(unittest.TestCase):
             config_repo_dir: str = str(Path(tmpdir) / "fworch-config-repos")
             cli_repo_dir: str = str(Path(tmpdir) / "fworch-cli-repos")
             with open(config_path, "w", encoding="utf-8") as fh:
-                fh.write(
-                    f"""
-                    {{
-                      "localRepoBaseDir": "{config_repo_dir}"
-                    }}
-                    """
-                )
+                json.dump({"localRepoBaseDir": config_repo_dir}, fh)
 
             resolved: str = resolve_local_repo_base_dir(str(config_path), cli_repo_dir, self.logger)
 

--- a/scripts/customizing/iiq_request_missing_roles/test_iiq_request_missing_roles.py
+++ b/scripts/customizing/iiq_request_missing_roles/test_iiq_request_missing_roles.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import tempfile
 import unittest
@@ -25,13 +26,7 @@ class IiqRequestMissingRolesTests(unittest.TestCase):
             config_path: Path = Path(tmpdir) / "customizingConfig.json"
             expected_repo_dir: str = str(Path(tmpdir) / "fworch-iiq-config-repos")
             with open(config_path, "w", encoding="utf-8") as fh:
-                fh.write(
-                    f"""
-                    {{
-                      "iiqLocalRepoBaseDir": "{expected_repo_dir}"
-                    }}
-                    """
-                )
+                json.dump({"iiqLocalRepoBaseDir": expected_repo_dir}, fh)
 
             resolved: str = resolve_local_repo_base_dir(str(config_path), None, self.logger)
 
@@ -41,15 +36,9 @@ class IiqRequestMissingRolesTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path: Path = Path(tmpdir) / "customizingConfig.json"
             expected_repo_dir: str = str(Path(tmpdir) / "fworch-shared-config-repos")
+            iiq_repo_dir: str = str(Path(tmpdir) / "fworch-iiq-config-repos")
             with open(config_path, "w", encoding="utf-8") as fh:
-                fh.write(
-                    f"""
-                    {{
-                      "localRepoBaseDir": "{expected_repo_dir}",
-                      "iiqLocalRepoBaseDir": "{Path(tmpdir) / "fworch-iiq-config-repos"}"
-                    }}
-                    """
-                )
+                json.dump({"localRepoBaseDir": expected_repo_dir, "iiqLocalRepoBaseDir": iiq_repo_dir}, fh)
 
             resolved: str = resolve_local_repo_base_dir(str(config_path), None, self.logger)
 
@@ -61,13 +50,7 @@ class IiqRequestMissingRolesTests(unittest.TestCase):
             config_repo_dir: str = str(Path(tmpdir) / "fworch-iiq-config-repos")
             cli_repo_dir: str = str(Path(tmpdir) / "fworch-iiq-cli-repos")
             with open(config_path, "w", encoding="utf-8") as fh:
-                fh.write(
-                    f"""
-                    {{
-                      "iiqLocalRepoBaseDir": "{config_repo_dir}"
-                    }}
-                    """
-                )
+                json.dump({"iiqLocalRepoBaseDir": config_repo_dir}, fh)
 
             resolved: str = resolve_local_repo_base_dir(str(config_path), cli_repo_dir, self.logger)
 
@@ -89,13 +72,7 @@ class IiqRequestMissingRolesTests(unittest.TestCase):
             config_import_dir: str = str(Path(tmpdir) / "config-import")
             cli_import_dir: str = str(Path(tmpdir) / "cli-import")
             with open(config_path, "w", encoding="utf-8") as fh:
-                fh.write(
-                    f"""
-                    {{
-                      "importFromFolder": "{config_import_dir}"
-                    }}
-                    """
-                )
+                json.dump({"importFromFolder": config_import_dir}, fh)
 
             resolved: str | None = resolve_import_from_folder(str(config_path), cli_import_dir, self.logger)
 
@@ -106,13 +83,7 @@ class IiqRequestMissingRolesTests(unittest.TestCase):
             config_path: Path = Path(tmpdir) / "customizingConfig.json"
             expected_import_dir: str = str(Path(tmpdir) / "config-import")
             with open(config_path, "w", encoding="utf-8") as fh:
-                fh.write(
-                    f"""
-                    {{
-                      "importFromFolder": "{expected_import_dir}"
-                    }}
-                    """
-                )
+                json.dump({"importFromFolder": expected_import_dir}, fh)
 
             resolved: str | None = resolve_import_from_folder(str(config_path), None, self.logger)
 


### PR DESCRIPTION
- fixes cp timestamp mismatch
  - we cannot interpret the cp api's timestamps as acutal point-in-times, as they are recalculated per gateway. instead we now assume gw time zone = importer tz and do that calculation ourselves, before writing to db
- fixes reports showing outdated time object per rule
- fixes integration test failing for python 3.10
- improve importer logging -> always show change details
- fixes script tests failing on windows (by @ErikPre )
- fixes missing permissions on owner table, leading to owner import failing