### PR TITLE
Nuget Updates

### DIFF
--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
     <PackageReference Include="PuppeteerSharp" Version="24.40.0" />
-    <PackageReference Include="Quartz" Version="3.18.0" />
-    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.18.0" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.18.0" />
+    <PackageReference Include="Quartz" Version="3.18.1" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.18.1" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 


### PR DESCRIPTION
bump  Quartz to 3.18.1
bump Quartz.Extensions.Hosting to 3.18.1
bump Quartz.Serialization.Json to 3.18.1

Schedulers seem to work fine.

Closes #4615

Closes #4614
Closes #4613