### PR TITLE
fix(importer): checkpoint chunking causing rulebase duplication

### DIFF
--- a/roles/importer/files/importer/fw_modules/checkpointR8x/cp_getter.py
+++ b/roles/importer/files/importer/fw_modules/checkpointR8x/cp_getter.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import fwo_const
 import fwo_globals
-import requests  # pyright: ignore[reportMissingModuleSource]
+import requests
 from fw_modules.checkpointR8x import cp_const, cp_network
 from fwo_exceptions import FwApiError, FwApiResponseDecodingError, FwLoginFailedError, FwoImporterError
 from fwo_log import FWOLogger
@@ -488,6 +488,18 @@ def resolve_checkpoint_uids_via_object_dict(
 
 
 def merge_split_section_with_previous_chunk(current_rulebase: dict[str, Any], rulebase_chunk: dict[str, Any]) -> None:
+    """
+    Append a fetched rulebase page after merging a section that continues across the page boundary.
+
+    Check Point can split one logical ``access-section`` across multiple paginated
+    ``show-access-rulebase`` responses. If both fragments are stored unchanged, later
+    section lookup can rediscover the trailing fragment as if it were an additional
+    standalone section.
+
+    This helper tries to merge the first section of the new page into the last stored
+    section of the previous page before appending the chunk. If the new page only
+    contained that continuation fragment, there is nothing left to append.
+    """
     previous_chunk = get_last_chunk_with_rulebase(current_rulebase)
     if (
         previous_chunk is not None
@@ -499,6 +511,12 @@ def merge_split_section_with_previous_chunk(current_rulebase: dict[str, Any], ru
 
 
 def get_last_chunk_with_rulebase(current_rulebase: dict[str, Any]) -> dict[str, Any] | None:
+    """
+    Return the most recent stored chunk that still contains rulebase entries.
+
+    A split section can only continue from the immediately preceding API page, so the
+    merge logic only needs the last non-empty chunk.
+    """
     for chunk in reversed(current_rulebase["chunks"]):
         if chunk.get("rulebase"):
             return chunk
@@ -506,6 +524,16 @@ def get_last_chunk_with_rulebase(current_rulebase: dict[str, Any]) -> dict[str, 
 
 
 def merge_section_across_chunk_boundary(previous_chunk: dict[str, Any], next_chunk: dict[str, Any]) -> bool:
+    """
+    Merge two chunk-boundary section fragments when they represent one logical section.
+
+    The last section of ``previous_chunk`` and the first section of ``next_chunk`` are
+    examined. If they are the same section split by pagination, the rules from the next
+    fragment are appended to the already stored one, the upper range marker is updated,
+    and the consumed fragment is removed from ``next_chunk``.
+
+    Returns ``True`` when a merge happened and ``False`` otherwise.
+    """
     previous_section = get_boundary_section(previous_chunk, first=False)
     next_section = get_boundary_section(next_chunk, first=True)
     if previous_section is None or next_section is None:
@@ -520,6 +548,12 @@ def merge_section_across_chunk_boundary(previous_chunk: dict[str, Any], next_chu
 
 
 def get_boundary_section(rulebase_chunk: dict[str, Any], first: bool) -> dict[str, Any] | None:
+    """
+    Return the boundary element of a chunk when that element is an ``access-section``.
+
+    The merge logic only stitches section objects at the chunk boundary. Plain access
+    rules are not treated as merge candidates and therefore yield ``None`` here.
+    """
     sections = rulebase_chunk.get("rulebase")
     if not sections:
         return None
@@ -530,11 +564,14 @@ def get_boundary_section(rulebase_chunk: dict[str, Any], first: bool) -> dict[st
 
 
 def is_split_section_continuation(previous_section: dict[str, Any], next_section: dict[str, Any]) -> bool:
+    """
+    Decide whether ``next_section`` is the direct paginated continuation of ``previous_section``.
+
+    The section UID establishes identity, while the numeric rule range confirms that the
+    second fragment begins immediately after the first one ends. Requiring both avoids
+    merging unrelated or malformed data that merely shares a UID.
+    """
     if previous_section.get("uid") != next_section.get("uid"):
-        return False
-    if previous_section.get("name") != next_section.get("name"):
-        return False
-    if "to" not in previous_section or "from" not in next_section:
         return False
     return previous_section["to"] + 1 == next_section["from"]
 

--- a/roles/importer/files/importer/fw_modules/checkpointR8x/cp_getter.py
+++ b/roles/importer/files/importer/fw_modules/checkpointR8x/cp_getter.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import fwo_const
 import fwo_globals
-import requests
+import requests  # pyright: ignore[reportMissingModuleSource]
 from fw_modules.checkpointR8x import cp_const, cp_network
 from fwo_exceptions import FwApiError, FwApiResponseDecodingError, FwLoginFailedError, FwoImporterError
 from fwo_log import FWOLogger
@@ -482,9 +482,61 @@ def resolve_checkpoint_uids_via_object_dict(
     try:
         for rule_field in ["source", "destination", "service", "action", "track", "install-on", "time"]:
             resolve_ref_list_from_object_dictionary(rulebase, rule_field, native_config_domain=native_config_domain)
-        current_rulebase["chunks"].append(rulebase)
+        merge_split_section_with_previous_chunk(current_rulebase, rulebase)
     except Exception:
         FWOLogger.error("error while getting a field of layer " + rulebase_uid + ", params: " + str(show_params_rules))
+
+
+def merge_split_section_with_previous_chunk(current_rulebase: dict[str, Any], rulebase_chunk: dict[str, Any]) -> None:
+    previous_chunk = get_last_chunk_with_rulebase(current_rulebase)
+    if (
+        previous_chunk is not None
+        and merge_section_across_chunk_boundary(previous_chunk, rulebase_chunk)
+        and not rulebase_chunk["rulebase"]
+    ):
+        return
+    current_rulebase["chunks"].append(rulebase_chunk)
+
+
+def get_last_chunk_with_rulebase(current_rulebase: dict[str, Any]) -> dict[str, Any] | None:
+    for chunk in reversed(current_rulebase["chunks"]):
+        if chunk.get("rulebase"):
+            return chunk
+    return None
+
+
+def merge_section_across_chunk_boundary(previous_chunk: dict[str, Any], next_chunk: dict[str, Any]) -> bool:
+    previous_section = get_boundary_section(previous_chunk, first=False)
+    next_section = get_boundary_section(next_chunk, first=True)
+    if previous_section is None or next_section is None:
+        return False
+    if not is_split_section_continuation(previous_section, next_section):
+        return False
+
+    previous_section["rulebase"].extend(next_section["rulebase"])
+    previous_section["to"] = next_section["to"]
+    next_chunk["rulebase"].pop(0)
+    return True
+
+
+def get_boundary_section(rulebase_chunk: dict[str, Any], first: bool) -> dict[str, Any] | None:
+    sections = rulebase_chunk.get("rulebase")
+    if not sections:
+        return None
+    section = sections[0] if first else sections[-1]
+    if section.get("type") != "access-section":
+        return None
+    return section
+
+
+def is_split_section_continuation(previous_section: dict[str, Any], next_section: dict[str, Any]) -> bool:
+    if previous_section.get("uid") != next_section.get("uid"):
+        return False
+    if previous_section.get("name") != next_section.get("name"):
+        return False
+    if "to" not in previous_section or "from" not in next_section:
+        return False
+    return previous_section["to"] + 1 == next_section["from"]
 
 
 def control_while_loop_in_get_rulebases_in_chunks(

--- a/roles/importer/files/importer/test/test_checkpoint_rulebase_fetch.py
+++ b/roles/importer/files/importer/test/test_checkpoint_rulebase_fetch.py
@@ -1,0 +1,64 @@
+from unittest.mock import patch
+
+from fw_modules.checkpointR8x import cp_getter
+
+
+def test_get_rulebases_in_chunks_merges_sections_split_across_api_pages():
+    first_chunk = {
+        "uid": "rb-uid",
+        "name": "Layer 1",
+        "total": 502,
+        "from": 1,
+        "to": 500,
+        "rulebase": [
+            {
+                "type": "access-section",
+                "uid": "section-uid",
+                "name": "Section 408-502",
+                "from": 408,
+                "to": 500,
+                "rulebase": [{"uid": f"rule-{rule_number}", "type": "access-rule"} for rule_number in range(408, 501)],
+            }
+        ],
+    }
+    second_chunk = {
+        "uid": "rb-uid",
+        "name": "Layer 1",
+        "total": 502,
+        "from": 501,
+        "to": 502,
+        "rulebase": [
+            {
+                "type": "access-section",
+                "uid": "section-uid",
+                "name": "Section 408-502",
+                "from": 501,
+                "to": 502,
+                "rulebase": [
+                    {"uid": "rule-501", "type": "access-rule"},
+                    {"uid": "rule-502", "type": "access-rule"},
+                ],
+            }
+        ],
+    }
+    with (
+        patch.object(cp_getter, "cp_api_call", side_effect=[first_chunk, second_chunk]) as cp_api_call,
+        patch.object(cp_getter, "resolve_ref_list_from_object_dictionary"),
+    ):
+        rulebase = cp_getter.get_rulebases_in_chunks(
+            "rb-uid",
+            {"limit": 500},
+            "https://example.invalid/",
+            "access",
+            "sid",
+            {"objects": []},
+        )
+
+    assert cp_api_call.call_count == 2
+    assert len(rulebase["chunks"]) == 1
+    merged_section = rulebase["chunks"][0]["rulebase"][0]
+    assert merged_section["uid"] == "section-uid"
+    assert merged_section["from"] == 408
+    assert merged_section["to"] == 502
+    assert len(merged_section["rulebase"]) == 95
+    assert [rule["uid"] for rule in merged_section["rulebase"][-2:]] == ["rule-501", "rule-502"]


### PR DESCRIPTION
Previous chunking logic lead to duplicate rulebases which resulted in self-referencing rulebase links.

Tested on K001 dev03.