### PR TITLE
fix: make supporting responsible non-mandatory

### DIFF
--- a/roles/tests-unit/files/FWO.Test/UiEditOwnerTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiEditOwnerTest.cs
@@ -142,6 +142,43 @@ namespace FWO.Test
         }
 
         [Test]
+        public void EditOwner_MainResponsibleType_IsRequired()
+        {
+            OwnerResponsibleType type = new() { Id = GlobalConst.kOwnerResponsibleTypeMain, Name = "main", Active = true };
+            bool required = (bool)GetPrivateStaticMethod("IsRequiredResponsibleType").Invoke(null, [type])!;
+            Assert.That(required, Is.True);
+        }
+
+        [Test]
+        public void EditOwner_SupportingResponsibleType_IsNotRequired()
+        {
+            OwnerResponsibleType type = new() { Id = GlobalConst.kOwnerResponsibleTypeSupporting, Name = "supporting", Active = true };
+            bool required = (bool)GetPrivateStaticMethod("IsRequiredResponsibleType").Invoke(null, [type])!;
+            Assert.That(required, Is.False);
+        }
+
+        [Test]
+        public async Task EditOwner_SupportingResponsibleLabel_HasNoMandatoryMarker()
+        {
+            await using BunitContext context = new();
+            FwoOwner owner = new() { Id = 0, Name = "Owner A" };
+            List<OwnerResponsibleType> types =
+            [
+                new OwnerResponsibleType { Id = GlobalConst.kOwnerResponsibleTypeMain, Name = "main", Active = true },
+                new OwnerResponsibleType { Id = GlobalConst.kOwnerResponsibleTypeSupporting, Name = "supporting", Active = true }
+            ];
+            IRenderedComponent<EditOwner> editOwner = RenderEditOwner(context, owner, readOnly: false, responsibleTypes: types);
+
+            string mainLabel = (string)GetPrivateMethod("GetResponsibleTypeEditLabel")
+                .Invoke(editOwner.Instance, [types[0]])!;
+            string supportingLabel = (string)GetPrivateMethod("GetResponsibleTypeEditLabel")
+                .Invoke(editOwner.Instance, [types[1]])!;
+
+            Assert.That(mainLabel, Does.EndWith("*"));
+            Assert.That(supportingLabel, Does.Not.Contain("*"));
+        }
+
+        [Test]
         public async Task EditOwner_AddOwnerResponsible_DoesNotDuplicateExistingDn()
         {
             await using BunitContext context = new();

--- a/roles/ui/files/FWO.UI/Pages/Settings/EditOwner.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/EditOwner.razor
@@ -553,8 +553,7 @@
 
     private static bool IsRequiredResponsibleType(OwnerResponsibleType type)
     {
-        return type.Id == GlobalConst.kOwnerResponsibleTypeMain
-            || type.Id == GlobalConst.kOwnerResponsibleTypeSupporting;
+        return type.Id == GlobalConst.kOwnerResponsibleTypeMain;
     }
 
     private bool CheckValues()


### PR DESCRIPTION
The "Supporting responsible" field in the Add/Edit owner dialog was marked with an asterisk (*) as mandatory, but the value was never enforced on save. Per issue #4365 the field is intended to be optional, so drop it from the required responsible types and remove the marker.

Closes #4365