### PR TITLE
fix a ui redirect bug in the login process

### DIFF
--- a/roles/tests-unit/files/FWO.Test/NavigationPathHelperTest.cs
+++ b/roles/tests-unit/files/FWO.Test/NavigationPathHelperTest.cs
@@ -1,0 +1,31 @@
+using FWO.Ui.Services;
+using NUnit.Framework;
+
+namespace FWO.Test
+{
+    [TestFixture]
+    public class NavigationPathHelperTest
+    {
+        private const string kBaseUri = "https://fwo-stest.ruv.de/";
+
+        [TestCase("/networkmodelling/", "networkmodelling")]
+        [TestCase("networkmodelling/", "networkmodelling")]
+        [TestCase("request/tickets/?id=1#details", "request/tickets")]
+        [TestCase("https://fwo-stest.ruv.de/networkmodelling/?id=1#details", "networkmodelling")]
+        [TestCase("HTTPS://FWO-STEST.RUV.DE/NetworkModelling/", "networkmodelling")]
+        public void GetBaseRelativePath_ReturnsLocalPath(string location, string expectedPath)
+        {
+            string path = NavigationPathHelper.GetBaseRelativePath(location, kBaseUri);
+
+            Assert.That(path, Is.EqualTo(expectedPath));
+        }
+
+        [Test]
+        public void GetBaseRelativePath_ReturnsEmptyPathForExternalHttpUri()
+        {
+            string path = NavigationPathHelper.GetBaseRelativePath("https://example.invalid/networkmodelling/", kBaseUri);
+
+            Assert.That(path, Is.Empty);
+        }
+    }
+}

--- a/roles/tests-unit/files/FWO.Test/UiNavigationMenuTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiNavigationMenuTest.cs
@@ -1,0 +1,37 @@
+using Bunit;
+using FWO.Api.Client;
+using FWO.Basics;
+using FWO.Config.Api;
+using FWO.Ui.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace FWO.Test
+{
+    [TestFixture]
+    internal class UiNavigationMenuTest
+    {
+        [Test]
+        public void NavigationMenu_IgnoresDisposedServicesDuringInitialization()
+        {
+            using BunitContext context = new();
+            UserConfig userConfig = new();
+            userConfig.User.Roles = [Roles.Requester];
+            userConfig.Dispose();
+
+            context.Services.AddSingleton<GlobalConfig>(new SimulatedGlobalConfig());
+            context.Services.AddSingleton<UserConfig>(userConfig);
+            context.Services.AddSingleton<ApiConnection>(new DisposedNavigationApiConnection());
+
+            Assert.DoesNotThrow(() => context.Render<NavigationMenu>());
+        }
+
+        private sealed class DisposedNavigationApiConnection : SimulatedApiConnection
+        {
+            public override Task<QueryResponseType> SendQueryAsync<QueryResponseType>(string query, object? variables = null, string? operationName = null, QueryChunkingOptions? chunkingOptions = null)
+            {
+                throw new ObjectDisposedException(nameof(DisposedNavigationApiConnection));
+            }
+        }
+    }
+}

--- a/roles/ui/files/FWO.UI/Services/NavigationPathHelper.cs
+++ b/roles/ui/files/FWO.UI/Services/NavigationPathHelper.cs
@@ -1,0 +1,37 @@
+namespace FWO.Ui.Services
+{
+    public static class NavigationPathHelper
+    {
+        /// <summary>
+        /// Converts a navigation target to a normalized path relative to the UI application.
+        /// </summary>
+        public static string GetBaseRelativePath(string location, string baseUri)
+        {
+            if (string.IsNullOrWhiteSpace(location))
+            {
+                return "";
+            }
+
+            string relativePath = location;
+            if (Uri.TryCreate(location, UriKind.Absolute, out Uri? targetUri) && IsHttpUri(targetUri))
+            {
+                if (!Uri.TryCreate(baseUri, UriKind.Absolute, out Uri? parsedBaseUri) || !parsedBaseUri.IsBaseOf(targetUri))
+                {
+                    return "";
+                }
+
+                relativePath = parsedBaseUri.MakeRelativeUri(targetUri).ToString();
+            }
+
+            return relativePath.Split(['?', '#'])[0].Trim('/').ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Determines whether the URI uses an HTTP scheme handled by Blazor navigation.
+        /// </summary>
+        private static bool IsHttpUri(Uri uri)
+        {
+            return uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps;
+        }
+    }
+}

--- a/roles/ui/files/FWO.UI/Shared/MainLayout.razor
+++ b/roles/ui/files/FWO.UI/Shared/MainLayout.razor
@@ -235,10 +235,7 @@
 
     private string GetRelativeLocationPath(string location)
     {
-        string relativePath = Uri.TryCreate(location, UriKind.Absolute, out _)
-            ? NavigationManager.ToBaseRelativePath(location)
-            : location;
-        return relativePath.Split(['?', '#'])[0].Trim('/').ToLowerInvariant();
+        return NavigationPathHelper.GetBaseRelativePath(location, NavigationManager.BaseUri);
     }
 
     private static List<string> GetRequestAmbientRoles(string path)

--- a/roles/ui/files/FWO.UI/Shared/NavigationMenu.razor
+++ b/roles/ui/files/FWO.UI/Shared/NavigationMenu.razor
@@ -147,42 +147,74 @@
     private StateMatrix stateMatrix = new();
     private List<Module> availableModules { get; set; } = [];
     private bool InitComplete = false;
+    private bool disposed = false;
     private string displayedExecutionMode = GlobalConst.kUserRolesSelection;
 
 
     protected override async Task OnInitializedAsync()
     {
-        userConfig.OnChange += OnChange;
-        apiConnection.OnExecutionModeChanged += OnExecutionModeChanged;
-        displayedExecutionMode = userConfig.ExecutionMode;
         try
         {
+            userConfig.OnChange += OnChange;
+            apiConnection.OnExecutionModeChanged += OnExecutionModeChanged;
+            displayedExecutionMode = userConfig.ExecutionMode;
+
             if (RequiresWorkflowStateInitialization())
             {
                 await stateMatrix.Init(WorkflowPhases.request, apiConnection);
 
+                if (disposed)
+                {
+                    return;
+                }
+
                 ConfigureFirstWorkflowPage();
+            }
+
+            if (disposed)
+            {
+                return;
             }
 
             availableModules = string.IsNullOrEmpty(userConfig.AvailableModules) ? [.. Enum.GetValues(typeof(Module)).Cast<Module>()]
                 : JsonSerializer.Deserialize<List<Module>>(userConfig.AvailableModules) ?? throw new JsonException("Config data could not be parsed.");
         }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
         catch (Exception exception)
         {
-            DisplayMessageInUi(exception, userConfig.GetText("init_environment"), "", true);
+            if (!disposed)
+            {
+                DisplayMessageInUi(exception, GetTextOrDefault("init_environment"), "", true);
+            }
         }
         InitComplete = true;
     }
 
     private void OnExecutionModeChanged(object? sender, string executionMode)
     {
-        Task.Run(async () => await InvokeAsync(() =>
+        if (disposed)
         {
+            return;
+        }
+
+        _ = InvokeAsync(() =>
+        {
+            if (disposed)
+            {
+                return;
+            }
+
             displayedExecutionMode = executionMode;
             firstWorkflowPage = "";
-            ConfigureFirstWorkflowPage();
+            if (stateMatrix.PhaseActive.Count > 0)
+            {
+                ConfigureFirstWorkflowPage();
+            }
             StateHasChanged();
-        }));
+        });
     }
 
     private void ConfigureFirstWorkflowPage()
@@ -219,12 +251,23 @@
         collapseNavMenu = !collapseNavMenu;
     }
 
-    private void OnChange(Config _, ConfigItem[] __)
-	{
-		availableModules = string.IsNullOrEmpty(userConfig.AvailableModules) ? [.. Enum.GetValues(typeof(Module)).Cast<Module>()]
-			: JsonSerializer.Deserialize<List<Module>>(userConfig.AvailableModules) ?? throw new JsonException("Config data could not be parsed.");
+    private void OnChange(Config config, ConfigItem[] configItems)
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        availableModules = string.IsNullOrEmpty(userConfig.AvailableModules) ? [.. Enum.GetValues(typeof(Module)).Cast<Module>()]
+            : JsonSerializer.Deserialize<List<Module>>(userConfig.AvailableModules) ?? throw new JsonException("Config data could not be parsed.");
         displayedExecutionMode = userConfig.ExecutionMode;
-        Task.Run(async () => await InvokeAsync(StateHasChanged));
+        _ = InvokeAsync(() =>
+        {
+            if (!disposed)
+            {
+                StateHasChanged();
+            }
+        });
     }
 
     private bool RequiresWorkflowStateInitialization()
@@ -265,9 +308,22 @@
         return executionMode == GlobalConst.kUserRolesSelection ? userConfig.GetText("user_roles") : executionMode;
     }
 
-	public void Dispose()
-	{
-		userConfig.OnChange -= OnChange;
+    private string GetTextOrDefault(string key)
+    {
+        try
+        {
+            return userConfig.GetText(key);
+        }
+        catch (ObjectDisposedException)
+        {
+            return key;
+        }
+    }
+
+    public void Dispose()
+    {
+        disposed = true;
+        userConfig.OnChange -= OnChange;
         apiConnection.OnExecutionModeChanged -= OnExecutionModeChanged;
-	}
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two independent issues in the UI login/navigation flow.

### 1. Redirect bug (absolute URL handling)
`MainLayout.GetRelativeLocationPath` relied on `NavigationManager.ToBaseRelativePath`, which throws when the navigation URI is not contained by the base URI (e.g. host/scheme casing mismatches behind a reverse proxy). This surfaced as a failed redirect during login.

- Extracted the path normalization into a testable `NavigationPathHelper.GetBaseRelativePath` helper that uses `IsBaseOf`/`MakeRelativeUri` and returns an empty path for foreign URIs instead of throwing.

### 2. Race condition during login teardown
When the Blazor circuit is torn down mid-initialization, scoped services (`UserConfig`, `ApiConnection`) can be disposed while `NavigationMenu.OnInitializedAsync` is still running. The previous error handler then called `userConfig.GetText(...)` on a disposed config, producing an unhandled `ObjectDisposedException`.

- Added a `disposed` guard with post-`await` checks and dedicated `ObjectDisposedException` handling.
- Guarded `ConfigureFirstWorkflowPage` against an uninitialized state matrix (`PhaseActive.Count > 0`) to avoid `KeyNotFoundException`.
- Replaced `Task.Run(async () => await InvokeAsync(...))` with a direct `InvokeAsync(...)` call.

## Tests
- `NavigationPathHelperTest` covers relative, absolute, query/fragment, casing, and external-URI cases.
- `UiNavigationMenuTest` verifies the menu renders without throwing when services are already disposed.
