### PR TITLE
feat: Combine dependabot pip pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,15 +21,27 @@ updates:
     target-branch: "develop"
     schedule:
       interval: "weekly"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/scripts/customizing/app_data_import"
     target-branch: "develop"
     schedule:
       interval: "weekly"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
     target-branch: "develop"
     schedule:
       interval: "weekly"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This change in the configuration lets dependabot create only one PR for all dependency updates at once