### PR TITLE
[codex] combine Python dependency bumps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ansible==14.0.0
-cryptography==48.0.1
+cryptography==49.0.0

--- a/roles/importer/files/importer/requirements.txt
+++ b/roles/importer/files/importer/requirements.txt
@@ -5,7 +5,7 @@ python-dateutil==2.9.0.post0
 netaddr==1.3.0
 
 # Crypto (AES/CBC via cryptography.hazmat)
-cryptography==48.0.0
+cryptography==49.0.0
 
 # HTTP / GraphQL stack
 requests==2.34.2
@@ -17,10 +17,10 @@ scrapli==2026.2.20
 scrapli-community==2025.1.30
 
 # Test
-pytest==9.0.3
+pytest==9.1.0
 pytest-mock==3.15.1
 
 # Linting
-ruff==0.15.16
+ruff==0.15.17
 pre-commit==4.6.0
 pyright==1.1.410


### PR DESCRIPTION
## Summary

Combines the currently open Dependabot Python bump PRs into one dependency update against `develop`:

- #4755 `cryptography` 48.0.1 -> 49.0.0 in root `requirements.txt`
- #4757 `cryptography` 48.0.0 -> 49.0.0 in importer requirements
- #4756 `pytest` 9.0.3 -> 9.1.0 in importer requirements
- #4758 `ruff` 0.15.16 -> 0.15.17 in importer requirements

## Validation

- `python3 -m compileall -q roles/importer/files/importer`
- `/tmp/fwo-python-bumps-venv/bin/python -m compileall -q roles/importer/files/importer`
- `/tmp/fwo-python-bumps-venv/bin/pytest -q roles/importer/files/importer/test` -> 229 passed
- commit hooks: passed during `git commit`

Note: the system `pytest` failed before the venv run because the system Python has an older `pydantic` without `TypeAdapter`; the temporary venv was installed from the bumped importer requirements.