### PR TITLE
fix(UI): Settings - Reporting sorting of report types not correct

### DIFF
--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsReportGeneral.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsReportGeneral.razor
@@ -1,4 +1,4 @@
-﻿@using System.Text.Json
+@using System.Text.Json
 
 @using System.Text.Json.Serialization
 @using FWO.Api.Client.Queries
@@ -88,7 +88,7 @@
         <div class="form-group row" data-toggle="tooltip" title="@(userConfig.PureLine("H5455"))">
             <label class="col-form-label col-sm-3">@(userConfig.GetText("availableReportTypes")):</label>
             <div class="form-group row col-sm-9">
-                @foreach (ReportType type in ReportTypeGroups.AllReportTypes())
+                @foreach (ReportType type in ReportTypeGroups.AllReportTypes().OrderBy(_ => userConfig.GetText(_.ToString())))
                 {
                     <div class="form-group col-sm-3">
                         <input id="cbx_@type.ToString()" type="checkbox" @bind="reportTypesActiveDict[type]" />

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsReportGeneral.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsReportGeneral.razor
@@ -4,6 +4,7 @@
 @using FWO.Api.Client.Queries
 @using FWO.Data.Report
 @using FWO.Ui.Services
+@using FWO.Basics
 
 @page "/settings/reportgeneral"
 @attribute [Authorize(Roles = $"{Roles.Admin}, {Roles.Auditor}")]
@@ -88,7 +89,7 @@
         <div class="form-group row" data-toggle="tooltip" title="@(userConfig.PureLine("H5455"))">
             <label class="col-form-label col-sm-3">@(userConfig.GetText("availableReportTypes")):</label>
             <div class="form-group row col-sm-9">
-                @foreach (ReportType type in ReportTypeGroups.AllReportTypes().OrderBy(_ => userConfig.GetText(_.ToString())))
+                @foreach (ReportType type in ReportTypeGroups.ReportTypeSelection().Except(new[] { ReportType.Undefined }))
                 {
                     <div class="form-group col-sm-3">
                         <input id="cbx_@type.ToString()" type="checkbox" @bind="reportTypesActiveDict[type]" />


### PR DESCRIPTION
I don't think this is an ideal solution due to naming but i couln't think of a better one for a quick fix.

This orders checkboxes by names (language dependend).

<img width="2122" height="246" alt="brave_yKxxGaLurg" src="https://github.com/user-attachments/assets/6b5ab1ed-a709-423b-bc45-f8eb2251ee93" />

---

<img width="2062" height="246" alt="brave_duc70WOLnu" src="https://github.com/user-attachments/assets/09fcd6d8-965d-4ad5-9cbe-0c437005c3c8" />

---

Maybe we should implement a parent type for this. 
Currently there are these types:

- Rules = 1,
- Changes = 2,
- Statistics = 3,
- NatRules = 4,
- ResolvedRules = 5,
- ResolvedRulesTech = 6,
- Recertification = 7,
- ResolvedChanges = 8,
- ResolvedChangesTech = 9,
- UnusedRules = 10,
- Connections = 21,
- AppRules = 22,
- VarianceAnalysis = 23,
- OwnerRecertification = 24,
- RecertificationEvent = 25,
- RecertEventReport = 26,
- ComplianceReport = 31,
- ComplianceDiffReport = 32,
- TicketReport = 41,
- TicketChangeReport = 42,
- Owners = 51

If we add a parent typ like rules, recert, compliance etc. we can order them by parenttype and then if wanted by name or child type.

I'm open for discussion.

Closes #3815