### PR TITLE
fix AuthStateProvider

### DIFF
--- a/roles/lib/files/FWO.Middleware.Client/JwtReader.cs
+++ b/roles/lib/files/FWO.Middleware.Client/JwtReader.cs
@@ -73,7 +73,7 @@ namespace FWO.Middleware.Client
 
                 JsonWebTokenHandler handler = new();
                 TokenValidationResult tokenValidationResult = await handler.ValidateTokenAsync(jwtString, validationParameters);
-                
+
                 if (tokenValidationResult.IsValid)
                 {
                     jwt = tokenValidationResult.SecurityToken as JsonWebToken;
@@ -88,7 +88,7 @@ namespace FWO.Middleware.Client
                 if (tokenValidationResult.Exception is SecurityTokenExpiredException)
                 {
                     Log.WriteDebug(JwtValidation, $"Jwt lifetime expired: {jwtString}.");
-                    
+
                     return new JwtValidationResult
                     {
                         Status = JwtValidationStatus.Expired
@@ -114,7 +114,7 @@ namespace FWO.Middleware.Client
             catch (SecurityTokenInvalidSignatureException InvalidSignatureException)
             {
                 Log.WriteError(JwtValidation, $"Jwt signature could not be verified. Potential attack: {jwtString}.", InvalidSignatureException);
-                
+
                 return new JwtValidationResult
                 {
                     Status = JwtValidationStatus.Invalid
@@ -123,7 +123,7 @@ namespace FWO.Middleware.Client
             catch (SecurityTokenInvalidAudienceException InvalidAudienceException)
             {
                 Log.WriteError(JwtValidation, $"Jwt audience incorrect: {jwtString}.", InvalidAudienceException);
-                
+
                 return new JwtValidationResult
                 {
                     Status = JwtValidationStatus.Invalid
@@ -132,7 +132,7 @@ namespace FWO.Middleware.Client
             catch (SecurityTokenInvalidIssuerException InvalidIssuerException)
             {
                 Log.WriteError(JwtValidation, $"Jwt issuer incorrect: {jwtString}.", InvalidIssuerException);
-                
+
                 return new JwtValidationResult
                 {
                     Status = JwtValidationStatus.Invalid
@@ -141,7 +141,7 @@ namespace FWO.Middleware.Client
             catch (Exception UnexpectedError)
             {
                 Log.WriteError(JwtValidation, $"Unexpected problem while trying to verify Jwt: {jwtString}.", UnexpectedError);
-                
+
                 return new JwtValidationResult
                 {
                     Status = JwtValidationStatus.Invalid

--- a/roles/tests-unit/files/FWO.Test/AuthStateProviderTest.cs
+++ b/roles/tests-unit/files/FWO.Test/AuthStateProviderTest.cs
@@ -78,7 +78,7 @@ namespace FWO.Test
         }
 
         [Test]
-        public async Task RestoreAuthenticationState_WhenRefreshFails_ShouldClearStoredTokenPairAndPublishReloginRequiredEvent()
+        public async Task RestoreAuthenticationState_WhenRefreshFails_ShouldClearStoredTokenPairAndKeepAuthenticatedUserForRelogin()
         {
             using RSA rsa = RSA.Create(2048);
             RsaSecurityKey privateKey = new(rsa.ExportParameters(true));
@@ -116,9 +116,9 @@ namespace FWO.Test
             AuthenticationState authenticationState = await authStateProvider.GetAuthenticationStateAsync();
 
             Assert.That(restored, Is.False);
-            Assert.That(authenticationState.User.Identity?.IsAuthenticated, Is.False);
+            Assert.That(authenticationState.User.Identity?.IsAuthenticated, Is.True);
             Assert.That(mockMiddlewareClient.RefreshTokenCallCount, Is.EqualTo(1));
-            Assert.That(mockMiddlewareClient.RevokeRefreshTokenCallCount, Is.EqualTo(1));
+            Assert.That(mockMiddlewareClient.RevokeRefreshTokenCallCount, Is.EqualTo(0));
             Assert.That(publishCount, Is.EqualTo(1));
             Assert.That(publishedUserDn, Is.EqualTo(TestApiConnection.TestUserDn));
             Assert.That(await tokenService.GetTokenPair(), Is.Null);

--- a/roles/tests-unit/files/FWO.Test/AuthStateProviderTest.cs
+++ b/roles/tests-unit/files/FWO.Test/AuthStateProviderTest.cs
@@ -118,7 +118,7 @@ namespace FWO.Test
             Assert.That(restored, Is.False);
             Assert.That(authenticationState.User.Identity?.IsAuthenticated, Is.True);
             Assert.That(mockMiddlewareClient.RefreshTokenCallCount, Is.EqualTo(1));
-            Assert.That(mockMiddlewareClient.RevokeRefreshTokenCallCount, Is.EqualTo(0));
+            Assert.That(mockMiddlewareClient.RevokeRefreshTokenCallCount, Is.EqualTo(1));
             Assert.That(publishCount, Is.EqualTo(1));
             Assert.That(publishedUserDn, Is.EqualTo(TestApiConnection.TestUserDn));
             Assert.That(await tokenService.GetTokenPair(), Is.Null);

--- a/roles/ui/files/FWO.UI/Auth/AuthStateProvider.cs
+++ b/roles/ui/files/FWO.UI/Auth/AuthStateProvider.cs
@@ -272,7 +272,7 @@ namespace FWO.Ui.Auth
         private async Task HandleExpiredSessionAsync()
         {
             PublishReloginRequiredForAuthenticatedUser();
-            await tokenService.ClearStoredTokenPair();
+            await tokenService.RevokeTokens();
         }
 
         /// <summary>

--- a/roles/ui/files/FWO.UI/Auth/AuthStateProvider.cs
+++ b/roles/ui/files/FWO.UI/Auth/AuthStateProvider.cs
@@ -267,12 +267,12 @@ namespace FWO.Ui.Auth
         }
 
         /// <summary>
-        /// Clears the current session and notifies the UI when automatic session recovery is no longer possible.
+        /// Clears unusable tokens and notifies the UI when automatic session recovery is no longer possible.
         /// </summary>
         private async Task HandleExpiredSessionAsync()
         {
             PublishReloginRequiredForAuthenticatedUser();
-            await Deauthenticate();
+            await tokenService.ClearStoredTokenPair();
         }
 
         /// <summary>

--- a/roles/ui/files/FWO.UI/Services/TokenService.cs
+++ b/roles/ui/files/FWO.UI/Services/TokenService.cs
@@ -291,7 +291,7 @@ namespace FWO.Ui.Services
         ///  Clears the stored token pair from memory and session storage
         /// </summary>
         /// <returns></returns>
-        public async Task ClearStoredTokenPair()
+        private async Task ClearStoredTokenPair()
         {
             await initializationTask.Value;
 

--- a/roles/ui/files/FWO.UI/Services/TokenService.cs
+++ b/roles/ui/files/FWO.UI/Services/TokenService.cs
@@ -291,7 +291,7 @@ namespace FWO.Ui.Services
         ///  Clears the stored token pair from memory and session storage
         /// </summary>
         /// <returns></returns>
-        private async Task ClearStoredTokenPair()
+        public async Task ClearStoredTokenPair()
         {
             await initializationTask.Value;
 


### PR DESCRIPTION
P1: AuthStateProvider.cs (line 272) publishes ReloginRequiredEvent and then immediately calls Deauthenticate(). Deauthenticate() clears the principal and notifies auth state, so App.razor (line 6) switches from MainLayout to <Login>, tearing down the relogin dialog that MainLayout.razor (line 269) just opened. This is the same user-visible failure mode as the older PR finding about the intended re-login dialog path being skipped, but now caused by the immediate deauth after publishing the event. On refresh-token failure, users will land on the normal login form instead of the non-abortable relogin dialog.