### PR TITLE
fix(db): flow fk duplication on fresh install plus upgrade

### DIFF
--- a/documentation/revision-history-main.md
+++ b/documentation/revision-history-main.md
@@ -613,3 +613,6 @@ A complete 80K lines rework of FWO, including
 - fixes time zone issues with checkpoint time objects
 - fixes python tests failing on python 3.10
 - fixes owner import from custom file
+
+### 9.1.2 - 26.05.2026
+- database: fix flow foreign key duplication on fresh install plus upgrade path

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,5 +1,5 @@
 ### general settings
-product_version: "9.1.1"
+product_version: "9.1.2"
 ansible_user: "{{ lookup('env', 'USER') }}"
 ansible_become_method: sudo
 ansible_python_interpreter: /usr/bin/python3

--- a/roles/database/files/sql/creation/fworch-create-foreign-keys.sql
+++ b/roles/database/files/sql/creation/fworch-create-foreign-keys.sql
@@ -61,8 +61,8 @@ Alter table "object" add  foreign key ("obj_last_seen") references "import_contr
 Alter table "object" add  foreign key ("obj_nat_install") references "device" ("dev_id") on update restrict on delete cascade;
 Alter table "object" add  foreign key ("obj_typ_id") references "stm_obj_typ" ("obj_typ_id") on update restrict on delete cascade;
 Alter table "object" add  foreign key ("zone_id") references "zone" ("zone_id") on update restrict on delete cascade;
-Alter table "object" add  foreign key ("flow_nwobj_id") references "flow"."nwobject" ("nwobj_id") on update restrict on delete set null;
-Alter table "object" add  foreign key ("flow_nwgrp_id") references "flow"."nwgroup" ("nwgrp_id") on update restrict on delete set null;
+Alter table "object" add constraint "flow_nwobj_id_foreign_key" foreign key ("flow_nwobj_id") references "flow"."nwobject" ("nwobj_id") on update restrict on delete set null;
+Alter table "object" add constraint "flow_nwgrp_id_foreign_key" foreign key ("flow_nwgrp_id") references "flow"."nwgroup" ("nwgrp_id") on update restrict on delete set null;
 Alter table "objgrp" add  foreign key ("import_created") references "import_control" ("control_id") on update restrict on delete cascade;
 Alter table "objgrp" add  foreign key ("import_last_seen") references "import_control" ("control_id") on update restrict on delete cascade;
 Alter table "objgrp" add  foreign key ("objgrp_id") references "object" ("obj_id") on update restrict on delete cascade;
@@ -171,8 +171,8 @@ Alter table "service" add  foreign key ("svc_color_id") references "stm_color" (
 Alter table "service" add  foreign key ("svc_create") references "import_control" ("control_id") on update restrict on delete cascade;
 Alter table "service" add  foreign key ("svc_last_seen") references "import_control" ("control_id") on update restrict on delete cascade;
 Alter table "service" add  foreign key ("svc_typ_id") references "stm_svc_typ" ("svc_typ_id") on update restrict on delete cascade;
-Alter table "service" add  foreign key ("flow_svcobj_id") references "flow"."svcobject" ("svcobj_id") on update restrict on delete set null;
-Alter table "service" add  foreign key ("flow_svcgrp_id") references "flow"."svcgroup" ("svcgrp_id") on update restrict on delete set null;
+Alter table "service" add constraint "flow_svcobj_id_foreign_key" foreign key ("flow_svcobj_id") references "flow"."svcobject" ("svcobj_id") on update restrict on delete set null;
+Alter table "service" add constraint "flow_svcgrp_id_foreign_key" foreign key ("flow_svcgrp_id") references "flow"."svcgroup" ("svcgrp_id") on update restrict on delete set null;
 Alter table "svcgrp" add  foreign key ("import_created") references "import_control" ("control_id") on update restrict on delete cascade;
 Alter table "svcgrp" add  foreign key ("import_last_seen") references "import_control" ("control_id") on update restrict on delete cascade;
 Alter table "svcgrp" add  foreign key ("svcgrp_id") references "service" ("svc_id") on update restrict on delete cascade;
@@ -222,7 +222,7 @@ ALTER TABLE ext_request ADD CONSTRAINT ext_request_ticket_id_foreign_key FOREIGN
 Alter table "time_object" add  foreign key ("mgm_id") references "management" ("mgm_id") on update restrict on delete cascade;
 Alter table "time_object" add  foreign key ("created") references "import_control" ("control_id") on update restrict on delete cascade;
 Alter table "time_object" add  foreign key ("removed") references "import_control" ("control_id") on update restrict on delete cascade;
-Alter table "time_object" add  foreign key ("flow_timeobj_id") references "flow"."timeobject" ("timeobj_id") on update restrict on delete set null;
+Alter table "time_object" add constraint "flow_timeobj_id_foreign_key" foreign key ("flow_timeobj_id") references "flow"."timeobject" ("timeobj_id") on update restrict on delete set null;
 
 Alter table "rule_time" add  foreign key ("rule_id") references "rule" ("rule_id") on update restrict on delete cascade;
 Alter table "rule_time" add  foreign key ("time_obj_id") references "time_object" ("time_obj_id") on update restrict on delete cascade;

--- a/roles/database/files/upgrade/9.1.2.sql
+++ b/roles/database/files/upgrade/9.1.2.sql
@@ -1,0 +1,136 @@
+-- Fix duplicate flow foreign key constraints introduced by mixed fresh-install and upgrade paths.
+
+DO $$
+DECLARE
+    rec record;
+BEGIN
+    -- public.object.flow_nwobj_id -> flow.nwobject
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'object'
+          AND column_name = 'flow_nwobj_id'
+    ) AND to_regclass('flow.nwobject') IS NOT NULL THEN
+        FOR rec IN
+            SELECT c.conname
+            FROM pg_constraint c
+            JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+            WHERE c.contype = 'f'
+              AND c.conrelid = 'public.object'::regclass
+              AND c.confrelid = 'flow.nwobject'::regclass
+              AND a.attname = 'flow_nwobj_id'
+        LOOP
+            EXECUTE format('ALTER TABLE public.object DROP CONSTRAINT IF EXISTS %I', rec.conname);
+        END LOOP;
+
+        ALTER TABLE public.object
+            ADD CONSTRAINT flow_nwobj_id_foreign_key
+            FOREIGN KEY (flow_nwobj_id) REFERENCES flow.nwobject(nwobj_id)
+            ON UPDATE RESTRICT ON DELETE SET NULL;
+    END IF;
+
+    -- public.object.flow_nwgrp_id -> flow.nwgroup
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'object'
+          AND column_name = 'flow_nwgrp_id'
+    ) AND to_regclass('flow.nwgroup') IS NOT NULL THEN
+        FOR rec IN
+            SELECT c.conname
+            FROM pg_constraint c
+            JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+            WHERE c.contype = 'f'
+              AND c.conrelid = 'public.object'::regclass
+              AND c.confrelid = 'flow.nwgroup'::regclass
+              AND a.attname = 'flow_nwgrp_id'
+        LOOP
+            EXECUTE format('ALTER TABLE public.object DROP CONSTRAINT IF EXISTS %I', rec.conname);
+        END LOOP;
+
+        ALTER TABLE public.object
+            ADD CONSTRAINT flow_nwgrp_id_foreign_key
+            FOREIGN KEY (flow_nwgrp_id) REFERENCES flow.nwgroup(nwgrp_id)
+            ON UPDATE RESTRICT ON DELETE SET NULL;
+    END IF;
+
+    -- public.service.flow_svcobj_id -> flow.svcobject
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'service'
+          AND column_name = 'flow_svcobj_id'
+    ) AND to_regclass('flow.svcobject') IS NOT NULL THEN
+        FOR rec IN
+            SELECT c.conname
+            FROM pg_constraint c
+            JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+            WHERE c.contype = 'f'
+              AND c.conrelid = 'public.service'::regclass
+              AND c.confrelid = 'flow.svcobject'::regclass
+              AND a.attname = 'flow_svcobj_id'
+        LOOP
+            EXECUTE format('ALTER TABLE public.service DROP CONSTRAINT IF EXISTS %I', rec.conname);
+        END LOOP;
+
+        ALTER TABLE public.service
+            ADD CONSTRAINT flow_svcobj_id_foreign_key
+            FOREIGN KEY (flow_svcobj_id) REFERENCES flow.svcobject(svcobj_id)
+            ON UPDATE RESTRICT ON DELETE SET NULL;
+    END IF;
+
+    -- public.service.flow_svcgrp_id -> flow.svcgroup
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'service'
+          AND column_name = 'flow_svcgrp_id'
+    ) AND to_regclass('flow.svcgroup') IS NOT NULL THEN
+        FOR rec IN
+            SELECT c.conname
+            FROM pg_constraint c
+            JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+            WHERE c.contype = 'f'
+              AND c.conrelid = 'public.service'::regclass
+              AND c.confrelid = 'flow.svcgroup'::regclass
+              AND a.attname = 'flow_svcgrp_id'
+        LOOP
+            EXECUTE format('ALTER TABLE public.service DROP CONSTRAINT IF EXISTS %I', rec.conname);
+        END LOOP;
+
+        ALTER TABLE public.service
+            ADD CONSTRAINT flow_svcgrp_id_foreign_key
+            FOREIGN KEY (flow_svcgrp_id) REFERENCES flow.svcgroup(svcgrp_id)
+            ON UPDATE RESTRICT ON DELETE SET NULL;
+    END IF;
+
+    -- public.time_object.flow_timeobj_id -> flow.timeobject
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'time_object'
+          AND column_name = 'flow_timeobj_id'
+    ) AND to_regclass('flow.timeobject') IS NOT NULL THEN
+        FOR rec IN
+            SELECT c.conname
+            FROM pg_constraint c
+            JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+            WHERE c.contype = 'f'
+              AND c.conrelid = 'public.time_object'::regclass
+              AND c.confrelid = 'flow.timeobject'::regclass
+              AND a.attname = 'flow_timeobj_id'
+        LOOP
+            EXECUTE format('ALTER TABLE public.time_object DROP CONSTRAINT IF EXISTS %I', rec.conname);
+        END LOOP;
+
+        ALTER TABLE public.time_object
+            ADD CONSTRAINT flow_timeobj_id_foreign_key
+            FOREIGN KEY (flow_timeobj_id) REFERENCES flow.timeobject(timeobj_id)
+            ON UPDATE RESTRICT ON DELETE SET NULL;
+    END IF;
+END $$;


### PR DESCRIPTION
fixes inconsistent naming of foreign key constraints relating object/service/rule/time_object tables to corresponding flow tables between install and upgrade script.