### PR TITLE
Fix/variance analysis nw obj hash collision

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -56,7 +56,7 @@ jobs:
             dotnet test /usr/local/fworch/test/csharp/FWO.Test/FWO.Test.csproj --filter "FullyQualifiedName~AuthenticationTokenIntegrationTest"
 
       - name: Run Ansible integration tests with cleanup
-        if: ${{ always() }}
+        if: ${{ success() }}
         run: |
           cd /home/runner/work/firewall-orchestrator/firewall-orchestrator
           ansible-playbook -e force_install=true site.yml -K --tags integrationtests

--- a/roles/lib/files/FWO.Services/Modelling/ModellingVarianceAnalysis.cs
+++ b/roles/lib/files/FWO.Services/Modelling/ModellingVarianceAnalysis.cs
@@ -39,7 +39,7 @@ namespace FWO.Services.Modelling
         private List<ModellingAppRole> allModelledAppRoles = [];
 
         private readonly Dictionary<int, List<ModellingAppRole>> allProdAppRoles = [];
-        private readonly Dictionary<int, Dictionary<int, long>> allExistingAppServersHashes = [];
+        private readonly Dictionary<int, Dictionary<ModellingAppServer, long>> allExistingAppServers = [];
         private readonly Dictionary<int, List<ModellingAppServer>> alreadyCreatedAppServers = [];
         private List<ModellingConnection> DeletedConns = [];
         private List<ModellingNetworkArea> AllAreas = [];

--- a/roles/lib/files/FWO.Services/Modelling/ModellingVarianceAnalysisGetProd.cs
+++ b/roles/lib/files/FWO.Services/Modelling/ModellingVarianceAnalysisGetProd.cs
@@ -223,15 +223,15 @@ namespace FWO.Services.Modelling
             List<NetworkObject>? objByMgt = await GetObjects(mgtId, [1, 3, 12]);
             if (objByMgt != null)
             {
-                if (!allExistingAppServersHashes.TryGetValue(mgtId, out Dictionary<int, long>? appServerHashes))
+                if (!allExistingAppServers.TryGetValue(mgtId, out Dictionary<ModellingAppServer, long>? appServers))
                 {
-                    appServerHashes = [];
-                    allExistingAppServersHashes.Add(mgtId, appServerHashes);
+                    appServers = new(appServerComparer);
+                    allExistingAppServers.Add(mgtId, appServers);
                 }
                 foreach (NetworkObject obj in objByMgt)
                 {
                     ModellingAppServer appServer = new(obj);
-                    appServerHashes.TryAdd(appServerComparer.GetHashCode(appServer), appServer.Id);
+                    appServers.TryAdd(appServer, appServer.Id);
                     aSCount++;
                 }
             }

--- a/roles/lib/files/FWO.Services/Modelling/ModellingVarianceAnalysisObjectsForRequest.cs
+++ b/roles/lib/files/FWO.Services/Modelling/ModellingVarianceAnalysisObjectsForRequest.cs
@@ -294,7 +294,7 @@ namespace FWO.Services.Modelling
         {
             Log.WriteDebug("Search AppServer", $"Name: {appServer.Name}, Ip: {appServer.Ip}, Management: {mgt.Name}");
 
-            if (allExistingAppServersHashes[mgt.Id].TryGetValue(appServerComparer.GetHashCode(appServer), out long existingAppServerId))
+            if (allExistingAppServers[mgt.Id].TryGetValue(appServer, out long existingAppServerId))
             {
                 Log.WriteDebug("Search AppServer", $"Found!!");
                 return (existingAppServerId, true);

--- a/roles/middleware/tasks/set_initial_ldap_tree.yml
+++ b/roles/middleware/tasks/set_initial_ldap_tree.yml
@@ -35,7 +35,7 @@
   become: true
 
 - name: add tree
-  command: "ldapmodify {{ ldap_tls_opts }} -H {{ ldap_cmd_url }} -D {{ openldap_superuser_dn }} -w {{ ldap_manager_pwd }} -x -f {{  middleware_ldif_dir }}/tree_{{ item }}.ldif"
+  command: "ldapmodify {{ ldap_tls_opts }} -H {{ ldap_cmd_url }} -D {{ openldap_superuser_dn }} -y {{ ldap_manager_pwd_file }} -x -f {{  middleware_ldif_dir }}/tree_{{ item }}.ldif"
   loop:
     - level_0
     - level_1
@@ -44,4 +44,9 @@
     - roles
     - tenant0
     - operators
-  # ignore errors only when re-installing on a system
+  register: ldap_initial_tree_result
+  failed_when:
+    - ldap_initial_tree_result.rc != 0
+    - "'Already exists' not in ldap_initial_tree_result.stderr"
+  changed_when: ldap_initial_tree_result.rc == 0
+  become: true

--- a/roles/tests-integration/tasks/test-auth.yml
+++ b/roles/tests-integration/tasks/test-auth.yml
@@ -1,12 +1,37 @@
 # this playbook contains middleware server tests
 
+- name: ensure middleware service is running
+  ansible.builtin.systemd:
+      name: "{{ middleware_service_name }}"
+      state: started
+      daemon_reload: true
+  become: true
+
+- name: ensure middleware reverse proxy is running
+  ansible.builtin.service:
+      name: "{{ webserver_package_name }}"
+      state: restarted
+  become: true
+
 - name: wait for middleware port to become available
   ansible.builtin.wait_for:
       port: "{{ middleware_web_listener_port }}"
       host: "{{ middleware_hostname }}"
       connect_timeout: 1
       delay: 10
-      timeout: 25
+      timeout: 120
+
+- name: wait for middleware web server to become available
+  ansible.builtin.uri:
+      url: "{{ middleware_uri }}/swagger/"
+      method: GET
+      validate_certs: false
+      return_content: false
+  register: middleware_web_result
+  changed_when: false
+  until: middleware_web_result.status == 200
+  retries: 12
+  delay: 5
 
 - name: middleware test get jwt valid creds
   ansible.builtin.uri:

--- a/roles/tests-unit/files/FWO.Test/ModellingVarianceAnalysisTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ModellingVarianceAnalysisTest.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
+using FWO.Api.Client.Queries;
 using FWO.Data;
 using FWO.Data.Modelling;
 using FWO.Data.Report;
@@ -314,6 +315,52 @@ namespace FWO.Test
             ClassicAssert.AreEqual("service", TaskList[3].Elements[0].Field);
             ClassicAssert.AreEqual("create", TaskList[3].Elements[0].RequestAction);
             userConfig.ModRolloutResolveServiceGroups = true;
+        }
+
+        [Test]
+        public async Task TestAnalyseModelledConnectionsForRequest_DoesNotTreatHashCollisionAsExistingAppServer()
+        {
+            ModellingNamingConvention namingConvention = new() { AppServerPrefix = "", NetworkPrefix = "", IpRangePrefix = "" };
+            AppServerComparer appServerComparer = new(namingConvention);
+            (ModellingAppServer existingAppServer, ModellingAppServer modelledAppServer) = CreateDifferentAppServersWithSameHash(appServerComparer);
+            SimulatedUserConfig localUserConfig = new()
+            {
+                ModNamingConvention = "{\"appServerPrefix\":\"\",\"networkPrefix\":\"\",\"ipRangePrefix\":\"\"}",
+                CreateAppZones = false,
+                RuleRecognitionOption = stdRecogOpt
+            };
+            ModellingConnection connection = new()
+            {
+                Id = 500,
+                Name = "HashCollisionConnection",
+                SourceAppRoles =
+                [
+                    new()
+                    {
+                        Content = new()
+                        {
+                            Id = 600,
+                            AppId = Application.Id,
+                            IdString = "AR-HASH-COLLISION",
+                            AppServers = [new() { Content = modelledAppServer }]
+                        }
+                    }
+                ]
+            };
+            ModellingVarianceAnalysis varianceAnalysis = new(
+                new HashCollisionVarianceAnalysisApiConn(existingAppServer),
+                extStateHandler,
+                localUserConfig,
+                Application,
+                DefaultInit.DoNothing);
+
+            List<WfReqTask> taskList = await varianceAnalysis.AnalyseModelledConnectionsForRequest([connection]);
+            WfReqTask groupCreateTask = taskList.First(t => t.TaskType == WfTaskType.group_create.ToString());
+            WfReqElement appServerElement = groupCreateTask.Elements[0];
+
+            ClassicAssert.AreEqual(RequestAction.create.ToString(), appServerElement.RequestAction);
+            ClassicAssert.IsNull(appServerElement.NetworkId);
+            ClassicAssert.AreEqual(modelledAppServer.Name, appServerElement.Name);
         }
 
         [Test]
@@ -903,6 +950,83 @@ namespace FWO.Test
             ClassicAssert.AreEqual(2, result.RuleDifferences[0].ImplementedRules.Count);
             ClassicAssert.AreEqual("FWOC7_mgt2", result.RuleDifferences[0].ImplementedRules[0].Name);
             ClassicAssert.AreEqual("FWOC7_mgt3", result.RuleDifferences[0].ImplementedRules[1].Name);
+        }
+
+        private static (ModellingAppServer, ModellingAppServer) CreateDifferentAppServersWithSameHash(AppServerComparer appServerComparer)
+        {
+            Dictionary<int, ModellingAppServer> appServersByHash = [];
+            const int kMaxCandidates = 400000;
+            for (int candidateIndex = 0; candidateIndex < kMaxCandidates; candidateIndex++)
+            {
+                ModellingAppServer candidate = new()
+                {
+                    Id = candidateIndex,
+                    Name = $"HashCollisionCandidate{candidateIndex}",
+                    Ip = $"10.{candidateIndex / 65536}.{candidateIndex / 256 % 256}.{candidateIndex % 256}",
+                    IpEnd = $"10.{candidateIndex / 65536}.{candidateIndex / 256 % 256}.{candidateIndex % 256}"
+                };
+                int hash = appServerComparer.GetHashCode(candidate);
+                if (appServersByHash.TryGetValue(hash, out ModellingAppServer? existingAppServer) &&
+                    !appServerComparer.Equals(existingAppServer, candidate))
+                {
+                    return (existingAppServer, candidate);
+                }
+                appServersByHash.TryAdd(hash, candidate);
+            }
+            Assert.Fail($"No app-server hash collision found in {kMaxCandidates} candidates.");
+            return (new(), new());
+        }
+
+        private class HashCollisionVarianceAnalysisApiConn(ModellingAppServer existingAppServer) : SimulatedApiConnection
+        {
+            private readonly NetworkObject existingNetworkObject = new()
+            {
+                Id = 700,
+                Name = existingAppServer.Name,
+                IP = existingAppServer.Ip,
+                IpEnd = existingAppServer.IpEnd,
+                Type = new() { Name = ObjectType.Host }
+            };
+
+            public override async Task<QueryResponseType> SendQueryAsync<QueryResponseType>(string query, object? variables = null, string? operationName = null)
+            {
+                await DefaultInit.DoNothing();
+                Type responseType = typeof(QueryResponseType);
+                if (responseType == typeof(List<Management>))
+                {
+                    if (query == ReportQueries.getRelevantImportIdsAtTime)
+                    {
+                        return (QueryResponseType)(object)new List<Management>
+                        {
+                            new() { Import = new() { ImportAggregate = new() { ImportAggregateMax = new() { RelevantImportId = 1 } } } }
+                        };
+                    }
+                    return (QueryResponseType)(object)new List<Management>
+                    {
+                        new() { Id = 1, Name = "Checkpoint1", ExtMgtData = "{\"id\":\"1\"}" }
+                    };
+                }
+                if (responseType == typeof(List<NetworkObject>))
+                {
+                    int[] objTypeIds = variables?.GetType().GetProperties().First(o => o.Name == "objTypeIds").GetValue(variables, null) as int[] ?? [];
+                    List<NetworkObject> networkObjects = objTypeIds.Length > 0 && objTypeIds[0] == 2 ? [] : [existingNetworkObject];
+                    return (QueryResponseType)(object)networkObjects;
+                }
+                if (responseType == typeof(List<Rule>))
+                {
+                    return (QueryResponseType)(object)new List<Rule>();
+                }
+                if (responseType == typeof(List<ModellingConnection>))
+                {
+                    return (QueryResponseType)(object)new List<ModellingConnection>();
+                }
+                if (responseType == typeof(List<ModellingNetworkArea>))
+                {
+                    return (QueryResponseType)(object)new List<ModellingNetworkArea>();
+                }
+
+                throw new NotImplementedException();
+            }
         }
     }
 }


### PR DESCRIPTION
closes #4680

PR 4685 fixes a modelling variance-analysis bug caused by using only GetHashCode() to identify existing app servers.

Before the PR, production app servers were stored as hash -> object id. If two different app servers produced the same hash code, variance analysis could incorrectly treat a new app server as already existing and reuse the wrong object ID.

The PR changes that to store app servers in a dictionary keyed by ModellingAppServer with AppServerComparer, so lookup uses the comparer’s equality check, not just the hash code. It also adds a unit test that deliberately creates two different app servers with the same hash and verifies the new one is still requested as create.

#### Sidenote
It also includes CI/install reliability fixes:

LDAP initial tree creation now reads the bind password from ldap_manager_pwd_file instead of passing it on the command line.
LDAP tree creation treats “Already exists” as non-fatal, improving re-run behavior.
Auth integration tests explicitly start middleware and the reverse proxy, wait longer, and poll Swagger before token tests.
The install workflow only runs cleanup integration tests if earlier steps succeeded.