### PR TITLE
feat(UI): RuleTree - Collapse all button

### DIFF
--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -327,6 +327,10 @@ INSERT INTO txt VALUES ('RuleExpiryCheck',      'German', 	'Ablaufdatum-Check');
 INSERT INTO txt VALUES ('RuleExpiryCheck',      'English', 	'Rule expiry check');
 INSERT INTO txt VALUES ('OwnerActiveRules',     'German', 	'Aktive Regeln von deaktivierten Eigent&uuml;mern');
 INSERT INTO txt VALUES ('OwnerActiveRules',     'English', 	'Active rules of decommissioned owners');
+INSERT INTO txt VALUES ('PreferredCollapseState_Collapsed', 'German', 'Eingeklappt');
+INSERT INTO txt VALUES ('PreferredCollapseState_Collapsed', 'English', 'Collapsed');
+INSERT INTO txt VALUES ('PreferredCollapseState_Expanded',  'German', 'Aufgeklappt');
+INSERT INTO txt VALUES ('PreferredCollapseState_Expanded',  'English', 'Expanded');
 
 -- general
 INSERT INTO txt VALUES ('cancel', 				'German',	'Abbrechen');

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -327,10 +327,14 @@ INSERT INTO txt VALUES ('RuleExpiryCheck',      'German', 	'Ablaufdatum-Check');
 INSERT INTO txt VALUES ('RuleExpiryCheck',      'English', 	'Rule expiry check');
 INSERT INTO txt VALUES ('OwnerActiveRules',     'German', 	'Aktive Regeln von deaktivierten Eigent&uuml;mern');
 INSERT INTO txt VALUES ('OwnerActiveRules',     'English', 	'Active rules of decommissioned owners');
+INSERT INTO txt VALUES ('PreferredCollapseState','German',  'Standardzustand der Klappelemente');
+INSERT INTO txt VALUES ('PreferredCollapseState','English', 'Default state of the collapsible elements');
 INSERT INTO txt VALUES ('PreferredCollapseState_Collapsed', 'German', 'Eingeklappt');
 INSERT INTO txt VALUES ('PreferredCollapseState_Collapsed', 'English', 'Collapsed');
 INSERT INTO txt VALUES ('PreferredCollapseState_Expanded',  'German', 'Aufgeklappt');
 INSERT INTO txt VALUES ('PreferredCollapseState_Expanded',  'English', 'Expanded');
+INSERT INTO txt VALUES ('PreferredCollapseState_Intermediate','German', 'Unbestimmt');
+INSERT INTO txt VALUES ('PreferredCollapseState_Intermediate','English', 'Intermediate');
 
 -- general
 INSERT INTO txt VALUES ('cancel', 				'German',	'Abbrechen');
@@ -5697,6 +5701,8 @@ INSERT INTO txt VALUES ('H5461', 'English', 'Every user can set his own preferre
     The default language at first login can be defined by the admin for all users in the <a href="/help/settings/defaults">Default Settings</a>.<br><br>
     Currently available:
 ');
+INSERT INTO txt VALUES ('H5462', 'German',  'Regelt den Standardzustand der Klappelemente für die Regelwerkanzeige im Rules Report.');
+INSERT INTO txt VALUES ('H5462', 'English', 'Sets the default state of the collapsible elements for the rule display in the Rules Report.');
 INSERT INTO txt VALUES ('H5466', 'German',  'Nachricht die auf der Anmeldeseite angezeigt werden soll.');
 INSERT INTO txt VALUES ('H5466', 'English', 'Message that is displayed on Login Page.');
 INSERT INTO txt VALUES ('H5471', 'German',  'Jeder Nutzer kann einige pers&ouml;nliche Voreinstellungen f&uuml;r die Reporteinstellungen &uuml;berschreiben.

--- a/roles/lib/files/FWO.Basics/Enums/PreferredCollapseState.cs
+++ b/roles/lib/files/FWO.Basics/Enums/PreferredCollapseState.cs
@@ -1,0 +1,9 @@
+namespace FWO.Basics.Enums
+{
+    public enum PreferredCollapseState
+    {
+        Collapsed
+        Expanded
+        Intermediate
+    }
+}

--- a/roles/lib/files/FWO.Basics/Enums/PreferredCollapseState.cs
+++ b/roles/lib/files/FWO.Basics/Enums/PreferredCollapseState.cs
@@ -2,8 +2,8 @@ namespace FWO.Basics.Enums
 {
     public enum PreferredCollapseState
     {
-        Collapsed
-        Expanded
+        Collapsed,
+        Expanded,
         Intermediate
     }
 }

--- a/roles/lib/files/FWO.Basics/Extensions/EnumExtensions.cs
+++ b/roles/lib/files/FWO.Basics/Extensions/EnumExtensions.cs
@@ -1,0 +1,74 @@
+namespace FWO.Basics.Extensions
+{
+    public static class EnumExtensions
+    {
+        extension<TEnum>(IEnumerable<TEnum> values) where TEnum : struct, Enum
+        {
+            /// <summary>
+            /// Returns the sequence without the excluded enum value.
+            /// </summary>
+            public IEnumerable<TEnum> Except(TEnum excludedValue)
+            {
+                ArgumentNullException.ThrowIfNull(values);
+
+                return ExceptSingle(values, excludedValue);
+            }
+
+            /// <summary>
+            /// Returns the sequence without the excluded enum values.
+            /// </summary>
+            public IEnumerable<TEnum> Except(params TEnum[] excludedValues)
+            {
+                ArgumentNullException.ThrowIfNull(values);
+                ArgumentNullException.ThrowIfNull(excludedValues);
+
+                return excludedValues.Length switch
+                {
+                    0 => values,
+                    1 => ExceptSingle(values, excludedValues[0]),
+                    2 => ExceptPair(values, excludedValues[0], excludedValues[1]),
+                    _ => ExceptMany(values, excludedValues),
+                };
+            }
+        }
+
+        private static IEnumerable<TEnum> ExceptSingle<TEnum>(IEnumerable<TEnum> values, TEnum excludedValue)
+            where TEnum : struct, Enum
+        {
+            foreach (TEnum value in values)
+            {
+                if (!EqualityComparer<TEnum>.Default.Equals(value, excludedValue))
+                {
+                    yield return value;
+                }
+            }
+        }
+
+        private static IEnumerable<TEnum> ExceptPair<TEnum>(IEnumerable<TEnum> values, TEnum firstExcludedValue, TEnum secondExcludedValue)
+            where TEnum : struct, Enum
+        {
+            foreach (TEnum value in values)
+            {
+                if (!EqualityComparer<TEnum>.Default.Equals(value, firstExcludedValue)
+                    && !EqualityComparer<TEnum>.Default.Equals(value, secondExcludedValue))
+                {
+                    yield return value;
+                }
+            }
+        }
+
+        private static IEnumerable<TEnum> ExceptMany<TEnum>(IEnumerable<TEnum> values, TEnum[] excludedValues)
+            where TEnum : struct, Enum
+        {
+            HashSet<TEnum> excluded = [.. excludedValues];
+
+            foreach (TEnum value in values)
+            {
+                if (!excluded.Contains(value))
+                {
+                    yield return value;
+                }
+            }
+        }
+    }
+}

--- a/roles/lib/files/FWO.Basics/Extensions/EnumExtensions.cs
+++ b/roles/lib/files/FWO.Basics/Extensions/EnumExtensions.cs
@@ -5,16 +5,6 @@ namespace FWO.Basics.Extensions
         extension<TEnum>(IEnumerable<TEnum> values) where TEnum : struct, Enum
         {
             /// <summary>
-            /// Returns the sequence without the excluded enum value.
-            /// </summary>
-            public IEnumerable<TEnum> Except(TEnum excludedValue)
-            {
-                ArgumentNullException.ThrowIfNull(values);
-
-                return ExceptSingle(values, excludedValue);
-            }
-
-            /// <summary>
             /// Returns the sequence without the excluded enum values.
             /// </summary>
             public IEnumerable<TEnum> Except(params TEnum[] excludedValues)

--- a/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
+++ b/roles/lib/files/FWO.Config.Api/Data/ConfigData.cs
@@ -5,6 +5,7 @@ using FWO.Basics;
 using FWO.Data;
 using FWO.Data.Workflow;
 using FWO.Mail;
+using FWO.Basics.Enums;
 
 namespace FWO.Config.Api.Data
 {
@@ -582,6 +583,8 @@ namespace FWO.Config.Api.Data
         [JsonProperty("complianceFilterOutInitialViolations"), JsonPropertyName("complianceFilterOutInitialViolations")]
         public bool ComplianceFilterOutInitialViolations { get; set; } = false;
 
+        [JsonProperty("reportingPersonalPreferredCollapseState"), JsonPropertyName("reportingPersonalPreferredCollapseState")]
+        public PreferredCollapseState ReportingPersonalPreferredCollapseState { get; set; } = PreferredCollapseState.Collapsed;
 
         public ConfigData(bool editable = false)
         {

--- a/roles/lib/files/FWO.Report/ReportRules.cs
+++ b/roles/lib/files/FWO.Report/ReportRules.cs
@@ -1,6 +1,7 @@
 using FWO.Api.Client;
 using FWO.Api.Client.Queries;
 using FWO.Basics;
+using FWO.Basics.Enums;
 using FWO.Config.Api;
 using FWO.Data;
 using FWO.Data.Report;
@@ -159,6 +160,7 @@ namespace FWO.Report
                     scopedRuleTreeBuilder.Reset(managementReport.Rulebases, deviceReport.RulebaseLinks);
 
                     List<Rule> allRules = scopedRuleTreeBuilder.BuildRuleTree(managementReport.Rulebases, deviceReport.RulebaseLinks, managementReport.Id, deviceReport.Id);
+                    ApplyPreferredCollapseState(scopedRuleTreeBuilder, managementReport.Id, deviceReport.Id);
 
                     Rule[] rulesArray = [.. allRules];
                     _rulesCache[(deviceReport.Id, managementReport.Id)] = rulesArray;
@@ -174,6 +176,30 @@ namespace FWO.Report
             }
 
             ReportData.ElementsCount = ruleCount;
+        }
+
+        /// <summary>
+        /// Applies the user's preferred initial collapse state to the generated rule tree.
+        /// </summary>
+        private void ApplyPreferredCollapseState(IRuleTreeBuilder scopedRuleTreeBuilder, int managementId, int deviceId)
+        {
+            if (!scopedRuleTreeBuilder.RuleTreeCache.TryGetValue((managementId, deviceId), out RuleTreeItem? ruleTree))
+            {
+                return;
+            }
+
+            switch (userConfig.ReportingPersonalPreferredCollapseState)
+            {
+                case PreferredCollapseState.Collapsed:
+                    RuleTreeItem.SetExpandedRecursively(ruleTree, false);
+                    break;
+                case PreferredCollapseState.Expanded:
+                    RuleTreeItem.SetExpandedRecursively(ruleTree, true);
+                    break;
+                case PreferredCollapseState.Intermediate:
+                default:
+                    break;
+            }
         }
 
         protected virtual void SetMgtQueryVars(ManagementReport management)

--- a/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeItem.cs
+++ b/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeItem.cs
@@ -125,23 +125,16 @@ namespace FWO.Services.RuleTreeBuilder
             }
         }
 
-        public static void SetCollapse(RuleTreeItem item, bool collapsed)
+        /// <summary>
+        /// Updates the expanded state for all expandable descendants of the provided root item.
+        /// </summary>
+        public static void SetExpandedRecursively(RuleTreeItem item, bool isExpanded)
         {
-            if (item.IsRule)
+            foreach (RuleTreeItem childItem in TraverseDown(item))
             {
-                item.IsVisible = !collapsed;
-            }
-            else
-            {
-                if (item.Children.Count > 0)
+                if (childItem != item && childItem.Children.Count > 0)
                 {
-                    foreach (RuleTreeItem childItem in TraverseDown(item))
-                    {
-                        if (item != childItem)
-                        {
-                            SetCollapse(childItem, collapsed);
-                        }
-                    }
+                    childItem.IsExpanded = isExpanded;
                 }
             }
         }

--- a/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeItem.cs
+++ b/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeItem.cs
@@ -125,7 +125,29 @@ namespace FWO.Services.RuleTreeBuilder
             }
         }
 
-        private IEnumerable<RuleTreeItem> TraverseDown(RuleTreeItem item, Action<RuleTreeItem>? action = null)
+        public static void SetCollapse(RuleTreeItem item, bool collapsed)
+        {
+            if (item.IsRule)
+            {
+                item.IsVisible = !collapsed;
+            }
+            else
+            {
+                if (item.Children.Count > 0)
+                {
+                    foreach (RuleTreeItem childItem in TraverseDown(item))
+                    {
+                        if (item != childItem)
+                        {
+                            SetCollapse(childItem, collapsed);
+                        }
+                    }
+                }
+            }
+        }
+
+
+        private static IEnumerable<RuleTreeItem> TraverseDown(RuleTreeItem item, Action<RuleTreeItem>? action = null)
         {
             if (action != null)
             {

--- a/roles/tests-unit/files/FWO.Test/EnumExtensionsTest.cs
+++ b/roles/tests-unit/files/FWO.Test/EnumExtensionsTest.cs
@@ -1,0 +1,101 @@
+using FWO.Basics.Extensions;
+using FWO.Basics.Enums;
+using FWO.Config.Api;
+using FWO.Ui.Data.Extensions;
+using NUnit.Framework;
+
+namespace FWO.Test
+{
+    [TestFixture]
+    [Parallelizable]
+    internal class EnumExtensionsTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SimulatedUserConfig.DummyTranslate["PreferredCollapseState_Collapsed"] = "Collapsed";
+            SimulatedUserConfig.DummyTranslate["PreferredCollapseState_Expanded"] = "Expanded";
+            SimulatedUserConfig.DummyTranslate["PreferredCollapseState_Intermediate"] = "Intermediate";
+        }
+
+        [TestCase(PreferredCollapseState.Collapsed, "Collapsed")]
+        [TestCase(PreferredCollapseState.Expanded, "Expanded")]
+        [TestCase(PreferredCollapseState.Intermediate, "Intermediate")]
+        public void ToString_ReturnsLocalizedText(PreferredCollapseState state, string expected)
+        {
+            UserConfig userConfig = new SimulatedUserConfig();
+
+            string result = state.ToString(userConfig);
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ToString_NullUserConfig_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => PreferredCollapseState.Collapsed.ToString((UserConfig)null!));
+        }
+
+        [Test]
+        public void Except_NoExcludedValues_ReturnsOriginalSequence()
+        {
+            PreferredCollapseState[] values =
+            [
+                PreferredCollapseState.Collapsed,
+                PreferredCollapseState.Expanded
+            ];
+
+            IEnumerable<PreferredCollapseState> result = values.Except();
+
+            Assert.That(result, Is.EqualTo(values));
+        }
+
+        [Test]
+        public void Except_SingleExcludedValue_FiltersMatchingEntries()
+        {
+            PreferredCollapseState[] values =
+            [
+                PreferredCollapseState.Collapsed,
+                PreferredCollapseState.Expanded,
+                PreferredCollapseState.Intermediate,
+                PreferredCollapseState.Expanded
+            ];
+
+            IEnumerable<PreferredCollapseState> result = values.Except(PreferredCollapseState.Expanded);
+
+            Assert.That(result, Is.EqualTo(
+            [
+                PreferredCollapseState.Collapsed,
+                PreferredCollapseState.Intermediate
+            ]));
+        }
+
+        [Test]
+        public void Except_MultipleExcludedValues_FiltersAllMatches()
+        {
+            PreferredCollapseState[] values =
+            [
+                PreferredCollapseState.Collapsed,
+                PreferredCollapseState.Expanded,
+                PreferredCollapseState.Intermediate
+            ];
+
+            IEnumerable<PreferredCollapseState> result = values.Except(
+                PreferredCollapseState.Collapsed,
+                PreferredCollapseState.Intermediate);
+
+            Assert.That(result, Is.EqualTo(
+            [
+                PreferredCollapseState.Expanded
+            ]));
+        }
+
+        [Test]
+        public void Except_NullValues_ThrowsArgumentNullException()
+        {
+            IEnumerable<PreferredCollapseState>? values = null;
+
+            Assert.Throws<ArgumentNullException>(() => values!.Except(PreferredCollapseState.Collapsed).ToList());
+        }
+    }
+}

--- a/roles/tests-unit/files/FWO.Test/NotificationTest.cs
+++ b/roles/tests-unit/files/FWO.Test/NotificationTest.cs
@@ -157,7 +157,7 @@ namespace FWO.Test
             MethodInfo? prepareEmail = typeof(NotificationService).GetMethod("PrepareEmail", BindingFlags.Instance | BindingFlags.NonPublic);
             ClassicAssert.IsNotNull(prepareEmail);
 
-            Task<FWO.Mail.MailData> task = (Task<FWO.Mail.MailData>)(prepareEmail?.Invoke(notificationService, [notification, null, owner, null, ""]) 
+            Task<FWO.Mail.MailData> task = (Task<FWO.Mail.MailData>)(prepareEmail?.Invoke(notificationService, [notification, null, owner, null, ""])
                 ?? throw new InvalidOperationException("PrepareEmail returned null task."));
             FWO.Mail.MailData mailData = await task;
 

--- a/roles/tests-unit/files/FWO.Test/ReportRulesTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ReportRulesTest.cs
@@ -1,10 +1,12 @@
 using FWO.Basics;
+using FWO.Basics.Enums;
 using FWO.Data;
 using FWO.Data.Report;
 using FWO.Report;
 using FWO.Report.Filter;
 using FWO.Services.RuleTreeBuilder;
 using FWO.Test.Mocks;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using System.Reflection;
@@ -426,6 +428,38 @@ namespace FWO.Test
             reportRules.TryBuildMockRuleTree();
 
             Assert.That(reportRules.ReportData.ElementsCount, Is.EqualTo(6));
+        }
+
+        [TestCase(PreferredCollapseState.Collapsed, false)]
+        [TestCase(PreferredCollapseState.Expanded, true)]
+        [TestCase(PreferredCollapseState.Intermediate, true)]
+        public void Test_TryBuildRuleTree_AppliesPreferredCollapseState(PreferredCollapseState preferredCollapseState, bool expectedExpandedState)
+        {
+            IServiceProvider? originalServices = FWO.Services.ServiceProvider.Services;
+            ServiceCollection services = new();
+            services.AddSingleton<IRuleTreeBuilder>(_ruleTreeBuilder);
+            FWO.Services.ServiceProvider.Services = services.BuildServiceProvider();
+
+            SimulatedUserConfig userConfig = new()
+            {
+                ReportingPersonalPreferredCollapseState = preferredCollapseState
+            };
+            try
+            {
+                MockReportRules reportRules = new(new DynGraphqlQuery(""), userConfig, ReportType.ResolvedRules, () => _managementReports);
+
+                reportRules.TryBuildMockRuleTree();
+
+                RuleTreeItem ruleTree = _ruleTreeBuilder.RuleTreeCache[(_managementReport!.Id, _deviceReport!.Id)];
+                Assert.That(ruleTree.Children, Is.Not.Empty);
+                RuleTreeItem expandableRule = ruleTree.Children.First();
+
+                Assert.That(expandableRule.IsExpanded, Is.EqualTo(expectedExpandedState));
+            }
+            finally
+            {
+                FWO.Services.ServiceProvider.Services = originalServices;
+            }
         }
     }
 }

--- a/roles/tests-unit/files/FWO.Test/RuleTreeItemTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleTreeItemTest.cs
@@ -1,0 +1,64 @@
+using FWO.Data;
+using FWO.Services.RuleTreeBuilder;
+using NUnit.Framework;
+
+namespace FWO.Test
+{
+    [TestFixture]
+    internal class RuleTreeItemTest
+    {
+        [Test]
+        public void SetExpandedRecursively_False_CollapsesAllExpandableDescendants()
+        {
+            RuleTreeItem root = BuildNestedTree(out RuleTreeItem parentRule, out RuleTreeItem childRule, out RuleTreeItem leafRule);
+
+            RuleTreeItem.SetExpandedRecursively(root, false);
+
+            Assert.That(parentRule.IsExpanded, Is.False);
+            Assert.That(childRule.IsExpanded, Is.False);
+            Assert.That(parentRule.IsVisible, Is.True);
+            Assert.That(childRule.IsVisible, Is.False);
+            Assert.That(leafRule.IsVisible, Is.False);
+            Assert.That(leafRule.IsExpanded, Is.False);
+        }
+
+        [Test]
+        public void SetExpandedRecursively_True_ExpandsAllExpandableDescendants()
+        {
+            RuleTreeItem root = BuildNestedTree(out RuleTreeItem parentRule, out RuleTreeItem childRule, out RuleTreeItem leafRule);
+            RuleTreeItem.SetExpandedRecursively(root, false);
+
+            RuleTreeItem.SetExpandedRecursively(root, true);
+
+            Assert.That(parentRule.IsExpanded, Is.True);
+            Assert.That(childRule.IsExpanded, Is.True);
+            Assert.That(parentRule.IsVisible, Is.True);
+            Assert.That(childRule.IsVisible, Is.True);
+            Assert.That(leafRule.IsVisible, Is.True);
+            Assert.That(leafRule.IsExpanded, Is.False);
+        }
+
+        private static RuleTreeItem BuildNestedTree(out RuleTreeItem parentRule, out RuleTreeItem childRule, out RuleTreeItem leafRule)
+        {
+            RuleTreeItem root = new() { IsRoot = true, IsVisible = true };
+            parentRule = new RuleTreeItem { Data = new Rule { Id = 1 }, IsRule = true, IsVisible = true };
+            childRule = new RuleTreeItem { Data = new Rule { Id = 2 }, IsRule = true, IsVisible = true };
+            leafRule = new RuleTreeItem { Data = new Rule { Id = 3 }, IsRule = true, IsVisible = true };
+
+            AttachChild(root, parentRule);
+            AttachChild(parentRule, childRule);
+            AttachChild(childRule, leafRule);
+
+            parentRule.IsExpanded = true;
+            childRule.IsExpanded = true;
+
+            return root;
+        }
+
+        private static void AttachChild(RuleTreeItem parent, RuleTreeItem child)
+        {
+            child.Parent = parent;
+            parent.Children.Add(child);
+        }
+    }
+}

--- a/roles/ui/files/FWO.UI/Data/Extensions/EnumExtensions.cs
+++ b/roles/ui/files/FWO.UI/Data/Extensions/EnumExtensions.cs
@@ -5,44 +5,23 @@ namespace FWO.Ui.Data.Extensions
 {
     public static class EnumExtensions
     {
-        extension(Enum @enum)
+        extension(PreferredCollapseState state)
         {
+            /// <summary>
+            /// Returns the localized label for the preferred collapse state.
+            /// </summary>
             public string ToString(UserConfig userConfig)
             {
-                bool success = Enum.TryParse(@enum.ToString(), out PreferredCollapseState state);
+                ArgumentNullException.ThrowIfNull(userConfig);
 
-                if(!success)
+                return state switch
                 {
-                    return @enum.ToString();
-                }
-
-                try
-                {
-                    return state switch
-                    {
-                        PreferredCollapseState.Collapsed => userConfig.GetText("PreferredCollapseState_Collapsed"),
-                        PreferredCollapseState.Expanded => userConfig.GetText("PreferredCollapseState_Expanded"),
-                        _ => "",
-                    };
-                }
-                catch (Exception)
-                {
-                    return @enum.ToString();
-                }
-            }
-
-            public IEnumerable<T> GetFlags<T>(Enum? ignore = null)
-            {
-                foreach (T value in Enum.GetValues(@enum.GetType()))
-                {
-                    Enum enumVal = (Enum)Convert.ChangeType(value, typeof(Enum));
-                    if (!enumVal.Equals(ignore) && @enum.HasFlag(enumVal))
-                    {
-                        yield return value;
-                    }
-                }
+                    PreferredCollapseState.Collapsed => userConfig.GetText("PreferredCollapseState_Collapsed"),
+                    PreferredCollapseState.Expanded => userConfig.GetText("PreferredCollapseState_Expanded"),
+                    PreferredCollapseState.Intermediate => userConfig.GetText("PreferredCollapseState_Intermediate"),
+                    _ => state.ToString(),
+                };
             }
         }
-
     }
 }

--- a/roles/ui/files/FWO.UI/Data/Extensions/EnumExtensions.cs
+++ b/roles/ui/files/FWO.UI/Data/Extensions/EnumExtensions.cs
@@ -1,0 +1,48 @@
+using FWO.Basics.Enums;
+using FWO.Config.Api;
+
+namespace FWO.Ui.Data.Extensions
+{
+    public static class EnumExtensions
+    {
+        extension(Enum @enum)
+        {
+            public string ToString(UserConfig userConfig)
+            {
+                bool success = Enum.TryParse(@enum.ToString(), out PreferredCollapseState state);
+
+                if(!success)
+                {
+                    return @enum.ToString();
+                }
+
+                try
+                {
+                    return state switch
+                    {
+                        PreferredCollapseState.Collapsed => userConfig.GetText("PreferredCollapseState_Collapsed"),
+                        PreferredCollapseState.Expanded => userConfig.GetText("PreferredCollapseState_Expanded"),
+                        _ => "",
+                    };
+                }
+                catch (Exception)
+                {
+                    return @enum.ToString();
+                }
+            }
+
+            public IEnumerable<T> GetFlags<T>(Enum? ignore = null)
+            {
+                foreach (T value in Enum.GetValues(@enum.GetType()))
+                {
+                    Enum enumVal = (Enum)Convert.ChangeType(value, typeof(Enum));
+                    if (!enumVal.Equals(ignore) && @enum.HasFlag(enumVal))
+                    {
+                        yield return value;
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
@@ -11,16 +11,16 @@
     @if (management.ContainsRules())
     {
         <Collapse Title="@management.Name" Style="@("primary")" StartToggled="false">
-            @if(Recertification || SelectedReportType.IsRulebaseReport())
+            @if (Recertification || SelectedReportType.IsRulebaseReport())
             {
-                @foreach(var rulebase in management.Rulebases)
+                @foreach (var rulebase in management.Rulebases)
                 {
                     var rulebaseRules = ReportRules.GetRulesByRulebaseId(rulebase.Id, management);
-                    @if(rulebaseRules.Length > 0)
+                    @if (rulebaseRules.Length > 0)
                     {
                         <Collapse Title="@rulebase.Name" Style="@("secondary")" StartToggled="true">
                             <RuleBaseReport Recertification="Recertification" ReadonlyMode="ReadonlyMode" SelectedReportType="SelectedReportType"
-                                Rules="[.. rulebaseRules]" @bind-SelectedRules="SelectedRules" RulesPerPage="RulesPerPage"/>
+                                            Rules="[.. rulebaseRules]" @bind-SelectedRules="SelectedRules" RulesPerPage="RulesPerPage" />
                         </Collapse>
                     }
                 }
@@ -32,25 +32,31 @@
                     @if (device.ContainsRules() && _ruleDisplay != null)
                     {
                         <Collapse Title="@device.Name" Style="@("secondary")" StartToggled="true" Class="py-1">
+
+                            <div class="sticky-collapse">
+                                <button class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-collapse"></i></button>
+                                <button class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-expand"></i></button>
+                            </div>
+
                             <Table SelectedItems="new List<RuleTreeItem>()"
-                                RowClickAction="@(async ruleTreeItem => 
-                                {
-                                    ruleTreeItem.Data?.DeviceName = device.Name ?? ""; 
+                                   RowClickAction="@(async ruleTreeItem =>
+                                                                {
+                                                                    ruleTreeItem.Data?.DeviceName = device.Name ?? "";
 
-                                    if (!SelectedRules.Remove(ruleTreeItem.Data!)) 
-                                    {
-                                        SelectedRules.Add(ruleTreeItem.Data!);
-                                    }
+                                                                    if (!SelectedRules.Remove(ruleTreeItem.Data!))
+                                                                    {
+                                                                        SelectedRules.Add(ruleTreeItem.Data!);
+                                                                    }
 
-                                    await SelectedRulesChanged.InvokeAsync(SelectedRules);
-                                })"
-                                style="font-size:small" 
-                                TableClass="table table-bordered table-sm th-bg-secondary table-responsive overflow-auto sticky-header" 
-                                TableItem="RuleTreeItem"
-                                Items="@GetRuleTreeItems(management, device)" 
-                                ShowSearchBar="false"
-                                PageSize="RulesPerPage" ColumnReorder="true" TableRowClass="@(item => GetTableRowClasses(item.Data!))"
-                                @ref="_reportTable">
+                                                                    await SelectedRulesChanged.InvokeAsync(SelectedRules);
+                                                                })"
+                                   style="font-size:small"
+                                   TableClass="table table-bordered table-sm th-bg-secondary table-responsive overflow-auto sticky-header"
+                                   TableItem="RuleTreeItem"
+                                   Items="@GetRuleTreeItems(management, device)"
+                                   ShowSearchBar="false"
+                                   PageSize="RulesPerPage" ColumnReorder="true" TableRowClass="@(item => GetTableRowClasses(item.Data!))"
+                                   @ref="_reportTable">
                                 
                                 @if (_emptyColumns[0] == false)
                                 {
@@ -63,7 +69,7 @@
                                     </Column>
                                 }
                                 
-                                @if(SelectedReportType == ReportType.UnusedRules || SelectedReportType == ReportType.AppRules)
+                                @if (SelectedReportType == ReportType.UnusedRules || SelectedReportType == ReportType.AppRules)
                                 {
                                     <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("last_hit"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Metadata.LastHit)" Sortable="false" Filterable="false">
                                         <Template>
@@ -80,7 +86,7 @@
                                     }
                                 }
                             
-                                @if(SelectedReportType.IsComplianceReport())
+                                @if (SelectedReportType.IsComplianceReport())
                                 {
                                     <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="Compliance" Field="@(ruleTreeItem => ruleTreeItem.Data!.Compliance)" Sortable="true" Filterable="true" Hideable="true">
                                         <Template>
@@ -94,61 +100,61 @@
                                     </Column>
                                 }
 
-                            @if (_emptyColumns[1] == false)
-                            {
-                                <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("name"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true" />
-                            }
+                                @if (_emptyColumns[1] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("name"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true" />
+                                }
 
-                            @if (_emptyColumns[2] == false)
-                            {
-                                <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("source_zone"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.RuleFromZones)" Sortable="true" Filterable="false" Hideable="true">
-                                    <Template>
-                                        @((MarkupString)RuleDisplayHtml.DisplaySourceZones(ruleTreeItem.Data!))
-                                    </Template>
-                                </Column>
-                            }
+                                @if (_emptyColumns[2] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("source_zone"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.RuleFromZones)" Sortable="true" Filterable="false" Hideable="true">
+                                        <Template>
+                                            @((MarkupString)RuleDisplayHtml.DisplaySourceZones(ruleTreeItem.Data!))
+                                        </Template>
+                                    </Column>
+                                }
                         
-                            @if (_emptyColumns[3] == false)
-                            {
-                            <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("source"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
-                                    <Template>
-                                        @((MarkupString)_ruleDisplay.DisplaySource(ruleTreeItem.Data!, GetActLocation(), SelectedReportType))
-                                    </Template>
-                                </Column>
-                            }
+                                @if (_emptyColumns[3] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("source"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
+                                        <Template>
+                                            @((MarkupString)_ruleDisplay.DisplaySource(ruleTreeItem.Data!, GetActLocation(), SelectedReportType))
+                                        </Template>
+                                    </Column>
+                                }
    
-                            @if (_emptyColumns[4] == false)
-                            {
-                                <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("destination_zone"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.RuleToZones)" Sortable="true" Filterable="false" Hideable="true">
-                                    <Template>
-                                        @((MarkupString)RuleDisplayHtml.DisplayDestinationZones(ruleTreeItem.Data!))
-                                    </Template>
-                                </Column>
-                            }
+                                @if (_emptyColumns[4] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("destination_zone"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.RuleToZones)" Sortable="true" Filterable="false" Hideable="true">
+                                        <Template>
+                                            @((MarkupString)RuleDisplayHtml.DisplayDestinationZones(ruleTreeItem.Data!))
+                                        </Template>
+                                    </Column>
+                                }
  
-                            @if (_emptyColumns[5] == false)
-                            {
-                                <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("destination"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
-                                    <Template>
-                                        @((MarkupString)_ruleDisplay.DisplayDestination(ruleTreeItem.Data!, GetActLocation(), SelectedReportType))
-                                    </Template>
-                                </Column>
-                            }
+                                @if (_emptyColumns[5] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("destination"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
+                                        <Template>
+                                            @((MarkupString)_ruleDisplay.DisplayDestination(ruleTreeItem.Data!, GetActLocation(), SelectedReportType))
+                                        </Template>
+                                    </Column>
+                                }
 
-                            @if (_emptyColumns[6] == false)
-                            {
-                                <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("services"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
-                                    <Template>
-                                        @((MarkupString)_ruleDisplay.DisplayServices(ruleTreeItem.Data!, GetActLocation(), SelectedReportType))
-                                    </Template>
-                                </Column>
-                            }
+                                @if (_emptyColumns[6] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("services"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
+                                        <Template>
+                                            @((MarkupString)_ruleDisplay.DisplayServices(ruleTreeItem.Data!, GetActLocation(), SelectedReportType))
+                                        </Template>
+                                    </Column>
+                                }
 
-                            @if(SelectedReportType == ReportType.NatRules)
-                            {
+                                @if (SelectedReportType == ReportType.NatRules)
+                                {
                                     <Column Class="table-active" TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("trans_source"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
                                         <Template>
-                                                @((MarkupString)_ruleDisplay.DisplayTranslatedSource(ruleTreeItem.Data!, GetActLocation()))
+                                            @((MarkupString)_ruleDisplay.DisplayTranslatedSource(ruleTreeItem.Data!, GetActLocation()))
                                         </Template>
                                     </Column>
                                     <Column Class="table-active" TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("trans_destination"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
@@ -161,83 +167,83 @@
                                             @((MarkupString)_ruleDisplay.DisplayTranslatedService(ruleTreeItem.Data!, GetActLocation()))
                                         </Template>
                                     </Column>
-                            }
+                                }
 
-                            @if (_emptyColumns[7] == false && SelectedReportType != ReportType.NatRules)
-                            {
-                                <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("action"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Action)" Sortable="true" Filterable="false" Hideable="true" />
-                            }
-
-                            @if (_emptyColumns[8] == false && SelectedReportType != ReportType.NatRules)
-                            {
-                                <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("track"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Track)" Sortable="true" Filterable="false" Hideable="true" />
-                            }
-
-                            @if (_emptyColumns[9] == false)
-                            {
-                                <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("enabled"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Disabled)" Sortable="true" Filterable="false" Hideable="true">
-                                    <Template>
-                                        @((MarkupString)RuleDisplayHtml.DisplayEnabled(ruleTreeItem.Data!, GetActLocation()))
-                                    </Template>
-                                </Column>
-                            }
-
-                            @if (_emptyColumns[10] == false)
-                            {
-                                <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("enforcing_devices"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
-                                    <Template>
-                                        @((MarkupString)RuleDisplayHtml.DisplayEnforcingGateways(ruleTreeItem.Data!, GetActLocation(), SelectedReportType))
-                                    </Template>
-                                </Column>
-                            }
-
-                            @if (_emptyColumns[11] == false)
-                            {
-                                <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("uid"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Uid)" Sortable="true" Filterable="false" Hideable="true" />
-                            }
-
-                            @if (_emptyColumns[12] == false)
-                            {
-                                <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("comment"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Comment)" Sortable="true" Filterable="false" Hideable="true" />
-                            }
-
-                            @if (_emptyColumns[13] == false)
-                            {
-                                @if (!_showLastModifiedAfterLastHit)
+                                @if (_emptyColumns[7] == false && SelectedReportType != ReportType.NatRules)
                                 {
-                                    <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="LastModified" Field="@(ruleTreeItem => ruleTreeItem.Data!.LastModified)" Sortable="true" Filterable="false" Hideable="true">
+                                    <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("action"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Action)" Sortable="true" Filterable="false" Hideable="true" />
+                                }
+
+                                @if (_emptyColumns[8] == false && SelectedReportType != ReportType.NatRules)
+                                {
+                                    <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("track"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Track)" Sortable="true" Filterable="false" Hideable="true" />
+                                }
+
+                                @if (_emptyColumns[9] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("enabled"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Disabled)" Sortable="true" Filterable="false" Hideable="true">
                                         <Template>
-                                            @((MarkupString)RuleDisplayBase.DisplayLastModified(ruleTreeItem.Data!))
+                                            @((MarkupString)RuleDisplayHtml.DisplayEnabled(ruleTreeItem.Data!, GetActLocation()))
                                         </Template>
                                     </Column>
                                 }
-                            }
 
-                            <DetailTemplate TableItem="RuleTreeItem">
-                                <RuleDetails Rule="context.Data!"/>
-                            </DetailTemplate>
+                                @if (_emptyColumns[10] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="@(userConfig.GetText("enforcing_devices"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Name)" Sortable="true" Filterable="false" Hideable="true">
+                                        <Template>
+                                            @((MarkupString)RuleDisplayHtml.DisplayEnforcingGateways(ruleTreeItem.Data!, GetActLocation(), SelectedReportType))
+                                        </Template>
+                                    </Column>
+                                }
 
-                            <CustomRow TableItem="RuleTreeItem" IsActiveForItem="(ruleTreeItem => !String.IsNullOrEmpty(ruleTreeItem.Data!.SectionHeader))">
-                                <tr>
-                                    <td>                          
-                                        <div style="cursor:pointer; white-space:nowrap;" @onclick="() => OnNumberIconClickToggle(context.Data!, management, device)">
-                                            @((MarkupString)GetToggleArrow(context.Data!, management, device))@((MarkupString)RuleDisplayHtml.DisplayNumber(context.Data!))
-                                        </div>                                        
+                                @if (_emptyColumns[11] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("uid"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Uid)" Sortable="true" Filterable="false" Hideable="true" />
+                                }
+
+                                @if (_emptyColumns[12] == false)
+                                {
+                                    <Column TableItem="RuleTreeItem" Title="@(userConfig.GetText("comment"))" Field="@(ruleTreeItem => ruleTreeItem.Data!.Comment)" Sortable="true" Filterable="false" Hideable="true" />
+                                }
+
+                                @if (_emptyColumns[13] == false)
+                                {
+                                    @if (!_showLastModifiedAfterLastHit)
+                                    {
+                                        <Column TableItem="RuleTreeItem" Context="ruleTreeItem" Title="LastModified" Field="@(ruleTreeItem => ruleTreeItem.Data!.LastModified)" Sortable="true" Filterable="false" Hideable="true">
+                                            <Template>
+                                                @((MarkupString)RuleDisplayBase.DisplayLastModified(ruleTreeItem.Data!))
+                                            </Template>
+                                        </Column>
+                                    }
+                                }
+
+                                <DetailTemplate TableItem="RuleTreeItem">
+                                    <RuleDetails Rule="context.Data!" />
+                                </DetailTemplate>
+
+                                <CustomRow TableItem="RuleTreeItem" IsActiveForItem="(ruleTreeItem => !String.IsNullOrEmpty(ruleTreeItem.Data!.SectionHeader))">
+                                    <tr>
+                                        <td>
+                                            <div style="cursor:pointer; white-space:nowrap;" @onclick="() => OnNumberIconClickToggle(context.Data!, management, device)">
+                                                @((MarkupString)GetToggleArrow(context.Data!, management, device))@((MarkupString)RuleDisplayHtml.DisplayNumber(context.Data!))
+                                            </div>
                              
-                                    </td>
+                                        </td>
 
-                                    <td class="bg-light" colspan="@(_reportTable?.Columns.Count)">
-                                        <div class="font-weight-bold">@(context.Data!.SectionHeader)</div>
-                                    </td>
-                                </tr>
-                            </CustomRow>  
+                                        <td class="bg-light" colspan="@(_reportTable?.Columns.Count)">
+                                            <div class="font-weight-bold">@(context.Data!.SectionHeader)</div>
+                                        </td>
+                                    </tr>
+                                </CustomRow>
 
-                            <Pager ShowPageNumber="true" ShowTotalCount="true" />
-                        </Table>
-                    </Collapse>
+                                <Pager ShowPageNumber="true" ShowTotalCount="true" />
+                            </Table>
+                        </Collapse>
+                    }
                 }
             }
-        }
         </Collapse>
     }
 }
@@ -247,7 +253,7 @@
     #region Parameters
 
     [Parameter]
-    public List<ManagementReport> Managements { get; set; } = new ();
+    public List<ManagementReport> Managements { get; set; } = new();
 
     [Parameter]
     public bool ReadonlyMode { get; set; } = false;
@@ -308,7 +314,7 @@
     private string GetTableRowClasses(Rule rule)
     {
         string classes = "";
-        if(rule.SectionHeader != null)
+        if (rule.SectionHeader != null)
         {
             classes = "hide-all-but-second-child second-child-full-width ";
         }
@@ -342,12 +348,12 @@
         {
             for (int i = 0; i < ruleTreeFromCache.ElementsFlat.Count; i++)
             {
-                RuleTreeItem ruleTreeItem = (RuleTreeItem) ruleTreeFromCache.ElementsFlat[i];
+                RuleTreeItem ruleTreeItem = (RuleTreeItem)ruleTreeFromCache.ElementsFlat[i];
 
                 if (ruleTreeItem.IsVisible)
                 {
                     ruleTreeItems.Add(ruleTreeItem);
-                }   
+                }
             }
         }
 
@@ -359,12 +365,12 @@
         // Get corresponding tree item for rule
 
         RuleTreeItem ruleTree = ruleTreeBuilder.RuleTreeCache[(managementReport.Id, deviceReport.Id)];
-        RuleTreeItem? treeItem = ruleTree.ElementsFlat.FirstOrDefault(element => element.Data == rule) as RuleTreeItem;     
+        RuleTreeItem? treeItem = ruleTree.ElementsFlat.FirstOrDefault(element => element.Data == rule) as RuleTreeItem;
 
         if (treeItem == null)
         {
             throw new Exception("No tree item found for rule");
-        }  
+        }
 
         // Print hidden span for rows (rules or dummy rules for rulebase headers) which are not expandable
 
@@ -400,7 +406,7 @@
         {
             // Update exapandable state
 
-            treeItem.IsExpanded = !treeItem.IsExpanded;       
+            treeItem.IsExpanded = !treeItem.IsExpanded;
         }
 
         InvokeAsync(StateHasChanged);

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
@@ -34,22 +34,22 @@
                         <Collapse Title="@device.Name" Style="@("secondary")" StartToggled="true" Class="py-1">
 
                             <div class="sticky-collapse">
-                                <button class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-collapse"></i></button>
-                                <button class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-expand"></i></button>
+                                <button @onclick="@(() => ToggleAll(management, device, collapse: true))" class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-collapse"></i></button>
+                                <button @onclick="@(() => ToggleAll(management, device, collapse: false))" class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-expand"></i></button>
                             </div>
 
                             <Table SelectedItems="new List<RuleTreeItem>()"
                                    RowClickAction="@(async ruleTreeItem =>
-                                                                {
-                                                                    ruleTreeItem.Data?.DeviceName = device.Name ?? "";
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       {
+                                                                       ruleTreeItem.Data?.DeviceName = device.Name ?? "";
 
-                                                                    if (!SelectedRules.Remove(ruleTreeItem.Data!))
-                                                                    {
-                                                                        SelectedRules.Add(ruleTreeItem.Data!);
-                                                                    }
+                                                                       if (!SelectedRules.Remove(ruleTreeItem.Data!))
+                                                                       {
+                                                                           SelectedRules.Add(ruleTreeItem.Data!);
+                                                                       }
 
-                                                                    await SelectedRulesChanged.InvokeAsync(SelectedRules);
-                                                                })"
+                                                                       await SelectedRulesChanged.InvokeAsync(SelectedRules);
+                                                                   })"
                                    style="font-size:small"
                                    TableClass="table table-bordered table-sm th-bg-secondary table-responsive overflow-auto sticky-header"
                                    TableItem="RuleTreeItem"
@@ -296,11 +296,11 @@
     private bool _showLastModifiedAfterLastHit => SelectedReportType == ReportType.UnusedRules || SelectedReportType == ReportType.AppRules;
 
     private Rule? _lastClickedRule = null;
-    
+
     #endregion
 
     #region Methods - Overrides
-    
+
     protected override void OnInitialized()
     {
         _ruleDisplay = new NatRuleDisplayHtml(userConfig);
@@ -358,6 +358,14 @@
         }
 
         return ruleTreeItems.ToArray();
+    }
+
+    private void ToggleAll(ManagementReport management, DeviceReport device, bool collapse)
+    {
+        foreach (var item in GetRuleTreeItems(management, device))
+        {
+            RuleTreeItem.SetCollapse(item, collapse);
+        }
     }
 
     private string GetToggleArrow(Rule rule, ManagementReport managementReport, DeviceReport deviceReport)

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
@@ -31,11 +31,11 @@
                 {
                     @if (device.ContainsRules() && _ruleDisplay != null)
                     {
-                        <Collapse Title="@device.Name" Style="@("secondary")" StartToggled="true" Class="py-1">
+                        <Collapse Title="@device.Name" Style="@("secondary")" StartToggled="false" Class="py-1">
 
                             <div class="sticky-collapse">
-                                <button @onclick="@(() => ToggleAll(management, device, collapse: true))" class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-collapse"></i></button>
-                                <button @onclick="@(() => ToggleAll(management, device, collapse: false))" class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-expand"></i></button>
+                                <button name="btnCollapseAll" @onclick="@(() => ToggleAll(management, device, collapse: true))" class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-collapse"></i></button>
+                                <button name="btnExpandAll" @onclick="@(() => ToggleAll(management, device, collapse: false))" class="btn btn-sm bg-dark-subtle px-4 pt-2 border-2 border-dark-subtle"><i class="bi bi-arrows-expand"></i></button>
                             </div>
 
                             <Table SelectedItems="new List<RuleTreeItem>()"
@@ -362,17 +362,14 @@
 
     private void ToggleAll(ManagementReport management, DeviceReport device, bool collapse)
     {
-        foreach (var item in GetRuleTreeItems(management, device))
-        {
-            RuleTreeItem.SetCollapse(item, collapse);
-        }
+        RuleTreeItem.SetExpandedRecursively(GetRuleTree(management, device), !collapse);
     }
 
     private string GetToggleArrow(Rule rule, ManagementReport managementReport, DeviceReport deviceReport)
     {
         // Get corresponding tree item for rule
 
-        RuleTreeItem ruleTree = ruleTreeBuilder.RuleTreeCache[(managementReport.Id, deviceReport.Id)];
+        RuleTreeItem ruleTree = GetRuleTree(managementReport, deviceReport);
         RuleTreeItem? treeItem = ruleTree.ElementsFlat.FirstOrDefault(element => element.Data == rule) as RuleTreeItem;
 
         if (treeItem == null)
@@ -407,7 +404,7 @@
 
         // Get corresponding tree item for rule
 
-        RuleTreeItem ruleTree = ruleTreeBuilder.RuleTreeCache[(managementReport.Id, deviceReport.Id)];
+        RuleTreeItem ruleTree = GetRuleTree(managementReport, deviceReport);
         RuleTreeItem? treeItem = ruleTree.ElementsFlat.FirstOrDefault(element => element.Data == rule) as RuleTreeItem;
 
         if (treeItem != null)
@@ -418,6 +415,16 @@
         }
 
         InvokeAsync(StateHasChanged);
+    }
+
+    private RuleTreeItem GetRuleTree(ManagementReport managementReport, DeviceReport deviceReport)
+    {
+        if (ruleTreeBuilder.RuleTreeCache.TryGetValue((managementReport.Id, deviceReport.Id), out RuleTreeItem? ruleTree))
+        {
+            return ruleTree;
+        }
+
+        throw new InvalidOperationException("No rule tree found for management and device.");
     }
 
     #endregion

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor
@@ -222,7 +222,7 @@
                                 <DetailTemplate TableItem="RuleTreeItem">
                                     <RuleDetails Rule="context.Data!" />
                                 </DetailTemplate>
-
+                               
                                 <CustomRow TableItem="RuleTreeItem" IsActiveForItem="(ruleTreeItem => !String.IsNullOrEmpty(ruleTreeItem.Data!.SectionHeader))">
                                     <tr>
                                         <td>

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor.css
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor.css
@@ -5,3 +5,5 @@
     top: 6rem;
     z-index: 14;
 }
+
+

--- a/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor.css
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/Reports/RulesReport.razor.css
@@ -1,0 +1,7 @@
+.sticky-collapse {
+    padding-left: 0.5rem;
+    padding-bottom: 0.5rem;
+    position: sticky;
+    top: 6rem;
+    z-index: 14;
+}

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsReport.razor
@@ -1,4 +1,6 @@
-﻿@page "/settings/report"
+@using FWO.Basics.Enums
+@using FWO.Ui.Data.Extensions
+@page "/settings/report"
 @attribute [Authorize(Roles = $"{Roles.Admin}, {Roles.Reporter}, {Roles.ReporterViewAll}, {Roles.Recertifier}, {Roles.Modeller}, {Roles.Auditor}, {Roles.FwAdmin}")]
 
 @inject ApiConnection apiConnection
@@ -7,7 +9,7 @@
 
 <div class="input-group">
     <h3>@(userConfig.GetText("report_settings"))</h3>
-    <HelpLink Page="settings/report"/>
+    <HelpLink Page="settings/report" />
 </div>
 @(userConfig.GetText("U5413"))
 <hr />
@@ -60,11 +62,20 @@
         </div>
     </form>
     <hr />
+    <div class="form-group row" data-toggle="tooltip" title="">
+        <label for="creationTolerance" class="col-form-label col-sm-4">@(userConfig.GetText("creationTolerance")):</label>
+        <div class="col-sm-2">
+            <Dropdown ElementType="PreferredCollapseState" ElementToString="_ => _.ToString(userConfig)" Elements="Enum.GetValues<PreferredCollapseState>()" SelectedElement="SelectedPreferredCollapseState">
+               
+            </Dropdown>
+        </div>
+    </div>
+    <hr />
     <button type="button" class="btn btn-sm btn-primary" @onclick="Save">@(DisplayService.DisplayButton(userConfig, "save", Icons.Save))</button>
 }
 else
 {
-    <Loading/>
+    <Loading />
 }
 
 
@@ -75,6 +86,8 @@ else
     Action<Exception?, string, string, bool> DisplayMessageInUi { get; set; } = DefaultInit.DoNothing;
 
     ConfigData? configData;
+
+    private PreferredCollapseState SelectedPreferredCollapseState { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -95,7 +108,7 @@ else
             if (configData != null)
             {
                 await userConfig.WriteToDatabase(configData, apiConnection);
-                DisplayMessageInUi(null, userConfig.GetText("report_settings"), userConfig.GetText("U5301"), false);             
+                DisplayMessageInUi(null, userConfig.GetText("report_settings"), userConfig.GetText("U5301"), false);
             }
             else
             {

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsReport.razor
@@ -69,7 +69,7 @@
         <div class="col-sm-2">
             <Dropdown ElementType="PreferredCollapseState" ElementToString="_ => _.ToString(userConfig)"
                       Elements="Enum.GetValues<PreferredCollapseState>().Except(PreferredCollapseState.Intermediate)"
-                      @bind-SelectedElement="SelectedPreferredCollapseState" />
+                      @bind-SelectedElement="configData!.ReportingPersonalPreferredCollapseState" />
         </div>
     </div>
     <hr />
@@ -88,8 +88,6 @@ else
     Action<Exception?, string, string, bool> DisplayMessageInUi { get; set; } = DefaultInit.DoNothing;
 
     ConfigData? configData;
-
-    private PreferredCollapseState SelectedPreferredCollapseState { get; set; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsReport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsReport.razor
@@ -1,5 +1,7 @@
 @using FWO.Basics.Enums
 @using FWO.Ui.Data.Extensions
+@using FWO.Basics.Extensions
+
 @page "/settings/report"
 @attribute [Authorize(Roles = $"{Roles.Admin}, {Roles.Reporter}, {Roles.ReporterViewAll}, {Roles.Recertifier}, {Roles.Modeller}, {Roles.Auditor}, {Roles.FwAdmin}")]
 
@@ -62,12 +64,12 @@
         </div>
     </form>
     <hr />
-    <div class="form-group row" data-toggle="tooltip" title="">
-        <label for="creationTolerance" class="col-form-label col-sm-4">@(userConfig.GetText("creationTolerance")):</label>
+    <div class="form-group row" data-toggle="tooltip" title="@(userConfig.PureLine("H5462"))">
+        <label for="creationTolerance" class="col-form-label col-sm-4">@(userConfig.GetText("PreferredCollapseState")):</label>
         <div class="col-sm-2">
-            <Dropdown ElementType="PreferredCollapseState" ElementToString="_ => _.ToString(userConfig)" Elements="Enum.GetValues<PreferredCollapseState>()" SelectedElement="SelectedPreferredCollapseState">
-               
-            </Dropdown>
+            <Dropdown ElementType="PreferredCollapseState" ElementToString="_ => _.ToString(userConfig)"
+                      Elements="Enum.GetValues<PreferredCollapseState>().Except(PreferredCollapseState.Intermediate)"
+                      @bind-SelectedElement="SelectedPreferredCollapseState" />
         </div>
     </div>
     <hr />

--- a/roles/ui/files/FWO.UI/wwwroot/css/site.css
+++ b/roles/ui/files/FWO.UI/wwwroot/css/site.css
@@ -10,6 +10,31 @@ body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
+
+/* CSS Hacks to change the Detail View Cell Icon of Blazor Table
+#tblRules > tbody > tr > td:nth-child(1) > a > span > img {
+    display: none;
+}
+
+#tblRules > tbody > tr > td:nth-child(1) {
+    vertical-align: bottom;
+    padding-left: 5px;
+    padding-right: 5px;
+}
+
+#tblRules > tbody > tr > td:nth-child(1) > a > span::after {
+   content: "\F434";
+   font-family: "bootstrap-icons";
+   font-size: 22px;
+   color: blue;
+   font-weight: 500;
+   padding: 0;
+   margin: 0;*/
+   /*display: inline-block;*/   
+/*}
+
+*/
+
 .stdtext {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }

--- a/roles/ui/files/FWO.UI/wwwroot/css/site.css
+++ b/roles/ui/files/FWO.UI/wwwroot/css/site.css
@@ -10,31 +10,6 @@ body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
-
-/* CSS Hacks to change the Detail View Cell Icon of Blazor Table
-#tblRules > tbody > tr > td:nth-child(1) > a > span > img {
-    display: none;
-}
-
-#tblRules > tbody > tr > td:nth-child(1) {
-    vertical-align: bottom;
-    padding-left: 5px;
-    padding-right: 5px;
-}
-
-#tblRules > tbody > tr > td:nth-child(1) > a > span::after {
-   content: "\F434";
-   font-family: "bootstrap-icons";
-   font-size: 22px;
-   color: blue;
-   font-weight: 500;
-   padding: 0;
-   margin: 0;*/
-   /*display: inline-block;*/   
-/*}
-
-*/
-
 .stdtext {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
As asked:

- [x]  add button to collapse all rulebases or uncollapse all rulebases

- [x]  Add setting for user (in personal/reporting) to set default collapse state on ruletree load (collapsed/not collapsed)

I made it stick to the table. I'm open for styling ideas...

Closes #4332