### PR TITLE
fix link order

### DIFF
--- a/roles/lib/files/FWO.Services/RuleTreeBuilder/IRuleTreeBuilder.cs
+++ b/roles/lib/files/FWO.Services/RuleTreeBuilder/IRuleTreeBuilder.cs
@@ -13,10 +13,9 @@ namespace FWO.Services.RuleTreeBuilder
         List<RulebaseReport> Rulebases { get; set; }
         Dictionary<(int managementId, int deviceId), RuleTreeItem> RuleTreeCache { get; set; }
         List<Rule> BuildRuleTree(RulebaseReport[] rulebases, RulebaseLink[] links, int managementId, int deviceId);
-        RulebaseLink? GetNextLink();
+        RulebaseLink? GetNextLink(int? previousRulebaseId = null);
         List<int> ProcessLink(RulebaseLink link, List<int>? trail = null);
         void Reset(RulebaseReport[] rulebases, RulebaseLink[] links);
         Dictionary<RuleTreeItem, Rule[]> FlattedRules { get; set; }
     }
 }
-

--- a/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeBuilder.cs
+++ b/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeBuilder.cs
@@ -80,9 +80,12 @@ namespace FWO.Services.RuleTreeBuilder
 
             // Iterate links in processing order to build the tree and order numbers.
 
-            while (GetNextLink() is RulebaseLink nextLink)
+            RulebaseLink? previousLink = null;
+
+            while (GetNextLink(previousLink?.NextRulebaseId) is RulebaseLink nextLink)
             {
                 trail = ProcessLink(nextLink, trail);
+                previousLink = nextLink;
             }
 
             // Returns the Rule objects of the flattened rule tree. Will be deprecated  as soon as we have the TreeView component.
@@ -270,10 +273,22 @@ namespace FWO.Services.RuleTreeBuilder
         }
 
         /// <summary>
-        /// Returns the next link to process, preferring initial links.
+        /// Returns the next link to process, preferring the current rulebase chain and then initial links.
         /// </summary>
-        public RulebaseLink? GetNextLink()
+        public RulebaseLink? GetNextLink(int? previousRulebaseId = null)
         {
+            if (previousRulebaseId != null)
+            {
+                RulebaseLink? chainLink = RemainingLinks.FirstOrDefault(link =>
+                    link.LinkType != 3 && link.FromRulebaseId == previousRulebaseId);
+
+                if (chainLink != null)
+                {
+                    RemainingLinks.Remove(chainLink);
+                    return chainLink;
+                }
+            }
+
             // Get initial first
 
             if (RemainingLinks.Any(link => link.IsInitial))
@@ -285,7 +300,7 @@ namespace FWO.Services.RuleTreeBuilder
 
             // Get next link in line
 
-            RulebaseLink? nextLink = RemainingLinks.FirstOrDefault();
+            RulebaseLink? nextLink = RemainingLinks.FirstOrDefault(link => link.LinkType != 3);
 
             if (nextLink != null)
             {
@@ -358,9 +373,9 @@ namespace FWO.Services.RuleTreeBuilder
                 RemainingLinks.Remove(inlineLayerLink);
                 List<int> innerTrail = ProcessLink(inlineLayerLink, trail);
 
-                if (RemainingLinks.FirstOrDefault(x => inlineLayerLink.NextRulebaseId == x.FromRulebaseId) != null)
+                if (RemainingLinks.FirstOrDefault(link => link.LinkType != 3 && link.FromRulebaseId == inlineLayerLink.NextRulebaseId) != null)
                 {
-                    RulebaseLink? nextLink = GetNextLink();
+                    RulebaseLink? nextLink = GetNextLink(inlineLayerLink.NextRulebaseId);
                     if (nextLink != null)
                     {
                         ProcessLink(nextLink, innerTrail);

--- a/roles/tests-unit/files/FWO.Test/RuleTreeBuilderTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleTreeBuilderTest.cs
@@ -70,6 +70,34 @@ namespace FWO.Test
         }
 
         [Test]
+        public void BuildRuleTree_EmptySectionWithUnorderedLinks_KeepsRulebaseChainOrder()
+        {
+            // Arrange
+            RulebaseReport[] rulebases =
+            [
+                Rulebase(1, "Layer-1", 10),
+                Rulebase(2, "Empty-Section"),
+                Rulebase(3, "Section-B", 30)
+            ];
+            RulebaseLink[] links =
+            [
+                OrderedLayerInitialLink(gatewayId: 1, nextRulebaseId: 1),
+                SectionLink(gatewayId: 1, fromRulebaseId: 2, nextRulebaseId: 3),
+                SectionLink(gatewayId: 1, fromRulebaseId: 1, nextRulebaseId: 2)
+            ];
+
+            // Act
+            List<Rule> resultRules = _ruleTreeBuilder.BuildRuleTree(rulebases, links, 1, 1);
+            List<string?> sectionHeaders = [.. _ruleTreeBuilder.RuleTree.ElementsFlat
+                .Where(element => element.IsSectionHeader)
+                .Select(element => element.Header)];
+
+            // Assert
+            Assert.That(sectionHeaders, Is.EqualTo(new[] { "Empty-Section", "Section-B" }));
+            Assert.That(resultRules.Where(rule => rule.SectionHeader == "").Select(rule => rule.RulebaseId), Is.EqualTo(new[] { 1, 3 }));
+        }
+
+        [Test]
         public void BuildRuleTree_InlineLayerFromRule_AddsInlineLayerAndRules()
         {
             // Arrange

--- a/roles/tests-unit/files/FWO.Test/RuleTreeBuilderTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleTreeBuilderTest.cs
@@ -13,6 +13,9 @@ namespace FWO.Test
     {
         private RuleTreeBuilder _ruleTreeBuilder = default!;
 
+        private static readonly string[] kExpectedSectionHeaders = ["Empty-Section", "Section-B"];
+        private static readonly int[] kExpectedRulebaseIds = [1, 3];
+
         [SetUp]
         public void SetUpTestMethod()
         {
@@ -93,8 +96,8 @@ namespace FWO.Test
                 .Select(element => element.Header)];
 
             // Assert
-            Assert.That(sectionHeaders, Is.EqualTo(new[] { "Empty-Section", "Section-B" }));
-            Assert.That(resultRules.Where(rule => rule.SectionHeader == "").Select(rule => rule.RulebaseId), Is.EqualTo(new[] { 1, 3 }));
+            Assert.That(sectionHeaders, Is.EqualTo(kExpectedSectionHeaders));
+            Assert.That(resultRules.Where(rule => rule.SectionHeader == "").Select(rule => rule.RulebaseId), Is.EqualTo(kExpectedRulebaseIds));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #4829

The report tree builder now follows the from_rulebase_id -> to_rulebase_id chain when choosing the next rulebase link, instead of relying on returned rulebase_links order. Inline-layer links stay handled from their owning rule, so they no longer interfere with normal section traversal. See [RuleTreeBuilder.cs (line 83)](/home/tim/dev/fwo-tim/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeBuilder.cs:83) and [RuleTreeBuilder.cs (line 278)](/home/tim/dev/fwo-tim/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeBuilder.cs:278).

Also added a regression test with deliberately unordered links and an empty section between two rulebases: [RuleTreeBuilderTest.cs (line 73)](/home/tim/dev/fwo-tim/roles/tests-unit/files/FWO.Test/RuleTreeBuilderTest.cs:73).