### PR TITLE
fix(importer): include rulebase link changes in change count

### DIFF
--- a/roles/importer/files/importer/model_controllers/import_statistics_controller.py
+++ b/roles/importer/files/importer/model_controllers/import_statistics_controller.py
@@ -29,6 +29,8 @@ class ImportStatisticsController:
             + self.statistics.rulebase_add_count
             + self.statistics.rulebase_change_count
             + self.statistics.rulebase_delete_count
+            + self.statistics.rulebase_link_add_count
+            + self.statistics.rulebase_link_delete_count
         )
 
     def get_rule_change_number(self):
@@ -39,6 +41,8 @@ class ImportStatisticsController:
             + self.statistics.rulebase_add_count
             + self.statistics.rulebase_change_count
             + self.statistics.rulebase_delete_count
+            + self.statistics.rulebase_link_add_count
+            + self.statistics.rulebase_link_delete_count
         )
 
     def get_change_details(self):


### PR DESCRIPTION
rulebase link changes were missing in the import change count.
one implication of this was that if there is an import with only rulebase link changes, it would not register as having changed the managements' data in the database at all (import_control.changes_found = False, which in turn has implications on e.g. reporting. (wrong/old data being shown, this is how I found it as well)