### PR TITLE
[codex] combine Python bump PRs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ansible==12.3.0
-cryptography==48.0.0
+cryptography==48.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==12.3.0
+ansible==14.0.0
 cryptography==48.0.0

--- a/roles/importer/files/importer/requirements.txt
+++ b/roles/importer/files/importer/requirements.txt
@@ -8,7 +8,7 @@ netaddr==1.3.0
 cryptography==48.0.0
 
 # HTTP / GraphQL stack
-requests==2.34.0
+requests==2.34.2
 urllib3==2.7.0
 graphql-core==3.2.8
 

--- a/roles/importer/files/importer/requirements.txt
+++ b/roles/importer/files/importer/requirements.txt
@@ -23,4 +23,4 @@ pytest-mock==3.15.1
 # Linting
 ruff==0.15.0
 pre-commit==4.6.0
-pyright==1.1.409
+pyright==1.1.410

--- a/roles/importer/files/importer/requirements.txt
+++ b/roles/importer/files/importer/requirements.txt
@@ -21,6 +21,6 @@ pytest==9.0.3
 pytest-mock==3.15.1
 
 # Linting
-ruff==0.15.0
+ruff==0.15.16
 pre-commit==4.6.0
 pyright==1.1.409

--- a/roles/importer/files/importer/requirements.txt
+++ b/roles/importer/files/importer/requirements.txt
@@ -1,6 +1,6 @@
 # Core runtime
 pydantic==2.13.4
-jsonpickle==4.1.1
+jsonpickle==4.1.2
 python-dateutil==2.9.0.post0
 netaddr==1.3.0
 

--- a/roles/importer/files/importer/requirements.txt
+++ b/roles/importer/files/importer/requirements.txt
@@ -10,7 +10,7 @@ cryptography==48.0.0
 # HTTP / GraphQL stack
 requests==2.34.0
 urllib3==2.7.0
-graphql-core==3.2.8
+graphql-core==3.2.11
 
 # SSH
 scrapli==2026.2.20


### PR DESCRIPTION
## Summary

Combines the currently open Python dependency bump PRs targeting `develop`:

- #4743 jsonpickle 4.1.1 -> 4.1.2
- #4744 graphql-core 3.2.8 -> 3.2.11
- #4745 pyright 1.1.409 -> 1.1.410
- #4746 ansible 12.3.0 -> 14.0.0
- #4747 cryptography 48.0.0 -> 48.0.1
- #4748 ruff 0.15.0 -> 0.15.16
- #4749 requests 2.34.0 -> 2.34.2

Clean install successfully tested on 
- Ubuntu 24.04 (github)
- debian 12
- debian 13
