### PR TITLE
refactor: clarify user config creation

### DIFF
--- a/roles/common/files/fwo-api-calls/recertification/getOwnerRecert.graphql
+++ b/roles/common/files/fwo-api-calls/recertification/getOwnerRecert.graphql
@@ -1,4 +1,4 @@
-query getInitialOwnerRecert ($ownerId: Int!) {
+query getOwnerRecert ($ownerId: Int!) {
   owner_recertification (where: {owner_id: {_eq: $ownerId}}){
     id
     owner_id

--- a/roles/lib/files/FWO.Api.Client/Queries/RecertQueries.cs
+++ b/roles/lib/files/FWO.Api.Client/Queries/RecertQueries.cs
@@ -17,7 +17,7 @@ namespace FWO.Api.Client.Queries
         public static readonly string addRecertEntries;
         public static readonly string refreshViewRuleWithOwner;
         public static readonly string getOwnerRecerts;
-        public static readonly string getInitialOwnerRecert;
+        public static readonly string getOwnerRecert;
         public static readonly string updateRecertReportId;
 
 
@@ -42,7 +42,7 @@ namespace FWO.Api.Client.Queries
                 addRecertEntries = GetQueryText("recertification/addRecertEntries.graphql");
                 refreshViewRuleWithOwner = GetQueryText("recertification/refreshViewRuleWithOwner.graphql");
                 getOwnerRecerts = GetQueryText("recertification/getOwnerRecerts.graphql");
-                getInitialOwnerRecert = GetQueryText("recertification/getInitialOwnerRecert.graphql");
+                getOwnerRecert = GetQueryText("recertification/getOwnerRecert.graphql");
                 updateRecertReportId = GetQueryText("recertification/updateRecertReportId.graphql");
             }
             catch (Exception exception)

--- a/roles/lib/files/FWO.Config.Api/UserConfig.cs
+++ b/roles/lib/files/FWO.Config.Api/UserConfig.cs
@@ -24,6 +24,23 @@ namespace FWO.Config.Api
         public UiUser User { private set; get; }
         public string ExecutionMode { get; private set; } = GlobalConst.kUserRolesSelection;
 
+        /// <summary>
+        /// Creates a text-only user configuration for unauthenticated UI/bootstrap display.
+        /// This does not load direct configuration properties for operational code.
+        /// </summary>
+        public static UserConfig ForTextOnly(GlobalConfig globalConfig, bool registerOnChangeHandler = true)
+        {
+            return new UserConfig(globalConfig, registerOnChangeHandler);
+        }
+
+        /// <summary>
+        /// Creates an initialized configuration for middleware and scheduled jobs that need global settings.
+        /// </summary>
+        public static UserConfig ForGlobalSettings(GlobalConfig globalConfig, ApiConnection apiConnection, string language = GlobalConst.kEnglish, bool owningApiConnection = false)
+        {
+            return new UserConfig(globalConfig, apiConnection, new UiUser { DbId = 0, Language = language }, owningApiConnection);
+        }
+
         public static async Task<UserConfig> ConstructAsync(GlobalConfig globalConfig, ApiConnection apiConnection, int userId, bool owningApiConnection = false)
         {
             UiUser[] users = await apiConnection.SendQueryAsync<UiUser[]>(AuthQueries.getUserByDbId, new { userId = userId });
@@ -47,7 +64,7 @@ namespace FWO.Config.Api
         }
 
         // Warning: only for Texts, ConfigItems contain Default content, correct ConfigItems are only in this.globalConfig
-        public UserConfig(GlobalConfig globalConfig, bool registerOnChangeHandler = true) : base()
+        private UserConfig(GlobalConfig globalConfig, bool registerOnChangeHandler = true) : base()
         {
             User = new UiUser();
             Translate = globalConfig.LangDict[globalConfig.DefaultLanguage];

--- a/roles/lib/files/FWO.Recert/RecertHandler.cs
+++ b/roles/lib/files/FWO.Recert/RecertHandler.cs
@@ -12,7 +12,7 @@ namespace FWO.Recert
 
         public async Task InitOwnerRecert(FwoOwner owner)
         {
-            if ((await apiConnection.SendQueryAsync<List<OwnerRecertification>>(RecertQueries.getInitialOwnerRecert, new { ownerId = owner.Id })).Count == 0)
+            if ((await apiConnection.SendQueryAsync<List<OwnerRecertification>>(RecertQueries.getOwnerRecert, new { ownerId = owner.Id })).Count == 0)
             {
                 FwoOwner recertifiedOwner = await RecertifyOwner(owner, LogMessageTitle, true);
                 Log.WriteInfo(LogMessageTitle,

--- a/roles/middleware/files/FWO.Middleware.Server/AppDataImport.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/AppDataImport.cs
@@ -52,7 +52,7 @@ namespace FWO.Middleware.Server
         {
             NamingConvention = JsonSerializer.Deserialize<ModellingNamingConvention>(globalConfig.ModNamingConvention) ?? new();
             List<string> importfilePathAndNames = JsonSerializer.Deserialize<List<string>>(globalConfig.ImportAppDataPath) ?? throw new JsonException("Config Data could not be deserialized.");
-            userConfig = new(globalConfig, apiConnection, new() { Language = GlobalConst.kEnglish });
+            userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
             userConfig.User.Name = Roles.MiddlewareServer;
             userConfig.AutoReplaceAppServer = globalConfig.AutoReplaceAppServer;
             await InitLdap();

--- a/roles/middleware/files/FWO.Middleware.Server/AppDataImport.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/AppDataImport.cs
@@ -17,7 +17,7 @@ namespace FWO.Middleware.Server
     /// <summary>
     /// Class handling the App Data Import
     /// </summary>
-    public class AppDataImport : DataImportBase
+    public class AppDataImport : DataImportBase, IDisposable
     {
         private List<ModellingImportAppData> ImportedApps = [];
         private List<FwoOwner> ExistingApps = [];
@@ -34,6 +34,7 @@ namespace FWO.Middleware.Server
         private bool hasImmediateAppDecommNotificationForImport;
         private ModellingNamingConvention NamingConvention = new();
         private UserConfig userConfig = new();
+        private bool disposed = false;
         private const string LogMessageTitle = "Import App Data";
         private const string LevelFile = "Import File";
         private const string LevelApp = "App";
@@ -46,12 +47,38 @@ namespace FWO.Middleware.Server
         { }
 
         /// <summary>
+        /// Dispose method to clean up resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Protected dispose method.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    userConfig.Dispose();
+                }
+                disposed = true;
+            }
+        }
+
+        /// <summary>
         /// Run the App Data Import
         /// </summary>
         public async Task<List<string>> Run()
         {
+            ObjectDisposedException.ThrowIf(disposed, this);
             NamingConvention = JsonSerializer.Deserialize<ModellingNamingConvention>(globalConfig.ModNamingConvention) ?? new();
             List<string> importfilePathAndNames = JsonSerializer.Deserialize<List<string>>(globalConfig.ImportAppDataPath) ?? throw new JsonException("Config Data could not be deserialized.");
+            userConfig.Dispose();
             userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
             userConfig.User.Name = Roles.MiddlewareServer;
             userConfig.AutoReplaceAppServer = globalConfig.AutoReplaceAppServer;

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/ComplianceController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/ComplianceController.cs
@@ -55,7 +55,7 @@ namespace FWO.Middleware.Server.Controllers
             try
             {
                 GlobalConfig globalConfig = await GlobalConfig.ConstructAsync(apiConnection, true);
-                UserConfig userConfig = new(globalConfig, apiConnection, new() { Language = GlobalConst.kEnglish });
+                UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
 
                 ComplianceCheck complianceCheck = new(userConfig, apiConnection);
                 await complianceCheck.RunComplianceCheck(ComplianceCheckType.Standard);
@@ -86,7 +86,7 @@ namespace FWO.Middleware.Server.Controllers
             try
             {
                 GlobalConfig globalConfig = await GlobalConfig.ConstructAsync(apiConnection, true);
-                UserConfig userConfig = new(globalConfig, apiConnection, new() { Language = GlobalConst.kEnglish });
+                UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
                 ComplianceCheck complianceCheck = new(userConfig, apiConnection);
                 await complianceCheck.RunComplianceCheck(ComplianceCheckType.Variable);
                 await complianceCheck.PersistDataAsync();
@@ -124,7 +124,7 @@ namespace FWO.Middleware.Server.Controllers
                     complianceCheckStatusTracker.SetRunning(jobStatus.JobId);
 
                     GlobalConfig globalConfig = await GlobalConfig.ConstructAsync(apiConnection, true);
-                    UserConfig userConfig = new(globalConfig, apiConnection, new() { Language = GlobalConst.kEnglish });
+                    UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
                     ComplianceCheck complianceCheck = new(userConfig, apiConnection);
                     await complianceCheck.RunComplianceCheck(ComplianceCheckType.Variable);
                     await complianceCheck.PersistDataAsync();

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/ExternalRequestController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/ExternalRequestController.cs
@@ -41,7 +41,7 @@ namespace FWO.Middleware.Server.Controllers
             if (parameters.TicketId > 0)
             {
                 using GlobalConfig GlobalConfig = await GlobalConfig.ConstructAsync(apiConnection, true);
-                using UserConfig userConfig = new(GlobalConfig, apiConnection, new() { Language = GlobalConst.kEnglish });
+                using UserConfig userConfig = UserConfig.ForGlobalSettings(GlobalConfig, apiConnection);
                 using ExternalRequestHandler extRequestHandler = new(userConfig, apiConnection);
                 return await extRequestHandler.SendFirstRequest(parameters.TicketId);
             }
@@ -70,7 +70,7 @@ namespace FWO.Middleware.Server.Controllers
             if (parameters.ExtRequestId > 0)
             {
                 using GlobalConfig GlobalConfig = await GlobalConfig.ConstructAsync(apiConnection, true);
-                using UserConfig userConfig = new(GlobalConfig, apiConnection, new() { Language = GlobalConst.kEnglish });
+                using UserConfig userConfig = UserConfig.ForGlobalSettings(GlobalConfig, apiConnection);
                 using ExternalRequestHandler extRequestHandler = new(userConfig, apiConnection);
                 ExternalRequest extRequest = new()
                 {

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/RuleController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/RuleController.cs
@@ -55,7 +55,7 @@ public class RuleController(ApiConnection apiConnection) : ControllerBase
             }
 
             GlobalConfig globalConfig = await GlobalConfig.ConstructAsync(apiConnection);
-            UserConfig userConfig = new(globalConfig, apiConnection, new() { Language = GlobalConst.kEnglish });
+            UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
 
             string requestId = HttpContext.Request.Headers["X-Request-Id"].FirstOrDefault()
                                ?? Guid.NewGuid().ToString();

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/WorkflowController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/WorkflowController.cs
@@ -153,7 +153,7 @@ namespace FWO.Middleware.Server.Controllers
         private async Task<WorkflowActionResult> ExecuteActionsInMiddlewareContext(ApiConnection actionApiConnection, WorkflowActionParameters parameters,
             WfObjectScopes scope, WorkflowPhases phase, long lockTicketId, WorkflowActionResult result)
         {
-            using UserConfig userConfig = new(globalConfig, actionApiConnection, new UiUser { DbId = 0, Language = globalConfig.DefaultLanguage }, false);
+            using UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, actionApiConnection, globalConfig.DefaultLanguage);
             WfHandler wfHandler = CreateWorkflowHandler(actionApiConnection, userConfig, phase, result);
             if (!await InitWorkflowHandler(wfHandler, result))
             {

--- a/roles/middleware/files/FWO.Middleware.Server/ExternalRequestSender.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ExternalRequestSender.cs
@@ -53,7 +53,7 @@ namespace FWO.Middleware.Server
         {
             this.apiConnection = apiConnection;
             this.globalConfig = globalConfig;
-            userConfig = new(globalConfig, apiConnection, new() { Language = GlobalConst.kEnglish });
+            userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
             InjScClient = injScClient;
         }
 

--- a/roles/middleware/files/FWO.Middleware.Server/ImportChangeNotifier.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ImportChangeNotifier.cs
@@ -16,7 +16,7 @@ namespace FWO.Middleware.Server
     /// <summary>
     /// Class handling the Import Change Notification
     /// </summary>
-    public class ImportChangeNotifier
+    public class ImportChangeNotifier : IDisposable
     {
         /// <summary>
         /// Api Connection
@@ -70,6 +70,13 @@ namespace FWO.Middleware.Server
             this.apiConnection = apiConnection;
             this.globalConfig = globalConfig;
             userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            userConfig.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/roles/middleware/files/FWO.Middleware.Server/ImportChangeNotifier.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ImportChangeNotifier.cs
@@ -59,6 +59,7 @@ namespace FWO.Middleware.Server
         private readonly DeviceFilter deviceFilter = new();
         private List<int> importedManagements = [];
         private readonly UserConfig userConfig;
+        private bool disposed = false;
         private const string LogMessageTitle = "Import Change Notifier";
 
 
@@ -75,8 +76,23 @@ namespace FWO.Middleware.Server
         /// <inheritdoc />
         public void Dispose()
         {
-            userConfig.Dispose();
+            Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases resources used by the notifier.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    userConfig.Dispose();
+                }
+                disposed = true;
+            }
         }
 
         /// <summary>
@@ -84,6 +100,7 @@ namespace FWO.Middleware.Server
         /// </summary>
         public async Task Run()
         {
+            ObjectDisposedException.ThrowIf(disposed, this);
             try
             {
                 if (!WorkInProgress)

--- a/roles/middleware/files/FWO.Middleware.Server/ImportChangeNotifier.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/ImportChangeNotifier.cs
@@ -69,7 +69,7 @@ namespace FWO.Middleware.Server
         {
             this.apiConnection = apiConnection;
             this.globalConfig = globalConfig;
-            userConfig = new(globalConfig);
+            userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
         }
 
         /// <summary>

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ComplianceJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ComplianceJob.cs
@@ -35,7 +35,7 @@ namespace FWO.Middleware.Server.Jobs
         {
             try
             {
-                UserConfig userConfig = new(globalConfig);
+                UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
                 ComplianceCheck complianceCheck = new(userConfig, apiConnection);
 
                 await complianceCheck.RunComplianceCheck(ComplianceCheckType.Standard);

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ComplianceJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ComplianceJob.cs
@@ -35,7 +35,7 @@ namespace FWO.Middleware.Server.Jobs
         {
             try
             {
-                UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
+                using UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
                 ComplianceCheck complianceCheck = new(userConfig, apiConnection);
 
                 await complianceCheck.RunComplianceCheck(ComplianceCheckType.Standard);

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/DailyCheckJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/DailyCheckJob.cs
@@ -235,7 +235,7 @@ namespace FWO.Middleware.Server.Jobs
         {
             int emailsSent = 0;
             List<UserGroup> OwnerGroups = await MiddlewareServerServices.GetInternalGroups(apiConnection);
-            UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
+            using UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
             WfHandler wfHandler = new(userConfig, apiConnection, WorkflowPhases.implementation, OwnerGroups, new ComplianceRequestedRulePolicyChecker(userConfig, apiConnection));
             await wfHandler.Init();
             NotificationService notificationService = await NotificationService.CreateAsync(NotificationClient.InterfaceRequest, globalConfig, apiConnection, OwnerGroups);

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/DailyCheckJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/DailyCheckJob.cs
@@ -235,7 +235,7 @@ namespace FWO.Middleware.Server.Jobs
         {
             int emailsSent = 0;
             List<UserGroup> OwnerGroups = await MiddlewareServerServices.GetInternalGroups(apiConnection);
-            UserConfig userConfig = new(globalConfig);
+            UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
             WfHandler wfHandler = new(userConfig, apiConnection, WorkflowPhases.implementation, OwnerGroups, new ComplianceRequestedRulePolicyChecker(userConfig, apiConnection));
             await wfHandler.Init();
             NotificationService notificationService = await NotificationService.CreateAsync(NotificationClient.InterfaceRequest, globalConfig, apiConnection, OwnerGroups);

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportAppDataJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportAppDataJob.cs
@@ -64,7 +64,7 @@ namespace FWO.Middleware.Server.Jobs
             {
                 if (globalConfig.DnsLookup)
                 {
-                    UserConfig userConfig = new(globalConfig, apiConnection, new() { Language = GlobalConst.kEnglish });
+                    UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
                     userConfig.User.Name = Roles.MiddlewareServer;
                     await AppServerHelper.AdjustAppServerNames(apiConnection, userConfig);
                 }

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportAppDataJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportAppDataJob.cs
@@ -45,7 +45,7 @@ namespace FWO.Middleware.Server.Jobs
         {
             try
             {
-                AppDataImport import = new(apiConnection, globalConfig);
+                using AppDataImport import = new(apiConnection, globalConfig);
                 List<string> failedImports = await import.Run();
                 if (failedImports.Count > 0)
                 {
@@ -64,7 +64,7 @@ namespace FWO.Middleware.Server.Jobs
             {
                 if (globalConfig.DnsLookup)
                 {
-                    UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
+                    using UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
                     userConfig.User.Name = Roles.MiddlewareServer;
                     await AppServerHelper.AdjustAppServerNames(apiConnection, userConfig);
                 }

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportChangeNotifyJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportChangeNotifyJob.cs
@@ -34,7 +34,7 @@ namespace FWO.Middleware.Server.Jobs
         {
             try
             {
-                ImportChangeNotifier notifyImportChanges = new(apiConnection, globalConfig);
+                using ImportChangeNotifier notifyImportChanges = new(apiConnection, globalConfig);
                 await notifyImportChanges.Run();
             }
             catch (Exception exc)

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/VarianceAnalysisJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/VarianceAnalysisJob.cs
@@ -46,7 +46,7 @@ namespace FWO.Middleware.Server.Jobs
             {
                 ExtStateHandler extStateHandler = new(apiConnection);
                 ModellingVarianceAnalysis? varianceAnalysis = null;
-                UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
+                using UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
 
                 List<FwoOwner> owners = await apiConnection.SendQueryAsync<List<FwoOwner>>(OwnerQueries.getOwners);
                 ReportBase? report = await ReportGenerator.GenerateFromTemplate(new ReportTemplate("", new() { ReportType = (int)ReportType.Connections, ModellingFilter = new() { SelectedOwners = owners } }), apiConnection, userConfig, DefaultInit.DoNothing);

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/VarianceAnalysisJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/VarianceAnalysisJob.cs
@@ -46,13 +46,7 @@ namespace FWO.Middleware.Server.Jobs
             {
                 ExtStateHandler extStateHandler = new(apiConnection);
                 ModellingVarianceAnalysis? varianceAnalysis = null;
-                UserConfig userConfig = new(globalConfig)
-                {
-                    RuleRecognitionOption = globalConfig.RuleRecognitionOption,
-                    ModNamingConvention = globalConfig.ModNamingConvention,
-                    ModModelledMarkerLocation = globalConfig.ModModelledMarkerLocation,
-                    ModModelledMarker = globalConfig.ModModelledMarker
-                };
+                UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
 
                 List<FwoOwner> owners = await apiConnection.SendQueryAsync<List<FwoOwner>>(OwnerQueries.getOwners);
                 ReportBase? report = await ReportGenerator.GenerateFromTemplate(new ReportTemplate("", new() { ReportType = (int)ReportType.Connections, ModellingFilter = new() { SelectedOwners = owners } }), apiConnection, userConfig, DefaultInit.DoNothing);

--- a/roles/middleware/files/FWO.Middleware.Server/RecertCheck.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/RecertCheck.cs
@@ -191,7 +191,7 @@ namespace FWO.Middleware.Server
             List<Rule> rules = [];
             try
             {
-                UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
+                using UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
 
                 DeviceFilter deviceFilter = new()
                 {

--- a/roles/middleware/files/FWO.Middleware.Server/RecertCheck.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/RecertCheck.cs
@@ -191,7 +191,7 @@ namespace FWO.Middleware.Server
             List<Rule> rules = [];
             try
             {
-                UserConfig userConfig = new(globalConfig);
+                UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, globalConfig.DefaultLanguage);
 
                 DeviceFilter deviceFilter = new()
                 {
@@ -350,7 +350,7 @@ namespace FWO.Middleware.Server
                     SelectedOwner = owner
                 }
             };
-            using UserConfig userConfig = new(globalConfig);
+            using UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnectionMiddlewareServer, globalConfig.DefaultLanguage);
             return await ReportGenerator.GenerateFromTemplate(new ReportTemplate("", reportParams), apiConnectionMiddlewareServer, userConfig, DefaultInit.DoNothing);
         }
 

--- a/roles/middleware/files/FWO.Middleware.Server/RuleNotificationBodyBase.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/RuleNotificationBodyBase.cs
@@ -220,7 +220,7 @@ namespace FWO.Middleware.Server
 
         private RuleDisplayHtml CreateRuleDisplayHtml()
         {
-            UserConfig displayUserConfig = new(GlobalConfig, false);
+            UserConfig displayUserConfig = UserConfig.ForTextOnly(GlobalConfig, false);
             return new RuleDisplayHtml(displayUserConfig);
         }
 

--- a/roles/tests-unit/files/FWO.Test/ActionHandlerTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ActionHandlerTest.cs
@@ -1255,7 +1255,7 @@ namespace FWO.Test
             ];
             SimulatedGlobalConfig globalConfig = new() { ComplianceCheckRelevantManagements = "1" };
             ActionHandlerTestPolicyChecker policyChecker = new() { Result = true };
-            WfHandler wfHandler = new((_, _, _, _) => { }, new UserConfig(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, policyChecker);
+            WfHandler wfHandler = new((_, _, _, _) => { }, UserConfig.ForTextOnly(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, policyChecker);
             ActionHandler handler = new(apiConn, wfHandler, null, true);
             await handler.Init();
             WfTicket ticket = CreateTicket(CreateEligibleRequestTask(11));
@@ -1284,7 +1284,7 @@ namespace FWO.Test
             ];
             SimulatedGlobalConfig globalConfig = new() { ComplianceCheckRelevantManagements = "1" };
             ActionHandlerTestPolicyChecker policyChecker = new() { Result = false };
-            WfHandler wfHandler = new((_, _, _, _) => { }, new UserConfig(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, policyChecker);
+            WfHandler wfHandler = new((_, _, _, _) => { }, UserConfig.ForTextOnly(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, policyChecker);
             ActionHandler handler = new(apiConn, wfHandler, null, true);
             await handler.Init();
             WfTicket ticket = CreateTicket(CreateEligibleRequestTask(12));
@@ -1307,7 +1307,7 @@ namespace FWO.Test
             ActionHandlerTestApiConn apiConn = new();
             apiConn.States = [new WfState { Id = 1 }, new WfState { Id = 2 }, new WfState { Id = 3 }];
             SimulatedGlobalConfig globalConfig = new() { ComplianceCheckRelevantManagements = "1" };
-            WfHandler wfHandler = new((_, _, _, _) => { }, new UserConfig(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, new ActionHandlerTestPolicyChecker() { Result = true });
+            WfHandler wfHandler = new((_, _, _, _) => { }, UserConfig.ForTextOnly(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, new ActionHandlerTestPolicyChecker() { Result = true });
             ActionHandler handler = new(apiConn, wfHandler, null, true);
             await handler.Init();
             WfTicket ticket = CreateTicket(CreateEligibleRequestTask(13));
@@ -1329,7 +1329,7 @@ namespace FWO.Test
             ActionHandlerTestApiConn apiConn = new();
             apiConn.States = [new WfState { Id = 1 }, new WfState { Id = 2 }, new WfState { Id = 3 }];
             SimulatedGlobalConfig globalConfig = new() { ComplianceCheckRelevantManagements = "1" };
-            WfHandler wfHandler = new((_, _, _, _) => { }, new UserConfig(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, new ActionHandlerTestPolicyChecker() { Result = true });
+            WfHandler wfHandler = new((_, _, _, _) => { }, UserConfig.ForTextOnly(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, new ActionHandlerTestPolicyChecker() { Result = true });
             ActionHandler handler = new(apiConn, wfHandler, null, true);
             await handler.Init();
             WfTicket ticket = CreateTicket(CreateEligibleRequestTask(14));
@@ -1351,7 +1351,7 @@ namespace FWO.Test
             apiConn.States = [new WfState { Id = 1 }, new WfState { Id = 2 }, new WfState { Id = 3 }];
             SimulatedGlobalConfig globalConfig = new() { ComplianceCheckRelevantManagements = "1" };
             ActionHandlerTestPolicyChecker policyChecker = new() { Result = true };
-            WfHandler wfHandler = new((_, _, _, _) => { }, new UserConfig(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, policyChecker);
+            WfHandler wfHandler = new((_, _, _, _) => { }, UserConfig.ForTextOnly(globalConfig, false), new System.Security.Claims.ClaimsPrincipal(), apiConn, new MiddlewareClient("http://localhost/"), WorkflowPhases.request, policyChecker);
             ActionHandler handler = new(apiConn, wfHandler, null, true);
             await handler.Init();
             WfReqTask eligibleTask = CreateEligibleRequestTask(15);
@@ -1386,7 +1386,7 @@ namespace FWO.Test
             ActionHandlerTestApiConn apiConn = new();
             apiConn.States = [new WfState { Id = 1 }, new WfState { Id = 2 }, new WfState { Id = 3 }];
             SimulatedGlobalConfig globalConfig = new() { ComplianceCheckRelevantManagements = "1" };
-            WfHandler wfHandler = new(new UserConfig(globalConfig, false), apiConn, WorkflowPhases.request, null, new ActionHandlerTestPolicyChecker() { Result = true });
+            WfHandler wfHandler = new(UserConfig.ForTextOnly(globalConfig, false), apiConn, WorkflowPhases.request, null, new ActionHandlerTestPolicyChecker() { Result = true });
             ActionHandler handler = new(apiConn, wfHandler, null, true);
             await handler.Init();
             WfTicket ticket = CreateTicket(CreateEligibleRequestTask(17));

--- a/roles/tests-unit/files/FWO.Test/AppDataImportTest.cs
+++ b/roles/tests-unit/files/FWO.Test/AppDataImportTest.cs
@@ -1273,7 +1273,7 @@ namespace FWO.Test
 
             Assert.That(imported, Is.True);
             Assert.That(apiConn.LastNewOwnerRecertActive, Is.True);
-            Assert.That(apiConn.GetInitialOwnerRecertCalls, Is.EqualTo(1));
+            Assert.That(apiConn.GetOwnerRecertCalls, Is.EqualTo(1));
             Assert.That(apiConn.RecertifyOwnerCalls, Is.EqualTo(1));
             Assert.That(apiConn.SetOwnerLastRecertCalls, Is.EqualTo(1));
         }
@@ -1300,7 +1300,7 @@ namespace FWO.Test
             bool imported = await InvokeSaveApp(import, incomingApp, new OwnerChangeImportTracker(apiConn));
 
             Assert.That(imported, Is.True);
-            Assert.That(apiConn.GetInitialOwnerRecertCalls, Is.EqualTo(1));
+            Assert.That(apiConn.GetOwnerRecertCalls, Is.EqualTo(1));
             Assert.That(apiConn.RecertifyOwnerCalls, Is.EqualTo(1));
             Assert.That(apiConn.SetOwnerLastRecertCalls, Is.EqualTo(1));
         }
@@ -1325,7 +1325,7 @@ namespace FWO.Test
 
             Assert.That(imported, Is.True);
             Assert.That(apiConn.LastNewOwnerRecertActive, Is.False);
-            Assert.That(apiConn.GetInitialOwnerRecertCalls, Is.EqualTo(0));
+            Assert.That(apiConn.GetOwnerRecertCalls, Is.EqualTo(0));
             Assert.That(apiConn.RecertifyOwnerCalls, Is.EqualTo(0));
             Assert.That(apiConn.SetOwnerLastRecertCalls, Is.EqualTo(0));
         }
@@ -1350,7 +1350,7 @@ namespace FWO.Test
 
             Assert.That(imported, Is.True);
             Assert.That(apiConn.LastNewOwnerRecertActive, Is.True);
-            Assert.That(apiConn.GetInitialOwnerRecertCalls, Is.EqualTo(0));
+            Assert.That(apiConn.GetOwnerRecertCalls, Is.EqualTo(0));
             Assert.That(apiConn.RecertifyOwnerCalls, Is.EqualTo(0));
             Assert.That(apiConn.SetOwnerLastRecertCalls, Is.EqualTo(0));
         }
@@ -1378,7 +1378,7 @@ namespace FWO.Test
 
             Assert.That(imported, Is.True);
             Assert.That(apiConn.LastUpdateOwnerRecertActive, Is.True);
-            Assert.That(apiConn.GetInitialOwnerRecertCalls, Is.EqualTo(1));
+            Assert.That(apiConn.GetOwnerRecertCalls, Is.EqualTo(1));
             Assert.That(apiConn.RecertifyOwnerCalls, Is.EqualTo(1));
             Assert.That(apiConn.SetOwnerLastRecertCalls, Is.EqualTo(1));
         }
@@ -1411,7 +1411,7 @@ namespace FWO.Test
             bool imported = await InvokeSaveApp(import, incomingApp, new OwnerChangeImportTracker(apiConn));
 
             Assert.That(imported, Is.True);
-            Assert.That(apiConn.GetInitialOwnerRecertCalls, Is.EqualTo(1));
+            Assert.That(apiConn.GetOwnerRecertCalls, Is.EqualTo(1));
             Assert.That(apiConn.RecertifyOwnerCalls, Is.EqualTo(0));
             Assert.That(apiConn.SetOwnerLastRecertCalls, Is.EqualTo(0));
         }
@@ -1444,7 +1444,7 @@ namespace FWO.Test
             bool imported = await InvokeSaveApp(import, incomingApp, new OwnerChangeImportTracker(apiConn));
 
             Assert.That(imported, Is.True);
-            Assert.That(apiConn.GetInitialOwnerRecertCalls, Is.EqualTo(1));
+            Assert.That(apiConn.GetOwnerRecertCalls, Is.EqualTo(1));
             Assert.That(apiConn.RecertifyOwnerCalls, Is.EqualTo(0));
             Assert.That(apiConn.SetOwnerLastRecertCalls, Is.EqualTo(0));
         }
@@ -2278,7 +2278,7 @@ namespace FWO.Test
             public Dictionary<string, string>? LastUpdateOwnerAdditionalInfo { get; private set; }
             public bool? LastNewOwnerRecertActive { get; private set; }
             public bool? LastUpdateOwnerRecertActive { get; private set; }
-            public int GetInitialOwnerRecertCalls { get; private set; }
+            public int GetOwnerRecertCalls { get; private set; }
             public int RecertifyOwnerCalls { get; private set; }
             public int SetOwnerLastRecertCalls { get; private set; }
             public List<OwnerRecertification> ExistingInitialOwnerRecerts { get; init; } = [];
@@ -2410,9 +2410,9 @@ namespace FWO.Test
                     });
                 }
 
-                if (query == RecertQueries.getInitialOwnerRecert)
+                if (query == RecertQueries.getOwnerRecert)
                 {
-                    ++GetInitialOwnerRecertCalls;
+                    ++GetOwnerRecertCalls;
                     return Task.FromResult((QueryResponseType)(object)ExistingInitialOwnerRecerts);
                 }
 

--- a/roles/tests-unit/files/FWO.Test/ConfigTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ConfigTest.cs
@@ -6,6 +6,7 @@ using FWO.Config.Api.Data;
 using FWO.Data;
 using FWO.Data.Modelling;
 using FWO.Data.Workflow;
+using FWO.Middleware.Server;
 using NUnit.Framework;
 
 namespace FWO.Test
@@ -18,6 +19,7 @@ namespace FWO.Test
         {
             public int UpsertConfigCallCount { get; private set; }
             public List<ConfigItem> LastConfigItems { get; private set; } = [];
+            public bool IsDisposed { get; private set; }
 
             public override void SetAuthHeader(string jwt) { }
             public override void SetRole(string role) { }
@@ -57,7 +59,10 @@ namespace FWO.Test
             }
 
             public override void DisposeSubscriptions<T>() { }
-            protected override void Dispose(bool disposing) { }
+            protected override void Dispose(bool disposing)
+            {
+                IsDisposed = true;
+            }
 
             public override Task ReconnectSubscriptionsAsync(string jwt, CancellationToken ct)
             {
@@ -127,6 +132,64 @@ namespace FWO.Test
             UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
 
             Assert.That(userConfig.ReqOwnerBased, Is.True);
+        }
+
+        [Test]
+        public void Dispose_DoesNotDisposeApiConnection_WhenNotOwned()
+        {
+            SimulatedGlobalConfig globalConfig = new();
+            using UserConfigApiConnection apiConnection = new([]);
+            using UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
+
+            userConfig.Dispose();
+
+            Assert.That(apiConnection.IsDisposed, Is.False);
+        }
+
+        [Test]
+        public void Dispose_UnsubscribesFromGlobalConfigChange()
+        {
+            SimulatedGlobalConfig globalConfig = new();
+            using UserConfigApiConnection apiConnection = new([]);
+            int initialSubscriberCount = GetOnChangeSubscriberCount(globalConfig);
+            UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
+
+            Assert.That(GetOnChangeSubscriberCount(globalConfig), Is.EqualTo(initialSubscriberCount + 1));
+
+            userConfig.Dispose();
+
+            Assert.That(GetOnChangeSubscriberCount(globalConfig), Is.EqualTo(initialSubscriberCount));
+        }
+
+        [Test]
+        public void Dispose_DisposesApiConnection_WhenOwned()
+        {
+            SimulatedGlobalConfig globalConfig = new();
+            UserConfigApiConnection apiConnection = new([]);
+            using UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection, owningApiConnection: true);
+
+            userConfig.Dispose();
+
+            Assert.That(apiConnection.IsDisposed, Is.True);
+        }
+
+        [Test]
+        public void ImportChangeNotifier_Dispose_UnsubscribesUserConfigWithoutDisposingApiConnection()
+        {
+            SimulatedGlobalConfig globalConfig = new();
+            using UserConfigApiConnection apiConnection = new([]);
+            int initialSubscriberCount = GetOnChangeSubscriberCount(globalConfig);
+            ImportChangeNotifier notifier = new(apiConnection, globalConfig);
+
+            Assert.That(GetOnChangeSubscriberCount(globalConfig), Is.EqualTo(initialSubscriberCount + 1));
+
+            notifier.Dispose();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetOnChangeSubscriberCount(globalConfig), Is.EqualTo(initialSubscriberCount));
+                Assert.That(apiConnection.IsDisposed, Is.False);
+            });
         }
 
         [Test]
@@ -338,6 +401,14 @@ namespace FWO.Test
                 ?? throw new MissingMethodException(typeof(FWO.Config.Api.Config).FullName, "Update");
 
             updateMethod.Invoke(config, [configItems]);
+        }
+
+        private static int GetOnChangeSubscriberCount(FWO.Config.Api.Config config)
+        {
+            FieldInfo onChangeField = typeof(FWO.Config.Api.Config).GetField("OnChange", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new MissingFieldException(typeof(FWO.Config.Api.Config).FullName, "OnChange");
+
+            return ((Delegate?)onChangeField.GetValue(config))?.GetInvocationList().Length ?? 0;
         }
     }
 }

--- a/roles/tests-unit/files/FWO.Test/ConfigTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ConfigTest.cs
@@ -193,6 +193,27 @@ namespace FWO.Test
         }
 
         [Test]
+        public void AppDataImport_Dispose_UnsubscribesUserConfigWithoutDisposingApiConnection()
+        {
+            SimulatedGlobalConfig globalConfig = new();
+            using UserConfigApiConnection apiConnection = new([]);
+            int initialSubscriberCount = GetOnChangeSubscriberCount(globalConfig);
+            UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
+            AppDataImport appDataImport = new(apiConnection, globalConfig);
+            SetPrivateField(appDataImport, "userConfig", userConfig);
+
+            Assert.That(GetOnChangeSubscriberCount(globalConfig), Is.EqualTo(initialSubscriberCount + 1));
+
+            appDataImport.Dispose();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetOnChangeSubscriberCount(globalConfig), Is.EqualTo(initialSubscriberCount));
+                Assert.That(apiConnection.IsDisposed, Is.False);
+            });
+        }
+
+        [Test]
         public void Constructor_DoesNotOverwriteUserSpecificConfigWithGlobalValues()
         {
             SimulatedGlobalConfig globalConfig = new();
@@ -409,6 +430,14 @@ namespace FWO.Test
                 ?? throw new MissingFieldException(typeof(FWO.Config.Api.Config).FullName, "OnChange");
 
             return ((Delegate?)onChangeField.GetValue(config))?.GetInvocationList().Length ?? 0;
+        }
+
+        private static void SetPrivateField(object target, string fieldName, object value)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new MissingFieldException(target.GetType().FullName, fieldName);
+
+            field.SetValue(target, value);
         }
     }
 }

--- a/roles/tests-unit/files/FWO.Test/ConfigTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ConfigTest.cs
@@ -95,6 +95,41 @@ namespace FWO.Test
         }
 
         [Test]
+        public void TextOnlyFactory_DoesNotExposePublicGlobalConfigConstructor()
+        {
+            ConstructorInfo? constructor = typeof(UserConfig).GetConstructor(
+                [typeof(GlobalConfig), typeof(bool)]);
+
+            Assert.That(constructor, Is.Null);
+        }
+
+        [Test]
+        public void TextOnlyFactory_DoesNotApplyDirectConfigValues()
+        {
+            SimulatedGlobalConfig globalConfig = new();
+            globalConfig.RawConfigItems =
+            [
+                new() { Key = "reqOwnerBased", Value = "true", User = 0 }
+            ];
+
+            UserConfig userConfig = UserConfig.ForTextOnly(globalConfig);
+
+            Assert.That(userConfig.ReqOwnerBased, Is.False);
+        }
+
+        [Test]
+        public void GlobalSettingsFactory_LoadsDirectConfigValues()
+        {
+            SimulatedGlobalConfig globalConfig = new();
+            using UserConfigApiConnection apiConnection =
+                new([new() { Key = "reqOwnerBased", Value = "true", User = 0 }]);
+
+            UserConfig userConfig = UserConfig.ForGlobalSettings(globalConfig, apiConnection);
+
+            Assert.That(userConfig.ReqOwnerBased, Is.True);
+        }
+
+        [Test]
         public void Constructor_DoesNotOverwriteUserSpecificConfigWithGlobalValues()
         {
             SimulatedGlobalConfig globalConfig = new();
@@ -154,7 +189,7 @@ namespace FWO.Test
                     new() { Key = "OwnerSoruceMappingID", Value = "0", User = 0 }
                 ]
             };
-            UserConfig userConfig = new(globalConfig);
+            UserConfig userConfig = UserConfig.ForTextOnly(globalConfig);
             ConfigData editableConfig = await globalConfig.GetEditableConfig();
             editableConfig.OwnerSoruceMappingID = 2;
 

--- a/roles/tests-unit/files/FWO.Test/ExtTicketHandlerTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ExtTicketHandlerTest.cs
@@ -155,7 +155,7 @@ namespace FWO.Test
             {
                 DefaultLanguage = "English"
             };
-            UserConfig localUserConfig = new(localGlobalConfig, registerOnChangeHandler: false);
+            UserConfig localUserConfig = UserConfig.ForTextOnly(localGlobalConfig, registerOnChangeHandler: false);
 
             using (ExternalRequestHandler externalRequestHandler = new(localUserConfig, apiConnection, null))
             {

--- a/roles/tests-unit/files/FWO.Test/Fixtures/ComplianceCheckTestFixture.cs
+++ b/roles/tests-unit/files/FWO.Test/Fixtures/ComplianceCheckTestFixture.cs
@@ -31,7 +31,7 @@ namespace FWO.Test.Fixtures
             ApiConnection = new();
             Logger = new();
             GlobalConfig = new SimulatedGlobalConfig { AutoCalculateInternetZone = true, AutoCalculateUndefinedInternalZone = true, TreatDynamicAndDomainObjectsAsInternet = true };
-            UserConfig = new UserConfig(GlobalConfig, false);
+            UserConfig = UserConfig.ForTextOnly(GlobalConfig, false);
 
             SimulatedUserConfig.DummyTranslate["internet_local_zone"] = "Internet/Local";
             SimulatedUserConfig.DummyTranslate["assess_broadcast"] = "Network objects in source or destination with 255.255.255.255/32";

--- a/roles/tests-unit/files/FWO.Test/NotificationTest.cs
+++ b/roles/tests-unit/files/FWO.Test/NotificationTest.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using FWO.Api.Client;
+using FWO.Config.Api;
 using FWO.Data;
 using FWO.Data.Report;
 using FWO.Middleware.Server;
@@ -55,7 +56,7 @@ namespace FWO.Test
             NotificationService notificationService = await NotificationService.CreateAsync(NotificationClient.Recertification, globalConfig, apiConnection, ownerGroups);
             FwoOwner owner = new() { NextRecertDate = DateTime.Now.AddDays(21) };
 
-            int emailsSent = await notificationService.SendNotificationsIfDue(owner, null, EmailText, new ReportRecertEvent(new(""), new(globalConfig), Basics.ReportType.RecertificationEvent) { });
+            int emailsSent = await notificationService.SendNotificationsIfDue(owner, null, EmailText, new ReportRecertEvent(new(""), UserConfig.ForTextOnly(globalConfig), Basics.ReportType.RecertificationEvent) { });
             ClassicAssert.AreEqual(1, emailsSent);
 
             notificationService.Notifications[0].LastSent = DateTime.Now;

--- a/roles/tests-unit/files/FWO.Test/ReportComplianceTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ReportComplianceTest.cs
@@ -21,7 +21,7 @@ namespace FWO.Test
             _testReport = _complianceReport;
             SimulatedGlobalConfig globalConfig = new();
             globalConfig.ComplianceCheckMaxPrintedViolations = 2;
-            UserConfig userConfig = new(globalConfig);
+            UserConfig userConfig = UserConfig.ForTextOnly(globalConfig);
 
             _testDiffReport = new(new(""), userConfig, Basics.ReportType.ComplianceDiffReport);
             ;
@@ -152,7 +152,7 @@ namespace FWO.Test
             {
                 ComplianceCheckRelevantManagements = "9,10"
             };
-            UserConfig userConfig = new(globalConfig);
+            UserConfig userConfig = UserConfig.ForTextOnly(globalConfig);
             MockReportCompliance report = new(new(""), userConfig, Basics.ReportType.ComplianceReport);
 
             Dictionary<string, object> queryVariables = report.CreateQueryVariablesPublic(0, 100, RuleQueries.getRulesWithCurrentViolationsByChunk);

--- a/roles/tests-unit/files/FWO.Test/ReportFiltersTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ReportFiltersTest.cs
@@ -128,7 +128,7 @@ namespace FWO.Test
         public void Init_CopiesGlobalDefaultForIncludeObjectChanges()
         {
             SimulatedGlobalConfig globalConfig = new() { ImpChangeIncludeObjectChanges = true };
-            UserConfig userConfig = new(globalConfig, registerOnChangeHandler: false);
+            UserConfig userConfig = UserConfig.ForTextOnly(globalConfig, registerOnChangeHandler: false);
             ReportFilters filters = new();
 
             filters.Init(userConfig, true);

--- a/roles/tests-unit/files/FWO.Test/RuleControllerWiringTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleControllerWiringTest.cs
@@ -125,7 +125,7 @@ namespace FWO.Test
             globalConfig.CustomFieldOwnerKey = @"[""owner_key""]";
             globalConfig.CustomFieldChangeIdKey = @"[""change_key""]";
 
-            return new UserConfig(globalConfig, registerOnChangeHandler: false);
+            return UserConfig.ForTextOnly(globalConfig, registerOnChangeHandler: false);
         }
 
         private static Rule CreateRule(int ownerId, string customFields)

--- a/roles/tests-unit/files/FWO.Test/UiEditOwnerTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiEditOwnerTest.cs
@@ -274,7 +274,7 @@ namespace FWO.Test
             await (Task)GetPrivateMethod("HandleSave").Invoke(editOwner.Instance, null)!;
 
             Assert.That(owner.Id, Is.EqualTo(apiConn.CreatedOwnerId));
-            Assert.That(apiConn.GetInitialOwnerRecertCalls, Is.EqualTo(1));
+            Assert.That(apiConn.GetOwnerRecertCalls, Is.EqualTo(1));
             Assert.That(apiConn.RecertifyOwnerCalls, Is.EqualTo(1));
             Assert.That(apiConn.SetOwnerLastRecertCalls, Is.EqualTo(1));
         }
@@ -442,7 +442,7 @@ namespace FWO.Test
     internal sealed class EditOwnerTestApiConn : SimulatedApiConnection
     {
         public int CreatedOwnerId { get; set; } = 77;
-        public int GetInitialOwnerRecertCalls { get; private set; }
+        public int GetOwnerRecertCalls { get; private set; }
         public int RecertifyOwnerCalls { get; private set; }
         public int SetOwnerLastRecertCalls { get; private set; }
 
@@ -489,9 +489,9 @@ namespace FWO.Test
                 return Task.FromResult((QueryResponseType)(object)new List<ConfigItem>());
             }
 
-            if (query == RecertQueries.getInitialOwnerRecert)
+            if (query == RecertQueries.getOwnerRecert)
             {
-                GetInitialOwnerRecertCalls++;
+                GetOwnerRecertCalls++;
                 return Task.FromResult((QueryResponseType)(object)new List<OwnerRecertification>());
             }
 

--- a/roles/tests-unit/files/FWO.Test/UiRequestRecertPopupTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiRequestRecertPopupTest.cs
@@ -1,0 +1,166 @@
+using Bunit;
+using FWO.Api.Client;
+using FWO.Api.Client.Queries;
+using FWO.Basics;
+using FWO.Config.Api;
+using FWO.Data;
+using FWO.Data.Modelling;
+using FWO.Data.Workflow;
+using FWO.Middleware.Client;
+using FWO.Services;
+using FWO.Services.RuleTreeBuilder;
+using FWO.Ui.Pages.NetworkModelling;
+using FWO.Ui.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System.Security.Claims;
+
+namespace FWO.Test
+{
+    [TestFixture]
+    internal class UiRequestRecertPopupTest
+    {
+        [Test]
+        public void CheckImplementation_RunsVarianceQueriesWithBestRole()
+        {
+            RequestRecertPopupTestApiConn apiConn = new();
+            SimulatedUserConfig userConfig = CreateUserConfig();
+            FwoOwner selectedApp = new() { Id = 7, Name = "App" };
+            ModellingAppHandler appHandler = new(apiConn, userConfig, selectedApp, DefaultInit.DoNothing, true)
+            {
+                Connections = [CreateConnection(41)]
+            };
+
+            using BunitContext context = new();
+            IRenderedComponent<CascadingAuthenticationState> wrapper = RenderPopup(context, apiConn, userConfig, appHandler);
+
+            wrapper.WaitForAssertion(() =>
+            {
+                Assert.That(apiConn.WasOnlySentWithBestRole(DeviceQueries.getManagementNames), Is.True);
+                Assert.That(apiConn.WasOnlySentWithBestRole(ModellingQueries.getNwGroupObjects), Is.True);
+                Assert.That(apiConn.WasOnlySentWithBestRole(ModellingQueries.getAppZonesByAppId), Is.True);
+            });
+        }
+
+        private static IRenderedComponent<CascadingAuthenticationState> RenderPopup(BunitContext context, RequestRecertPopupTestApiConn apiConn, SimulatedUserConfig userConfig, ModellingAppHandler appHandler)
+        {
+            context.JSInterop.Mode = JSRuntimeMode.Loose;
+            context.Services.AddAuthorizationCore();
+            context.Services.AddLocalization();
+            context.Services.AddSingleton<IAuthorizationService, AllowAllAuthorizationService>();
+            context.Services.AddSingleton<AuthenticationStateProvider>(new RequestRecertPopupAuthStateProvider(Roles.Auditor));
+            context.Services.AddSingleton<ApiConnection>(apiConn);
+            context.Services.AddSingleton(new MiddlewareClient("http://localhost/"));
+            context.Services.AddSingleton<UserConfig>(userConfig);
+            context.Services.AddSingleton<IRuleTreeBuilder, RuleTreeBuilder>();
+
+            return context.Render<CascadingAuthenticationState>(parameters => parameters
+                .AddChildContent<RequestRecertPopup>(child => child
+                    .Add(p => p.Display, true)
+                    .Add(p => p.AppHandler, appHandler)
+                    .Add(p => p.CanRecertify, true)));
+        }
+
+        private static SimulatedUserConfig CreateUserConfig()
+        {
+            return new()
+            {
+                ModNamingConvention = "{}",
+                ModIntegrationMode = ModIntegrationMode.FullyIntegrated,
+                ModModelledMarker = "FWO:",
+                User = { Ownerships = [7], Roles = [Roles.Auditor] }
+            };
+        }
+
+        private static ModellingConnection CreateConnection(int id)
+        {
+            return new()
+            {
+                Id = id,
+                Name = $"Conn{id}",
+                SourceAppRoles =
+                [
+                    new() { Content = new() { Id = 101, IdString = "AR1", Name = "AR1" } }
+                ],
+                DestinationAppServers =
+                [
+                    new() { Content = new() { Id = 201, Name = "Server1", Ip = "10.0.1.1/32" } }
+                ],
+                Services =
+                [
+                    new() { Content = new() { Id = 301, Name = "HTTPS", ProtoId = 6, Port = 443 } }
+                ]
+            };
+        }
+
+        private sealed class RequestRecertPopupAuthStateProvider : AuthenticationStateProvider
+        {
+            private readonly ClaimsPrincipal principal;
+
+            public RequestRecertPopupAuthStateProvider(params string[] roles)
+            {
+                List<Claim> claims = [.. roles.Select(role => new Claim(ClaimTypes.Role, role))];
+                principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+            }
+
+            public override Task<AuthenticationState> GetAuthenticationStateAsync()
+            {
+                return Task.FromResult(new AuthenticationState(principal));
+            }
+        }
+
+        private sealed class RequestRecertPopupTestApiConn : SimulatedApiConnection
+        {
+            private int bestRoleDepth;
+            private readonly List<(string Query, bool WithBestRole)> queries = [];
+
+            public override void SetBestRole(ClaimsPrincipal user, List<string> targetRoleList)
+            {
+                bestRoleDepth++;
+            }
+
+            public override void SwitchBack()
+            {
+                bestRoleDepth--;
+            }
+
+            public bool WasOnlySentWithBestRole(string query)
+            {
+                List<(string Query, bool WithBestRole)> matchingQueries = [.. queries.Where(q => q.Query == query)];
+                return matchingQueries.Count > 0 && matchingQueries.All(q => q.WithBestRole);
+            }
+
+            public override Task<QueryResponseType> SendQueryAsync<QueryResponseType>(string query, object? variables = null, string? operationName = null, QueryChunkingOptions? chunkingOptions = null)
+            {
+                queries.Add((query, bestRoleDepth > 0));
+                if (query == ExtRequestQueries.getLatestTicketId)
+                {
+                    return Task.FromResult((QueryResponseType)(object)new List<TicketId>());
+                }
+                if (query == RequestQueries.getExtStates)
+                {
+                    return Task.FromResult((QueryResponseType)(object)new List<WfExtState>
+                    {
+                        new() { Name = ExtStates.ExtReqDone.ToString(), StateId = 90 },
+                        new() { Name = ExtStates.ExtReqRejected.ToString(), StateId = 91 }
+                    });
+                }
+                if (query == DeviceQueries.getManagementNames)
+                {
+                    return Task.FromResult((QueryResponseType)(object)new List<Management>());
+                }
+                if (query == ModellingQueries.getNwGroupObjects)
+                {
+                    return Task.FromResult((QueryResponseType)(object)new List<ModellingNetworkArea>());
+                }
+                if (query == ModellingQueries.getAppZonesByAppId)
+                {
+                    return Task.FromResult((QueryResponseType)(object)new List<ModellingAppZone>());
+                }
+                throw new AssertionException($"Unexpected query: {query}");
+            }
+        }
+    }
+}

--- a/roles/tests-unit/files/FWO.Test/UiZoneMatrixTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiZoneMatrixTest.cs
@@ -24,7 +24,7 @@ namespace FWO.Test
 
             SimulatedGlobalConfig globalConfig = new();
             globalConfig.ComplianceCheckSortMatrixByID = sortById;
-            _userConfig = new(globalConfig);
+            _userConfig = UserConfig.ForTextOnly(globalConfig);
 
             // Set up NetworkZoneService.
 

--- a/roles/ui/files/FWO.UI/Pages/Logout.razor
+++ b/roles/ui/files/FWO.UI/Pages/Logout.razor
@@ -1,5 +1,4 @@
 ﻿
-@using FWO.Middleware.Client;
 @using Microsoft.AspNetCore.Components.Server.Circuits;
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using FWO.Ui.Services
@@ -10,8 +9,6 @@
 @inject NavigationManager NavigationManager
 @inject UserConfig userConfig
 @inject CircuitHandler circuitHandler
-@inject ApiConnection apiConnection
-@inject MiddlewareClient middlewareClient
 
 @page "/logout"
 
@@ -34,9 +31,6 @@
         }
         finally
         {
-            apiConnection.Dispose();
-            middlewareClient.Dispose();
-
             Log.WriteAudit("Logout", $"User \"{user.Name}\" with DN: \"{user.Dn}\" logged out.");
             ((CircuitHandlerService)circuitHandler).User = null;
 

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/NetworkModelling.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/NetworkModelling.razor
@@ -636,7 +636,8 @@ else
     {
         try
         {
-            List<ExternalRequest> lastRequests = await apiConnection.SendQueryAsync<List<ExternalRequest>>(ExtRequestQueries.getLastRequest, new{ticketId = intTicket.Id});
+            List<ExternalRequest> lastRequests = await apiConnection.RunWithBestRole(authenticationStateTask!.Result.User, [Roles.Modeller, Roles.Admin, Roles.Auditor],
+                async () => await apiConnection.SendQueryAsync<List<ExternalRequest>>(ExtRequestQueries.getLastRequest, new{ticketId = intTicket.Id}));
             if(lastRequests != null && lastRequests.Count > 0)
             {
                 bool shortened = false;

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/RequestFwChangePopup.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/RequestFwChangePopup.razor
@@ -145,7 +145,8 @@
     {
         try
         {
-            extStateHandler = new(apiConnection);
+            extStateHandler = await apiConnection.RunWithBestRole(authenticationStateTask!.Result.User, [Roles.Modeller, Roles.Admin, Roles.Auditor],
+                () => Task.FromResult(new ExtStateHandler(apiConnection)));
             ipProtos = await apiConnection.SendQueryAsync<List<IpProtocol>>(StmQueries.getIpProtocols);
             Devices = await apiConnection.SendQueryAsync<List<Device>>(DeviceQueries.getDeviceDetails);
         }
@@ -206,7 +207,8 @@
     private async Task<bool> GetActTicketStatus()
     {
         LastRequestStartedAt = null;
-        WfTicket? intTicket = await ModellingAppHandler.GetLatestFWRequestTicket(SelectedApp, apiConnection);
+        WfTicket? intTicket = await apiConnection.RunWithBestRole(authenticationStateTask!.Result.User, [Roles.Modeller, Roles.Admin, Roles.Auditor],
+            async () => await ModellingAppHandler.GetLatestFWRequestTicket(SelectedApp, apiConnection));
         if (intTicket != null)
         {
             LastRequestStartedAt = intTicket.CreationDate;

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/RequestRecertPopup.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/RequestRecertPopup.razor
@@ -236,16 +236,21 @@
 
     private async Task<bool> CheckImplementation()
     {
-        ExtStateHandler extStateHandler = await apiConnection.RunWithBestRole(authenticationStateTask!.Result.User, [Roles.Modeller, Roles.Admin, Roles.Auditor],
-            () => Task.FromResult(new ExtStateHandler(apiConnection)));
-        ModellingVarianceAnalysis varianceAnalysis = new(apiConnection, extStateHandler, userConfig, AppHandler!.Application, DisplayMessageInUi);
-        ModellingFilter modellingFilter = new()
-        {
-            SelectedOwner = AppHandler!.Application,
-            AnalyseRemainingRules = userConfig.ModRecertExpectAllModelled,
-            RulesForDeletedConns = true
-        };
-        VarianceResult = await varianceAnalysis.AnalyseRulesVsModelledConnections(ModelledConnections, modellingFilter, true, true);
+        (VarianceResult, AppZoneModelled, MgmIdsWithDifferingAZ) = await apiConnection.RunWithBestRole(authenticationStateTask!.Result.User, [Roles.Modeller, Roles.Admin, Roles.Auditor],
+            async () =>
+            {
+                ExtStateHandler extStateHandler = new(apiConnection);
+                ModellingVarianceAnalysis varianceAnalysis = new(apiConnection, extStateHandler, userConfig, AppHandler!.Application, DisplayMessageInUi);
+                ModellingFilter modellingFilter = new()
+                {
+                    SelectedOwner = AppHandler!.Application,
+                    AnalyseRemainingRules = userConfig.ModRecertExpectAllModelled,
+                    RulesForDeletedConns = true
+                };
+                ModellingVarianceResult varianceResult = await varianceAnalysis.AnalyseRulesVsModelledConnections(ModelledConnections, modellingFilter, true, true);
+                (bool appZoneModelled, List<ModellingAppZone?> mgmIdsWithDifferingAZ) = await varianceAnalysis.CheckExistingAppZone();
+                return (varianceResult, appZoneModelled, mgmIdsWithDifferingAZ);
+            });
         RulesFromDeletedConns = [];
         foreach(var mgt in VarianceResult.DeletedModelsRules.Keys)
         {
@@ -256,7 +261,6 @@
         {
             UnmodelledRules.AddRange(VarianceResult.UnModelledRules[mgt]);
         }
-        (AppZoneModelled, MgmIdsWithDifferingAZ) = await varianceAnalysis.CheckExistingAppZone();
 
         return MissingAppRoles.Count == 0 && DifferingAppRoles.Count == 0 && RulesFromDeletedConns.Count == 0 && UnmodelledRules.Count == 0
             && VarianceResult.ConnsNotImplemented.Count == 0 && VarianceResult.RuleDifferences.Count == 0

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/RequestRecertPopup.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/RequestRecertPopup.razor
@@ -212,10 +212,12 @@
 
     private async Task<bool> CheckRequestRunning()
     {
-        WfTicket? intTicket = await ModellingAppHandler.GetLatestFWRequestTicket(AppHandler!.Application, apiConnection);
+        WfTicket? intTicket = await apiConnection.RunWithBestRole(authenticationStateTask!.Result.User, [Roles.Modeller, Roles.Admin, Roles.Auditor],
+            async () => await ModellingAppHandler.GetLatestFWRequestTicket(AppHandler!.Application, apiConnection));
         if(intTicket != null)
         {
-           ExtStateHandler extStateHandler = new(apiConnection);
+           ExtStateHandler extStateHandler = await apiConnection.RunWithBestRole(authenticationStateTask!.Result.User, [Roles.Modeller, Roles.Admin, Roles.Auditor],
+               () => Task.FromResult(new ExtStateHandler(apiConnection)));
            return extStateHandler.IsInProgress(intTicket.StateId) && intTicket.Tasks.Any(t => extStateHandler.IsInProgress(t.StateId));
         }
         return false;
@@ -234,7 +236,8 @@
 
     private async Task<bool> CheckImplementation()
     {
-        ExtStateHandler extStateHandler = new(apiConnection);
+        ExtStateHandler extStateHandler = await apiConnection.RunWithBestRole(authenticationStateTask!.Result.User, [Roles.Modeller, Roles.Admin, Roles.Auditor],
+            () => Task.FromResult(new ExtStateHandler(apiConnection)));
         ModellingVarianceAnalysis varianceAnalysis = new(apiConnection, extStateHandler, userConfig, AppHandler!.Application, DisplayMessageInUi);
         ModellingFilter modellingFilter = new()
         {

--- a/roles/ui/files/FWO.UI/Program.cs
+++ b/roles/ui/files/FWO.UI/Program.cs
@@ -98,7 +98,7 @@ builder.Services.AddSingleton<GlobalConfig>(_ => globalConfig);
 builder.Services.AddSingleton<IUrlSanitizer, UrlSanitizer>();
 
 // the user's personal config
-builder.Services.AddScoped<UserConfig>(_ => new UserConfig(globalConfig));
+builder.Services.AddScoped<UserConfig>(_ => UserConfig.ForTextOnly(globalConfig));
 
 builder.Services.AddScoped(_ => new NetworkZoneService());
 builder.Services.AddScoped(_ => new DomEventService());


### PR DESCRIPTION
PR #4752 makes UserConfig creation explicit and safer.

It adds ForTextOnly(...) for UI/bootstrap text lookup and ForGlobalSettings(...) for middleware jobs/controllers that need initialized config values, then makes the ambiguous UserConfig(GlobalConfig, ...) constructor private. It updates middleware, UI, and tests to use the appropriate factory, preventing scheduled/background code from accidentally using default config values.

