### PR TITLE
set more relaxed config path restriction for customizing scripts

### DIFF
--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -6572,14 +6572,14 @@ INSERT INTO txt VALUES ('H5610', 'English', 'App Role Pattern: Defines the begin
     According to an network area name (e.g. "NAxx"), an App Role name (e.g. "ARxx") is preset in the length of the fixed part defined above.
     If the length of the pattern is greater than the fixed part length, the surplus part is ignored.
 ');
-INSERT INTO txt VALUES ('H5611', 'German',  'Pfad und Name von Appdaten-Import (ohne Endung): Hier werden Importskripte und -dateien unter /usr/local/fworch/scripts/customizing eingetragen.
-    Der gespeicherte Wert enth&auml;lt keine Dateiendung. Beim Speichern wird gepr&uuml;ft, dass der Eintrag unterhalb des Customizing-Verzeichnisses liegt und keine unzul&auml;ssige Dateiendung verwendet. Der Importprozess pr&uuml;ft f&uuml;r jede eingetragene Datenquelle zun&auml;chst, ob ein Skript dieses Namens mit der Endung .py vorhanden und zul&auml;ssig ist, und f&uuml;hrt dieses ggf. aus.
+INSERT INTO txt VALUES ('H5611', 'German',  'Pfad und Name von Appdaten-Import (ohne Endung): Hier werden Importskripte und -dateien unterhalb des konfigurierten Produkt-Verzeichnisses eingetragen.
+    Der gespeicherte Wert enth&auml;lt keine Dateiendung. Beim Speichern wird gepr&uuml;ft, dass der Eintrag unterhalb des konfigurierten Produkt-Verzeichnisses liegt und keine unzul&auml;ssige Dateiendung verwendet. Der Importprozess pr&uuml;ft f&uuml;r jede eingetragene Datenquelle zun&auml;chst, ob ein Skript dieses Namens mit der Endung .py vorhanden und zul&auml;ssig ist, und f&uuml;hrt dieses ggf. aus.
     Anschliessend wird eine Datei desselben Namens mit der Endung .json gesucht und ggf. importiert.
     Es gibt f&uuml;r den Import pro Datenquelle also sowohl die M&ouml;glichkeit, eine direkt zu importierende Datei zur Verf&uuml;gung zu stellen, als auch ein Skript zur Datenabholung,
     welches die ben&ouml;tigte Import-Datei erst erzeugt. Die Struktur der Importdatei wird unter <a href="/help/API/appdataimport">Import-Schnittstellen</a> beschrieben.
 ');
-INSERT INTO txt VALUES ('H5611', 'English', 'Path and Name of App data import (without ending): Import scripts and files below /usr/local/fworch/scripts/customizing are entered here.
-    The stored value contains no file extension. Saving checks that the entry stays below the customizing directory and does not use a disallowed extension. The import process checks each configured data source for an existing and allowed script of this name with ending .py and executes it if present.
+INSERT INTO txt VALUES ('H5611', 'English', 'Path and Name of App data import (without ending): Import scripts and files below the configured product directory are entered here.
+    The stored value contains no file extension. Saving checks that the entry stays below the configured product directory and does not use a disallowed extension. The import process checks each configured data source for an existing and allowed script of this name with ending .py and executes it if present.
     Then a file of this name with ending .json is searched and imported if found.
     Thus there is the possibility for each data source to provide a file for direct import or a script to catch the import data and create the app data import file.
     The structure of the import file is described at <a href="/help/API/appdataimport">Import Interfaces</a>.
@@ -6594,13 +6594,13 @@ INSERT INTO txt VALUES ('H5612', 'English', 'Import App data sleep time (in hour
 ');
 INSERT INTO txt VALUES ('H5613', 'German',  'Import Appdaten-Start: Legt eine Bezugszeit fest, ab dem die Intervalle f&uuml;r die Appdaten-Importe gerechnet werden.');
 INSERT INTO txt VALUES ('H5613', 'English', 'Import App data start at: Defines a referential time from which the App data import intervals are calculated.');
-INSERT INTO txt VALUES ('H5614', 'German',  'Pfad und Name von Subnetzdaten-Import (ohne Endung): Hier wird ein Importskript oder eine Import-Datei unter /usr/local/fworch/scripts/customizing eingetragen.
-    Der gespeicherte Wert enth&auml;lt keine Dateiendung. Beim Speichern wird gepr&uuml;ft, dass der Eintrag unterhalb des Customizing-Verzeichnisses liegt und keine unzul&auml;ssige Dateiendung verwendet. Der Importprozess pr&uuml;ft zun&auml;chst, ob ein Skript dieses Namens mit der Endung .py vorhanden und zul&auml;ssig ist, und f&uuml;hrt dieses ggf. aus. Anschliessend wird eine Datei desselben Namens mit der Endung .json
+INSERT INTO txt VALUES ('H5614', 'German',  'Pfad und Name von Subnetzdaten-Import (ohne Endung): Hier wird ein Importskript oder eine Import-Datei unterhalb des konfigurierten Produkt-Verzeichnisses eingetragen.
+    Der gespeicherte Wert enth&auml;lt keine Dateiendung. Beim Speichern wird gepr&uuml;ft, dass der Eintrag unterhalb des konfigurierten Produkt-Verzeichnisses liegt und keine unzul&auml;ssige Dateiendung verwendet. Der Importprozess pr&uuml;ft zun&auml;chst, ob ein Skript dieses Namens mit der Endung .py vorhanden und zul&auml;ssig ist, und f&uuml;hrt dieses ggf. aus. Anschliessend wird eine Datei desselben Namens mit der Endung .json
     gesucht und ggf. importiert. Es gibt f&uuml;r den Import also sowohl die M&ouml;glichkeit, eine direkt zu importierende Datei zur Verf&uuml;gung zu stellen, als auch ein Skript zur Datenabholung,
     welches die ben&ouml;tigte Import-Datei erst erzeugt. Die Struktur der Importdatei wird unter <a href="/help/API/subnetdataimport">Import-Schnittstellen</a> beschrieben.
 ');
-INSERT INTO txt VALUES ('H5614', 'English', 'Path and Name of subnet data import (without ending): An import script or file below /usr/local/fworch/scripts/customizing is entered here.
-    The stored value contains no file extension. Saving checks that the entry stays below the customizing directory and does not use a disallowed extension. The import process checks if an existing and allowed script of this name with ending .py is present and executes it if found.
+INSERT INTO txt VALUES ('H5614', 'English', 'Path and Name of subnet data import (without ending): An import script or file below the configured product directory is entered here.
+    The stored value contains no file extension. Saving checks that the entry stays below the configured product directory and does not use a disallowed extension. The import process checks if an existing and allowed script of this name with ending .py is present and executes it if found.
     Then a file of this name with ending .json is searched and imported if found.
     Thus there is the possibility to provide a file for direct import or a script to catch the import data and create the subnet data import file.
     The structure of the import file is described at <a href="/help/API/subnetdataimport">Import Interfaces</a>.

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -6572,14 +6572,14 @@ INSERT INTO txt VALUES ('H5610', 'English', 'App Role Pattern: Defines the begin
     According to an network area name (e.g. "NAxx"), an App Role name (e.g. "ARxx") is preset in the length of the fixed part defined above.
     If the length of the pattern is greater than the fixed part length, the surplus part is ignored.
 ');
-INSERT INTO txt VALUES ('H5611', 'German',  'Pfad und Name von Appdaten-Import (ohne Endung): Hier werden Importskripte und -dateien unterhalb des konfigurierten Produkt-Verzeichnisses eingetragen.
-    Der gespeicherte Wert enth&auml;lt keine Dateiendung. Beim Speichern wird gepr&uuml;ft, dass der Eintrag unterhalb des konfigurierten Produkt-Verzeichnisses liegt und keine unzul&auml;ssige Dateiendung verwendet. Der Importprozess pr&uuml;ft f&uuml;r jede eingetragene Datenquelle zun&auml;chst, ob ein Skript dieses Namens mit der Endung .py vorhanden und zul&auml;ssig ist, und f&uuml;hrt dieses ggf. aus.
+INSERT INTO txt VALUES ('H5611', 'German',  'Pfad und Name von Appdaten-Import (ohne Endung): Hier werden Importskripte und -dateien unterhalb von scripts/customizing oder etc im konfigurierten Produkt-Verzeichnis eingetragen.
+    Der gespeicherte Wert enth&auml;lt keine Dateiendung. Beim Speichern wird gepr&uuml;ft, dass der Eintrag unterhalb eines dieser erlaubten Verzeichnisse liegt und keine unzul&auml;ssige Dateiendung verwendet. Der Importprozess pr&uuml;ft f&uuml;r jede eingetragene Datenquelle zun&auml;chst, ob ein Skript dieses Namens mit der Endung .py vorhanden und zul&auml;ssig ist, und f&uuml;hrt dieses ggf. aus.
     Anschliessend wird eine Datei desselben Namens mit der Endung .json gesucht und ggf. importiert.
     Es gibt f&uuml;r den Import pro Datenquelle also sowohl die M&ouml;glichkeit, eine direkt zu importierende Datei zur Verf&uuml;gung zu stellen, als auch ein Skript zur Datenabholung,
     welches die ben&ouml;tigte Import-Datei erst erzeugt. Die Struktur der Importdatei wird unter <a href="/help/API/appdataimport">Import-Schnittstellen</a> beschrieben.
 ');
-INSERT INTO txt VALUES ('H5611', 'English', 'Path and Name of App data import (without ending): Import scripts and files below the configured product directory are entered here.
-    The stored value contains no file extension. Saving checks that the entry stays below the configured product directory and does not use a disallowed extension. The import process checks each configured data source for an existing and allowed script of this name with ending .py and executes it if present.
+INSERT INTO txt VALUES ('H5611', 'English', 'Path and Name of App data import (without ending): Import scripts and files below scripts/customizing or etc in the configured product directory are entered here.
+    The stored value contains no file extension. Saving checks that the entry stays below one of these allowed directories and does not use a disallowed extension. The import process checks each configured data source for an existing and allowed script of this name with ending .py and executes it if present.
     Then a file of this name with ending .json is searched and imported if found.
     Thus there is the possibility for each data source to provide a file for direct import or a script to catch the import data and create the app data import file.
     The structure of the import file is described at <a href="/help/API/appdataimport">Import Interfaces</a>.
@@ -6594,13 +6594,13 @@ INSERT INTO txt VALUES ('H5612', 'English', 'Import App data sleep time (in hour
 ');
 INSERT INTO txt VALUES ('H5613', 'German',  'Import Appdaten-Start: Legt eine Bezugszeit fest, ab dem die Intervalle f&uuml;r die Appdaten-Importe gerechnet werden.');
 INSERT INTO txt VALUES ('H5613', 'English', 'Import App data start at: Defines a referential time from which the App data import intervals are calculated.');
-INSERT INTO txt VALUES ('H5614', 'German',  'Pfad und Name von Subnetzdaten-Import (ohne Endung): Hier wird ein Importskript oder eine Import-Datei unterhalb des konfigurierten Produkt-Verzeichnisses eingetragen.
-    Der gespeicherte Wert enth&auml;lt keine Dateiendung. Beim Speichern wird gepr&uuml;ft, dass der Eintrag unterhalb des konfigurierten Produkt-Verzeichnisses liegt und keine unzul&auml;ssige Dateiendung verwendet. Der Importprozess pr&uuml;ft zun&auml;chst, ob ein Skript dieses Namens mit der Endung .py vorhanden und zul&auml;ssig ist, und f&uuml;hrt dieses ggf. aus. Anschliessend wird eine Datei desselben Namens mit der Endung .json
+INSERT INTO txt VALUES ('H5614', 'German',  'Pfad und Name von Subnetzdaten-Import (ohne Endung): Hier wird ein Importskript oder eine Import-Datei unterhalb von scripts/customizing oder etc im konfigurierten Produkt-Verzeichnis eingetragen.
+    Der gespeicherte Wert enth&auml;lt keine Dateiendung. Beim Speichern wird gepr&uuml;ft, dass der Eintrag unterhalb eines dieser erlaubten Verzeichnisse liegt und keine unzul&auml;ssige Dateiendung verwendet. Der Importprozess pr&uuml;ft zun&auml;chst, ob ein Skript dieses Namens mit der Endung .py vorhanden und zul&auml;ssig ist, und f&uuml;hrt dieses ggf. aus. Anschliessend wird eine Datei desselben Namens mit der Endung .json
     gesucht und ggf. importiert. Es gibt f&uuml;r den Import also sowohl die M&ouml;glichkeit, eine direkt zu importierende Datei zur Verf&uuml;gung zu stellen, als auch ein Skript zur Datenabholung,
     welches die ben&ouml;tigte Import-Datei erst erzeugt. Die Struktur der Importdatei wird unter <a href="/help/API/subnetdataimport">Import-Schnittstellen</a> beschrieben.
 ');
-INSERT INTO txt VALUES ('H5614', 'English', 'Path and Name of subnet data import (without ending): An import script or file below the configured product directory is entered here.
-    The stored value contains no file extension. Saving checks that the entry stays below the configured product directory and does not use a disallowed extension. The import process checks if an existing and allowed script of this name with ending .py is present and executes it if found.
+INSERT INTO txt VALUES ('H5614', 'English', 'Path and Name of subnet data import (without ending): An import script or file below scripts/customizing or etc in the configured product directory is entered here.
+    The stored value contains no file extension. Saving checks that the entry stays below one of these allowed directories and does not use a disallowed extension. The import process checks if an existing and allowed script of this name with ending .py is present and executes it if found.
     Then a file of this name with ending .json is searched and imported if found.
     Thus there is the possibility to provide a file for direct import or a script to catch the import data and create the subnet data import file.
     The structure of the import file is described at <a href="/help/API/subnetdataimport">Import Interfaces</a>.

--- a/roles/lib/files/FWO.Basics/ImportPathPolicy.cs
+++ b/roles/lib/files/FWO.Basics/ImportPathPolicy.cs
@@ -7,34 +7,26 @@ namespace FWO.Basics
     /// </summary>
     public static class ImportPathPolicy
     {
-        /// <summary>
-        /// Directory below which app-data and subnet-data import sources may live.
-        /// </summary>
-        public const string kAllowedCustomizationRoot = "/usr/local/fworch";
-
         private static readonly string[] kAllowedExtensions = [".json", ".py"];
-
-        /// <summary>
-        /// Returns allowed import file stems below the default customization root.
-        /// </summary>
-        public static List<string> GetAllowedImportFileStems()
-        {
-            return GetAllowedImportFileStems(kAllowedCustomizationRoot);
-        }
 
         /// <summary>
         /// Returns allowed import file stems below the given customization root.
         /// </summary>
         public static List<string> GetAllowedImportFileStems(string allowedRoot)
         {
-            if (!Directory.Exists(allowedRoot))
-            {
-                return [];
-            }
+            return GetAllowedImportFileStems([allowedRoot]);
+        }
 
-            return Directory.EnumerateFiles(allowedRoot, "*", SearchOption.AllDirectories)
+        /// <summary>
+        /// Returns allowed import file stems below the given customization roots.
+        /// </summary>
+        public static List<string> GetAllowedImportFileStems(IReadOnlyCollection<string> allowedRoots)
+        {
+            return allowedRoots
+                .Where(Directory.Exists)
+                .SelectMany(allowedRoot => Directory.EnumerateFiles(allowedRoot, "*", SearchOption.AllDirectories))
                 .Where(IsAllowedImportFileExtension)
-                .Where(path => TryValidateExistingFile(path, allowedRoot, out _))
+                .Where(path => TryValidateExistingFile(path, allowedRoots, out _))
                 .Select(RemoveAllowedExtension)
                 .Distinct(StringComparer.Ordinal)
                 .Order(StringComparer.Ordinal)
@@ -55,15 +47,15 @@ namespace FWO.Basics
         /// <summary>
         /// Validates a stored extensionless import source and returns matching files.
         /// </summary>
-        public static List<string> GetValidatedExistingImportFiles(string storedPath)
+        public static List<string> GetValidatedExistingImportFiles(string storedPath, string allowedRoot)
         {
-            return GetValidatedExistingImportFiles(storedPath, kAllowedCustomizationRoot);
+            return GetValidatedExistingImportFiles(storedPath, [allowedRoot]);
         }
 
         /// <summary>
         /// Validates a stored extensionless import source and returns matching files.
         /// </summary>
-        public static List<string> GetValidatedExistingImportFiles(string storedPath, string allowedRoot)
+        public static List<string> GetValidatedExistingImportFiles(string storedPath, IReadOnlyCollection<string> allowedRoots)
         {
             string extension = Path.GetExtension(storedPath);
             string pathWithoutExtension = kAllowedExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase)
@@ -82,7 +74,7 @@ namespace FWO.Basics
 
             foreach (string existingFile in existingFiles)
             {
-                if (!TryValidateExistingFile(existingFile, allowedRoot, out string errorMessage))
+                if (!TryValidateExistingFile(existingFile, allowedRoots, out string errorMessage))
                 {
                     throw new UnauthorizedAccessException(errorMessage);
                 }
@@ -97,15 +89,19 @@ namespace FWO.Basics
         /// File existence and security attributes (symlink, world-writable) are validated on the
         /// importer host at read/run time, since only that host owns the customization directory.
         /// </summary>
-        public static void ValidateImportSourceShape(string importSource)
+        public static void ValidateImportSourceShape(string importSource, string allowedRoot)
         {
-            ValidateImportSourceShape(importSource, kAllowedCustomizationRoot);
+            ValidateImportSourceShape(importSource, [allowedRoot]);
         }
 
         /// <summary>
         /// Validates the shape of a configured import source without touching the filesystem.
+        /// Ensures the source resolves below one of the allowed customization roots, uses no path
+        /// traversal, and (when an extension is present) uses an allowed extension.
+        /// File existence and security attributes (symlink, world-writable) are validated on the
+        /// importer host at read/run time, since only that host owns the customization directory.
         /// </summary>
-        public static void ValidateImportSourceShape(string importSource, string allowedRoot)
+        public static void ValidateImportSourceShape(string importSource, IReadOnlyCollection<string> allowedRoots)
         {
             if (string.IsNullOrWhiteSpace(importSource))
             {
@@ -118,20 +114,16 @@ namespace FWO.Basics
                 throw new ArgumentException($"Import source '{importSource}' must reference a .json or .py file.");
             }
 
-            string fullRoot = Path.GetFullPath(allowedRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
-            string fullPath = Path.GetFullPath(importSource, fullRoot);
-            if (!fullPath.StartsWith(fullRoot, StringComparison.Ordinal))
+            foreach (string allowedRoot in allowedRoots)
             {
-                throw new UnauthorizedAccessException($"Import source '{importSource}' is outside the allowed customization directory '{allowedRoot}'.");
+                string fullRoot = GetFullRoot(allowedRoot);
+                string fullPath = Path.GetFullPath(importSource, fullRoot);
+                if (fullPath.StartsWith(fullRoot, StringComparison.Ordinal))
+                {
+                    return;
+                }
             }
-        }
-
-        /// <summary>
-        /// Validates a specific existing import file.
-        /// </summary>
-        public static void ValidateExistingImportFile(string filePath)
-        {
-            ValidateExistingImportFile(filePath, kAllowedCustomizationRoot);
+            throw new UnauthorizedAccessException($"Import source '{importSource}' is outside the allowed customization directories '{FormatAllowedRoots(allowedRoots)}'.");
         }
 
         /// <summary>
@@ -139,7 +131,15 @@ namespace FWO.Basics
         /// </summary>
         public static void ValidateExistingImportFile(string filePath, string allowedRoot)
         {
-            if (!TryValidateExistingFile(filePath, allowedRoot, out string errorMessage))
+            ValidateExistingImportFile(filePath, [allowedRoot]);
+        }
+
+        /// <summary>
+        /// Validates a specific existing import file.
+        /// </summary>
+        public static void ValidateExistingImportFile(string filePath, IReadOnlyCollection<string> allowedRoots)
+        {
+            if (!TryValidateExistingFile(filePath, allowedRoots, out string errorMessage))
             {
                 throw new UnauthorizedAccessException(errorMessage);
             }
@@ -155,7 +155,7 @@ namespace FWO.Basics
             return Convert.ToHexString(hash).ToLowerInvariant();
         }
 
-        private static bool TryValidateExistingFile(string filePath, string allowedRoot, out string errorMessage)
+        private static bool TryValidateExistingFile(string filePath, IReadOnlyCollection<string> allowedRoots, out string errorMessage)
         {
             errorMessage = "";
             if (!File.Exists(filePath))
@@ -170,27 +170,32 @@ namespace FWO.Basics
                 return false;
             }
 
-            string fullRoot = Path.GetFullPath(allowedRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
             string fullPath = Path.GetFullPath(filePath);
-            if (!fullPath.StartsWith(fullRoot, StringComparison.Ordinal))
+            foreach (string allowedRoot in allowedRoots)
             {
-                errorMessage = $"Import file '{filePath}' is outside the allowed customization directory '{allowedRoot}'.";
-                return false;
+                string fullRoot = GetFullRoot(allowedRoot);
+                if (!fullPath.StartsWith(fullRoot, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (ContainsSymlink(fullPath, fullRoot))
+                {
+                    errorMessage = $"Import file '{filePath}' contains a symbolic link in its path.";
+                    return false;
+                }
+
+                string? writablePath = GetFirstWorldWritablePath(fullPath, fullRoot);
+                if (writablePath != null)
+                {
+                    errorMessage = $"Import file '{filePath}' uses world-writable path '{writablePath}'.";
+                    return false;
+                }
+                return true;
             }
 
-            if (ContainsSymlink(fullPath, fullRoot))
-            {
-                errorMessage = $"Import file '{filePath}' contains a symbolic link in its path.";
-                return false;
-            }
-
-            string? writablePath = GetFirstWorldWritablePath(fullPath, fullRoot);
-            if (writablePath != null)
-            {
-                errorMessage = $"Import file '{filePath}' uses world-writable path '{writablePath}'.";
-                return false;
-            }
-            return true;
+            errorMessage = $"Import file '{filePath}' is outside the allowed customization directories '{FormatAllowedRoots(allowedRoots)}'.";
+            return false;
         }
 
         private static bool IsAllowedImportFileExtension(string filePath)
@@ -234,6 +239,16 @@ namespace FWO.Basics
             UnixFileMode mode = File.GetUnixFileMode(path);
 #pragma warning restore CA1416
             return (mode & UnixFileMode.OtherWrite) == UnixFileMode.OtherWrite;
+        }
+
+        private static string GetFullRoot(string allowedRoot)
+        {
+            return Path.GetFullPath(allowedRoot).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        }
+
+        private static string FormatAllowedRoots(IReadOnlyCollection<string> allowedRoots)
+        {
+            return string.Join("', '", allowedRoots);
         }
 
         private static IEnumerable<string> EnumeratePathComponents(string fullPath, string fullRoot)

--- a/roles/lib/files/FWO.Basics/ImportPathPolicy.cs
+++ b/roles/lib/files/FWO.Basics/ImportPathPolicy.cs
@@ -10,7 +10,7 @@ namespace FWO.Basics
         /// <summary>
         /// Directory below which app-data and subnet-data import sources may live.
         /// </summary>
-        public const string kAllowedCustomizationRoot = "/usr/local/fworch/scripts/customizing";
+        public const string kAllowedCustomizationRoot = "/usr/local/fworch";
 
         private static readonly string[] kAllowedExtensions = [".json", ".py"];
 

--- a/roles/lib/files/FWO.Config.File/ConfigFile.cs
+++ b/roles/lib/files/FWO.Config.File/ConfigFile.cs
@@ -120,6 +120,22 @@ namespace FWO.Config.File
             }
         }
 
+        /// <summary>
+        /// Root directories from which customization import files and scripts may be read or executed.
+        /// </summary>
+        public static List<string> AllowedCustomizationRoots
+        {
+            get
+            {
+                string fwoHome = FwoHome;
+                return
+                [
+                    Path.Combine(fwoHome, "scripts", "customizing"),
+                    Path.Combine(fwoHome, "etc")
+                ];
+            }
+        }
+
         public static string[] RemoteAddresses
         {
             get

--- a/roles/lib/files/FWO.Config.File/ConfigFile.cs
+++ b/roles/lib/files/FWO.Config.File/ConfigFile.cs
@@ -52,6 +52,9 @@ namespace FWO.Config.File
 
             [JsonPropertyName("product_version")]
             public string? ProductVersion { get; set; }
+
+            [JsonPropertyName("fworch_home")]
+            public string? CfgFwoHome { get; set; }
         }
 
         /// <summary>
@@ -106,6 +109,14 @@ namespace FWO.Config.File
             get
             {
                 return CriticalConfigValueLoaded(Data.ProductVersion);
+            }
+        }
+
+        public static string FwoHome
+        {
+            get
+            {
+                return CriticalConfigValueLoaded(Data.CfgFwoHome);
             }
         }
 

--- a/roles/middleware/files/FWO.Middleware.Server/DataImportBase.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/DataImportBase.cs
@@ -3,6 +3,7 @@ using FWO.Api.Client.Queries;
 using FWO.Basics;
 using FWO.Data;
 using FWO.Config.Api;
+using FWO.Config.File;
 using FWO.Logging;
 using System.Diagnostics;
 using System.Text;
@@ -48,7 +49,7 @@ namespace FWO.Middleware.Server
             {
                 if (validateImportFile)
                 {
-                    ImportPathPolicy.ValidateExistingImportFile(filepath);
+                    ImportPathPolicy.ValidateExistingImportFile(filepath, ConfigFile.FwoHome);
                     LogFileHash("Read Import File", filepath);
                 }
                 importFile = File.ReadAllText(filepath).Trim();
@@ -71,7 +72,7 @@ namespace FWO.Middleware.Server
                 {
                     if (validateImportFile)
                     {
-                        ImportPathPolicy.ValidateExistingImportFile(importScriptFile);
+                        ImportPathPolicy.ValidateExistingImportFile(importScriptFile, ConfigFile.FwoHome);
                     }
                     LogFileHash("Run Import Script", importScriptFile);
                     ProcessStartInfo start = new()
@@ -103,7 +104,7 @@ namespace FWO.Middleware.Server
         protected static List<string> ValidateConfiguredImportSource(string importfilePathAndName)
         {
             string normalizedPath = ImportPathPolicy.RemoveAllowedExtension(importfilePathAndName);
-            return ImportPathPolicy.GetValidatedExistingImportFiles(normalizedPath);
+            return ImportPathPolicy.GetValidatedExistingImportFiles(normalizedPath, ConfigFile.FwoHome);
         }
 
         /// <summary>

--- a/roles/middleware/files/FWO.Middleware.Server/DataImportBase.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/DataImportBase.cs
@@ -49,7 +49,7 @@ namespace FWO.Middleware.Server
             {
                 if (validateImportFile)
                 {
-                    ImportPathPolicy.ValidateExistingImportFile(filepath, ConfigFile.FwoHome);
+                    ImportPathPolicy.ValidateExistingImportFile(filepath, ConfigFile.AllowedCustomizationRoots);
                     LogFileHash("Read Import File", filepath);
                 }
                 importFile = File.ReadAllText(filepath).Trim();
@@ -72,7 +72,7 @@ namespace FWO.Middleware.Server
                 {
                     if (validateImportFile)
                     {
-                        ImportPathPolicy.ValidateExistingImportFile(importScriptFile, ConfigFile.FwoHome);
+                        ImportPathPolicy.ValidateExistingImportFile(importScriptFile, ConfigFile.AllowedCustomizationRoots);
                     }
                     LogFileHash("Run Import Script", importScriptFile);
                     ProcessStartInfo start = new()
@@ -104,7 +104,7 @@ namespace FWO.Middleware.Server
         protected static List<string> ValidateConfiguredImportSource(string importfilePathAndName)
         {
             string normalizedPath = ImportPathPolicy.RemoveAllowedExtension(importfilePathAndName);
-            return ImportPathPolicy.GetValidatedExistingImportFiles(normalizedPath, ConfigFile.FwoHome);
+            return ImportPathPolicy.GetValidatedExistingImportFiles(normalizedPath, ConfigFile.AllowedCustomizationRoots);
         }
 
         /// <summary>

--- a/roles/tests-unit/files/FWO.Test/ConfigFileTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ConfigFileTest.cs
@@ -19,6 +19,11 @@ namespace FWO.Test
         private const string configFileTestPath = "config_file.test";
         private const string privateKeyTestPath = "private_key.test";
         private const string publicKeyTestPath = "public_key.test";
+        private static readonly string[] kExpectedAllowedCustomizationRoots =
+        [
+            "/usr/local/fworch/scripts/customizing",
+            "/usr/local/fworch/etc"
+        ];
 
         #region configFiles
         private const string correctConfigFile = @"{
@@ -121,14 +126,7 @@ z2cAR6HkNFB63sh2qZwtC0utP3i3yXlDSxD8lQ7A7NYlifRszw==
             CreateAndReadConfigFile(7, correctConfigFile);
 
             Assert.That(ConfigFile.FwoHome, Is.EqualTo("/usr/local/fworch"));
-            Assert.That(
-                ConfigFile.AllowedCustomizationRoots,
-                Is.EqualTo(new[]
-                {
-                    "/usr/local/fworch/scripts/customizing",
-                    "/usr/local/fworch/etc"
-                })
-            );
+            Assert.That(ConfigFile.AllowedCustomizationRoots, Is.EqualTo(kExpectedAllowedCustomizationRoots));
         }
 
         [Test]

--- a/roles/tests-unit/files/FWO.Test/ConfigFileTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ConfigFileTest.cs
@@ -116,6 +116,22 @@ z2cAR6HkNFB63sh2qZwtC0utP3i3yXlDSxD8lQ7A7NYlifRszw==
         }
 
         [Test]
+        public void AllowedCustomizationRootsUseConfiguredFwoHome()
+        {
+            CreateAndReadConfigFile(7, correctConfigFile);
+
+            Assert.That(ConfigFile.FwoHome, Is.EqualTo("/usr/local/fworch"));
+            Assert.That(
+                ConfigFile.AllowedCustomizationRoots,
+                Is.EqualTo(new[]
+                {
+                    "/usr/local/fworch/scripts/customizing",
+                    "/usr/local/fworch/etc"
+                })
+            );
+        }
+
+        [Test]
         public void IncorrectSyntaxConfigFile()
         {
             Assert.Catch(typeof(TargetInvocationException), () => CreateAndReadConfigFile(1, incorrectSyntaxConfigFile));
@@ -162,7 +178,7 @@ z2cAR6HkNFB63sh2qZwtC0utP3i3yXlDSxD8lQ7A7NYlifRszw==
         [OneTimeTearDown]
         public void OnFinish()
         {
-            for (int uniqueId = 0; uniqueId < 7; uniqueId++)
+            for (int uniqueId = 0; uniqueId < 8; uniqueId++)
             {
                 File.Delete(configFileTestPath + uniqueId);
                 File.Delete(privateKeyTestPath + uniqueId);

--- a/roles/tests-unit/files/FWO.Test/DataImportBaseTest.cs
+++ b/roles/tests-unit/files/FWO.Test/DataImportBaseTest.cs
@@ -154,6 +154,49 @@ namespace FWO.Test
         }
 
         [Test]
+        public void ImportPathPolicyAllowsOnlyConfiguredCustomizationRoots()
+        {
+            string fwoHome = CreateNonWorldWritableTempDirectory();
+            try
+            {
+                string customizingRoot = Path.Combine(fwoHome, "scripts", "customizing");
+                string etcRoot = Path.Combine(fwoHome, "etc");
+                string blockedRoot = Path.Combine(fwoHome, "importer");
+                Directory.CreateDirectory(customizingRoot);
+                Directory.CreateDirectory(etcRoot);
+                Directory.CreateDirectory(blockedRoot);
+
+                string customizingScript = Path.Combine(customizingRoot, "owners.py");
+                string etcFile = Path.Combine(etcRoot, "owners.json");
+                string blockedScript = Path.Combine(blockedRoot, "owners.py");
+                File.WriteAllText(customizingScript, "#!/usr/bin/env python3\n");
+                File.WriteAllText(etcFile, "{}");
+                File.WriteAllText(blockedScript, "#!/usr/bin/env python3\n");
+
+                List<string> allowedRoots = [customizingRoot, etcRoot];
+
+                Assert.DoesNotThrow(() => ImportPathPolicy.ValidateExistingImportFile(customizingScript, allowedRoots));
+                Assert.DoesNotThrow(() => ImportPathPolicy.ValidateExistingImportFile(etcFile, allowedRoots));
+                Assert.Throws<UnauthorizedAccessException>(() =>
+                    ImportPathPolicy.ValidateExistingImportFile(blockedScript, allowedRoots));
+                Assert.Throws<UnauthorizedAccessException>(() =>
+                    ImportPathPolicy.ValidateImportSourceShape(blockedScript, allowedRoots));
+                Assert.That(
+                    ImportPathPolicy.GetAllowedImportFileStems(allowedRoots),
+                    Is.EquivalentTo(new[]
+                    {
+                        Path.Combine(customizingRoot, "owners"),
+                        Path.Combine(etcRoot, "owners")
+                    })
+                );
+            }
+            finally
+            {
+                Directory.Delete(fwoHome, true);
+            }
+        }
+
+        [Test]
         public void ImportPathPolicyRejectsFileOutsideAllowedRoot()
         {
             string tempRoot = CreateNonWorldWritableTempDirectory();

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsAppDataImport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsAppDataImport.razor
@@ -3,6 +3,7 @@
 
 @using System.Text.Json
 @using FWO.Basics
+@using FWO.Config.File
 @using FWO.Data.Middleware
 @using FWO.Logging
 @using FWO.Middleware.Client
@@ -50,7 +51,7 @@
                     </Display>
                 </EditList>
                 <div class="row col-sm-12 mt-1">
-                    <input type="text" class="col-sm-10" @bind="actPath" placeholder="@(ImportPathPolicy.kAllowedCustomizationRoot)/..." />
+                    <input type="text" class="col-sm-10" @bind="actPath" placeholder="@(ConfigFile.FwoHome)/..." />
                     <button type="button" class="col-sm-2 btn btn-sm btn-primary" disabled="@(string.IsNullOrWhiteSpace(actPath))" @onclick="AddPath"
                             @onclick:preventDefault>@(DisplayService.DisplayButton(userConfig, "add", Icons.Add))</button>
                 </div>
@@ -108,7 +109,7 @@
                     </Display>
                 </EditList>
                 <div class="row col-sm-12 mt-1">
-                    <input type="text" class="col-sm-10" @bind="SubnetActPath" placeholder="@(ImportPathPolicy.kAllowedCustomizationRoot)/..." />
+                    <input type="text" class="col-sm-10" @bind="SubnetActPath" placeholder="@(ConfigFile.FwoHome)/..." />
                     <button type="button" class="col-sm-2 btn btn-sm btn-primary" disabled="@(string.IsNullOrWhiteSpace(SubnetActPath))" @onclick="AddPathSubnet"
                             @onclick:preventDefault>@(DisplayService.DisplayButton(userConfig, "add", Icons.Add))</button>
                 </div>
@@ -442,7 +443,7 @@ OnCSVAppServerImportEvent(_.EventArgs));
     {
         foreach (string importPath in importPaths)
         {
-            ImportPathPolicy.ValidateImportSourceShape(importPath);
+            ImportPathPolicy.ValidateImportSourceShape(importPath, ConfigFile.FwoHome);
         }
     }
 

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsAppDataImport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsAppDataImport.razor
@@ -51,7 +51,7 @@
                     </Display>
                 </EditList>
                 <div class="row col-sm-12 mt-1">
-                    <input type="text" class="col-sm-10" @bind="actPath" placeholder="@(ConfigFile.FwoHome)/..." />
+                    <input type="text" class="col-sm-10" @bind="actPath" placeholder="@AllowedImportPathPlaceholder" />
                     <button type="button" class="col-sm-2 btn btn-sm btn-primary" disabled="@(string.IsNullOrWhiteSpace(actPath))" @onclick="AddPath"
                             @onclick:preventDefault>@(DisplayService.DisplayButton(userConfig, "add", Icons.Add))</button>
                 </div>
@@ -109,7 +109,7 @@
                     </Display>
                 </EditList>
                 <div class="row col-sm-12 mt-1">
-                    <input type="text" class="col-sm-10" @bind="SubnetActPath" placeholder="@(ConfigFile.FwoHome)/..." />
+                    <input type="text" class="col-sm-10" @bind="SubnetActPath" placeholder="@AllowedImportPathPlaceholder" />
                     <button type="button" class="col-sm-2 btn btn-sm btn-primary" disabled="@(string.IsNullOrWhiteSpace(SubnetActPath))" @onclick="AddPathSubnet"
                             @onclick:preventDefault>@(DisplayService.DisplayButton(userConfig, "add", Icons.Add))</button>
                 </div>
@@ -435,7 +435,7 @@ OnCSVAppServerImportEvent(_.EventArgs));
         configData!.ImportSubnetDataPath = JsonSerializer.Serialize(SubnetDataPaths);
     }
 
-    // Save validates path shape only (rooted in the customization dir, allowed extension, no traversal).
+    // Save validates path shape only (rooted in an allowed customization dir, allowed extension, no traversal).
     // File existence and security attributes are enforced on the importer host at read/run time, so
     // saving unrelated settings is not blocked by sources that are absent on the UI host (split deploy)
     // or not yet deployed.
@@ -443,9 +443,12 @@ OnCSVAppServerImportEvent(_.EventArgs));
     {
         foreach (string importPath in importPaths)
         {
-            ImportPathPolicy.ValidateImportSourceShape(importPath, ConfigFile.FwoHome);
+            ImportPathPolicy.ValidateImportSourceShape(importPath, ConfigFile.AllowedCustomizationRoots);
         }
     }
+
+    private static string AllowedImportPathPlaceholder =>
+        string.Join(" | ", ConfigFile.AllowedCustomizationRoots.Select(root => $"{root}/..."));
 
     private void WriteImporterSettingsAudit(string oldAppDataPath, string oldSubnetDataPath, string oldScriptArgs)
     {


### PR DESCRIPTION
The import path root now comes from /etc/fworch/fworch_home in fworch.json via [ConfigFile.FworchHome (line 115)](/home/tim/dev/fwo-tim/roles/lib/files/FWO.Config.File/ConfigFile.cs:115).

This allows us to use both FWO_HOME/scripts and etc as directories for scripts and static config files.

Fixes #4863 

- Runtime callers now use that configured value:
Middleware import validation in [DataImportBase.cs (line 52)](/home/tim/dev/fwo-tim/roles/middleware/files/FWO.Middleware.Server/DataImportBase.cs:52)
- UI placeholders and save-time validation in [SettingsAppDataImport.razor (line 54)](/home/tim/dev/fwo-tim/roles/ui/files/FWO.UI/Pages/Settings/SettingsAppDataImport.razor:54)
- Localized help text now says “configured product directory” instead of hardcoding /usr/local/fworch in [fworch-texts.sql (line 6581)](/home/tim/dev/fwo-tim/roles/database/files/sql/idempotent/fworch-texts.sql:6581)
- Added config test coverage in [ConfigFileTest.cs (line 116)](/home/tim/dev/fwo-tim/roles/tests-unit/files/FWO.Test/ConfigFileTest.cs:116)