### PR TITLE
Nuget Updates

### DIFF
--- a/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
+++ b/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="GraphQL.Client" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.8" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="114.0.0" />

--- a/roles/lib/files/FWO.Basics/FWO.Basics.csproj
+++ b/roles/lib/files/FWO.Basics/FWO.Basics.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DnsClient" Version="1.8.0" />
     <PackageReference Include="IPAddressRange" Version="6.3.0" />
-    <PackageReference Include="IPNetwork2" Version="4.2.0" />
+    <PackageReference Include="IPNetwork2" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Data/FWO.Data.csproj
+++ b/roles/lib/files/FWO.Data/FWO.Data.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.8" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
   </ItemGroup>
 

--- a/roles/lib/files/FWO.Mail/FWO.Mail.csproj
+++ b/roles/lib/files/FWO.Mail/FWO.Mail.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="MimeKit" Version="4.16.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Report/FWO.Report.csproj
+++ b/roles/lib/files/FWO.Report/FWO.Report.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-	  <PackageReference Include="PuppeteerSharp" Version="24.40.0" />
+	  <PackageReference Include="PuppeteerSharp" Version="24.42.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Services/FWO.Services.csproj
+++ b/roles/lib/files/FWO.Services/FWO.Services.csproj
@@ -10,7 +10,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="PuppeteerSharp" Version="24.40.0" />
+		<PackageReference Include="PuppeteerSharp" Version="24.42.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\FWO.Api.Client\FWO.Api.Client.csproj" />

--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
-    <PackageReference Include="PuppeteerSharp" Version="24.40.0" />
+    <PackageReference Include="PuppeteerSharp" Version="24.42.0" />
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />

--- a/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
+++ b/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
@@ -11,13 +11,13 @@
   <ItemGroup>
     <PackageReference Include="bunit" Version="2.7.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="PuppeteerSharp" Version="24.40.0" />
-    <PackageReference Include="NUnit" Version="4.6.0" />
+    <PackageReference Include="PuppeteerSharp" Version="24.42.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
+	<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/roles/ui/files/FWO.UI/FWO.Ui.csproj
+++ b/roles/ui/files/FWO.UI/FWO.Ui.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="IPAddressRange" Version="6.3.0" />
 		<PackageReference Include="BlazorTable" Version="1.17.0" />
-		<PackageReference Include="PuppeteerSharp" Version="24.40.0" />
+		<PackageReference Include="PuppeteerSharp" Version="24.42.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Bump IPNetwork2 from 4.2.0 to 4.3.0 #4650
Bump Microsoft.AspNetCore.Authentication.JwtBearer from 10.0.7 to 10.0.8 #4631
Bump Microsoft.AspNetCore.Components from 10.0.7 to 10.0.8
Bump Microsoft.AspNetCore.Http from 2.3.9 to 2.3.10 #4633
Bump Microsoft.AspNetCore.Mvc.Testing from 10.0.2 to 10.0.8 #4655
Bump NUnit from 4.6.0 to 4.6.1 #4656
Bump PuppeteerSharp from 24.40.0 to 24.42.0