### PR TITLE
Resolve zones for objects

### DIFF
--- a/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceCheck.cs
@@ -1495,45 +1495,11 @@ namespace FWO.Compliance
         private List<ComplianceNetworkZone> DetermineZones(List<IPAddressRange> ranges, List<ComplianceNetworkZone>? networkZonesOverride = null)
         {
             List<ComplianceNetworkZone> activeNetworkZones = networkZonesOverride ?? NetworkZones;
-            List<ComplianceNetworkZone> result = [];
-            List<List<IPAddressRange>> unseenIpAddressRanges = [];
-
-            for (int i = 0; i < ranges.Count; i++)
-            {
-                unseenIpAddressRanges.Add(
-                [
-                    new(ranges[i].Begin, ranges[i].End)
-                ]);
-            }
-
-            foreach (ComplianceNetworkZone zone in activeNetworkZones.Where(z => z.OverlapExists(ranges, unseenIpAddressRanges)))
-            {
-                result.Add(zone);
-            }
-
-            // No need to proceed if auto calculated internet zone is activated.
-
-            if (_autoCalculatedInternetZoneActive)
-            {
-                return result;
-            }
-
-            // Get ip ranges that are not in any zone
-
-            List<IPAddressRange> undefinedIpRanges = [.. unseenIpAddressRanges.SelectMany(x => x)];
-
-            if (undefinedIpRanges.Count > 0)
-            {
-                result.Add
-                (
-                    new ComplianceNetworkZone()
-                    {
-                        Name = _userConfig.GetText("internet_local_zone"),
-                    }
-                );
-            }
-
-            return result;
+            return ComplianceZoneResolver.ResolveZones(
+                ranges,
+                activeNetworkZones,
+                _autoCalculatedInternetZoneActive,
+                _userConfig.GetText("internet_local_zone"));
         }
 
         /// <summary>

--- a/roles/lib/files/FWO.Compliance/ComplianceZoneResolver.cs
+++ b/roles/lib/files/FWO.Compliance/ComplianceZoneResolver.cs
@@ -1,0 +1,53 @@
+using FWO.Data;
+using NetTools;
+
+namespace FWO.Compliance;
+
+/// <summary>
+/// Resolves compliance network zones for a set of IP ranges.
+/// </summary>
+public static class ComplianceZoneResolver
+{
+    /// <summary>
+    /// Resolves the zones that overlap with the provided IP ranges.
+    /// </summary>
+    /// <param name="ranges">IP ranges to evaluate.</param>
+    /// <param name="activeNetworkZones">The active compliance zones.</param>
+    /// <param name="autoCalculatedInternetZoneActive">Whether the internet zone is auto-calculated and therefore should not be added as a fallback.</param>
+    /// <param name="internetLocalZoneName">Localized display name for the fallback internet zone.</param>
+    public static List<ComplianceNetworkZone> ResolveZones(
+        List<IPAddressRange> ranges,
+        List<ComplianceNetworkZone> activeNetworkZones,
+        bool autoCalculatedInternetZoneActive,
+        string internetLocalZoneName)
+    {
+        List<ComplianceNetworkZone> result = [];
+        List<List<IPAddressRange>> unseenIpAddressRanges = [];
+
+        for (int index = 0; index < ranges.Count; index++)
+        {
+            unseenIpAddressRanges.Add([new(ranges[index].Begin, ranges[index].End)]);
+        }
+
+        foreach (ComplianceNetworkZone zone in activeNetworkZones.Where(zone => zone.OverlapExists(ranges, unseenIpAddressRanges)))
+        {
+            result.Add(zone);
+        }
+
+        if (autoCalculatedInternetZoneActive)
+        {
+            return result;
+        }
+
+        List<IPAddressRange> undefinedIpRanges = [.. unseenIpAddressRanges.SelectMany(rangeSet => rangeSet)];
+        if (undefinedIpRanges.Count > 0)
+        {
+            result.Add(new ComplianceNetworkZone
+            {
+                Name = internetLocalZoneName
+            });
+        }
+
+        return result;
+    }
+}

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/ComplianceController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/ComplianceController.cs
@@ -6,11 +6,11 @@ using FWO.Compliance;
 using FWO.Data;
 using FWO.Data.Middleware;
 using FWO.Logging;
-using FWO.Middleware.Server.Services;
+using FWO.Middleware.Server.Requests;
 using FWO.Middleware.Server.Responses;
+using FWO.Middleware.Server.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Text.Json;
 using FWO.Report;
 
 namespace FWO.Middleware.Server.Controllers
@@ -21,7 +21,10 @@ namespace FWO.Middleware.Server.Controllers
     [Authorize]
     [ApiController]
     [Route("api/[controller]")]
-    public class ComplianceController(ApiConnection apiConnection, ComplianceCheckStatusTracker complianceCheckStatusTracker) : ControllerBase
+    public class ComplianceController(
+        ApiConnection apiConnection,
+        ComplianceCheckStatusTracker complianceCheckStatusTracker,
+        ComplianceZoneService complianceZoneService) : ControllerBase
     {
         /// <summary>
         /// Import Compliance Matrix
@@ -87,12 +90,36 @@ namespace FWO.Middleware.Server.Controllers
         {
             try
             {
-                List<ComplianceDesignatedZoneResponse> zones = await LoadDesignatedZoneMatrixZonesAsync();
+                List<ComplianceDesignatedZoneResponse> zones = await complianceZoneService.GetDesignatedZoneMatrixZonesAsync();
                 return Ok(zones);
             }
             catch (Exception exception)
             {
                 Log.WriteError("Get Designated Zone Matrix Zones", "Error while getting designated zone matrix zones.", exception);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// Returns the zones occupied by draft flow network objects.
+        /// </summary>
+        /// <param name="request">The draft object tree to resolve.</param>
+        [HttpPost("ResolveZonesForObjects")]
+        [Authorize(Roles = $"{Roles.Admin}, {Roles.Auditor}")]
+        public async Task<ActionResult<List<ComplianceDesignatedZoneResponse>>> ResolveZonesForObjects([FromBody] GetZonesForDraftObjectsRequest request)
+        {
+            if (!GetZonesForDraftObjectsRequestValidator.TryValidate(request, out ActionResult? errorResult))
+            {
+                return errorResult!;
+            }
+
+            try
+            {
+                return Ok(await complianceZoneService.ResolveZonesForObjectsAsync(request));
+            }
+            catch (Exception exception)
+            {
+                Log.WriteError("Resolve Zones For Objects", "Error while resolving object zones.", exception);
                 return StatusCode(500);
             }
         }
@@ -182,53 +209,6 @@ namespace FWO.Middleware.Server.Controllers
             }
 
             return Ok(jobStatus);
-        }
-
-        /// <summary>
-        /// Loads the zones belonging to the configured designated matrix.
-        /// </summary>
-        private async Task<List<ComplianceDesignatedZoneResponse>> LoadDesignatedZoneMatrixZonesAsync()
-        {
-            GlobalConfig globalConfig = await GlobalConfig.ConstructAsync(apiConnection, false);
-            if (globalConfig.ComplianceDesignatedZoneMatrixId <= 0)
-            {
-                return [];
-            }
-
-            List<ComplianceCriterion> designatedMatrices = await apiConnection.SendQueryAsync<List<ComplianceCriterion>>(
-                ComplianceQueries.getMatrixById,
-                new { criterionId = globalConfig.ComplianceDesignatedZoneMatrixId }) ?? [];
-
-            if (designatedMatrices.Count == 0)
-            {
-                return [];
-            }
-
-            List<ComplianceNetworkZone> zones = await apiConnection.SendQueryAsync<List<ComplianceNetworkZone>>(
-                ComplianceQueries.getNetworkZonesForMatrix,
-                new { criterionId = globalConfig.ComplianceDesignatedZoneMatrixId }) ?? [];
-
-            return zones.Select(MapDesignatedZoneResponse).ToList();
-        }
-
-        private static string ConvertOutput(List<(Rule, (ComplianceNetworkZone, ComplianceNetworkZone))> forbiddenCommunicationsOutput)
-        {
-            return JsonSerializer.Serialize(forbiddenCommunicationsOutput);
-        }
-
-        private static ComplianceDesignatedZoneResponse MapDesignatedZoneResponse(ComplianceNetworkZone zone)
-        {
-            return new ComplianceDesignatedZoneResponse
-            {
-                Id = zone.Id,
-                Name = zone.Name,
-                Description = zone.Description,
-                IpRanges = [.. zone.IPRanges.Select(ipRange => new ComplianceDesignatedZoneIpRangeResponse
-                {
-                    IpStart = ipRange.Begin.ToString(),
-                    IpEnd = ipRange.End.ToString()
-                })]
-            };
         }
     }
 }

--- a/roles/middleware/files/FWO.Middleware.Server/OpenApi/ApiExampleServiceCollectionExtensions.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/OpenApi/ApiExampleServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class ApiExampleServiceCollectionExtensions
         services.AddSingleton<IApiExampleProvider, GetRequestStatusRequestExample>();
         services.AddSingleton<IApiExampleProvider, VisibleInRequestFilterExample>();
         services.AddSingleton<IApiExampleProvider, GetFlowComplianceStateRequestExample>();
+        services.AddSingleton<IApiExampleProvider, GetZonesForDraftObjectsRequestExample>();
         services.AddSingleton<IApiExampleProvider, GetOwnersRequestExample>();
         services.AddSingleton<IApiExampleProvider, GenerateAddressObjectNameResponseExample>();
         services.AddSingleton<IApiExampleProvider, GenerateServiceObjectNameResponseExample>();
@@ -31,6 +32,7 @@ public static class ApiExampleServiceCollectionExtensions
         services.AddSingleton<IApiExampleProvider, CreateRequestResponseExample>();
         services.AddSingleton<IApiExampleProvider, GetRequestStatusResponseExample>();
         services.AddSingleton<IApiExampleProvider, FlowComplianceStateResponseExample>();
+        services.AddSingleton<IApiExampleProvider, ComplianceDesignatedZoneResponseExample>();
         services.AddSingleton<IApiExampleProvider, GetPolicyIdsResponseExample>();
         services.AddSingleton<IApiExampleProvider, AddressObjectResponseExample>();
         services.AddSingleton<IApiExampleProvider, AddressGroupResponseExample>();
@@ -241,6 +243,50 @@ public sealed class GetFlowComplianceStateRequestExample : ApiExampleProvider<Ge
 }
 
 /// <summary>
+/// Provides a typed example for <see cref="GetZonesForDraftObjectsRequest"/>.
+/// </summary>
+public sealed class GetZonesForDraftObjectsRequestExample : ApiExampleProvider<GetZonesForDraftObjectsRequest>
+{
+    /// <inheritdoc />
+    public override GetZonesForDraftObjectsRequest GetExample() => new()
+    {
+        Objects =
+        [
+            new GetZonesForDraftObjectsRequest.DraftObjectRequest
+            {
+                Name = "preview-group",
+                Type = "group",
+                Members =
+                [
+                    new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                    {
+                        Name = "branch-a",
+                        Type = "network",
+                        IpStart = "10.0.0.1",
+                        IpEnd = "10.0.0.1"
+                    },
+                    new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                    {
+                        Name = "branch-b",
+                        Type = "group",
+                        Members =
+                        [
+                            new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                            {
+                                Name = "leaf",
+                                Type = "ip_range",
+                                IpStart = "10.0.1.1",
+                                IpEnd = "10.0.1.10"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+}
+
+/// <summary>
 /// Provides a typed example for <see cref="GetOwnersRequest"/>.
 /// </summary>
 public sealed class GetOwnersRequestExample : ApiExampleProvider<GetOwnersRequest>
@@ -334,6 +380,28 @@ public sealed class FlowComplianceStateResponseExample : ApiExampleProvider<Flow
             {
                 Id = 3,
                 Type = "missing-approval"
+            }
+        ]
+    };
+}
+
+/// <summary>
+/// Provides a typed example for <see cref="ComplianceDesignatedZoneResponse"/>.
+/// </summary>
+public sealed class ComplianceDesignatedZoneResponseExample : ApiExampleProvider<ComplianceDesignatedZoneResponse>
+{
+    /// <inheritdoc />
+    public override ComplianceDesignatedZoneResponse GetExample() => new()
+    {
+        Id = 7,
+        Name = "DMZ",
+        Description = "Demilitarized zone",
+        IpRanges =
+        [
+            new ComplianceDesignatedZoneIpRangeResponse
+            {
+                IpStart = "10.0.0.0",
+                IpEnd = "10.0.0.255"
             }
         ]
     };

--- a/roles/middleware/files/FWO.Middleware.Server/Program.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Program.cs
@@ -93,6 +93,7 @@ builder.Services.AddControllers()
 builder.Services.AddSingleton<JwtWriter>(jwtWriter);
 builder.Services.AddSingleton<List<Ldap>>(connectedLdaps);
 builder.Services.AddSingleton<FlowCatalogService>();
+builder.Services.AddSingleton<ComplianceZoneService>();
 builder.Services.AddSingleton<FlowComplianceService>();
 builder.Services.AddSingleton<FlowRequestService>();
 

--- a/roles/middleware/files/FWO.Middleware.Server/Requests/GetZonesForDraftObjectsRequest.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Requests/GetZonesForDraftObjectsRequest.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FWO.Middleware.Server.Requests;
+
+/// <summary>
+/// Represents the request body for resolving zones for draft flow network objects.
+/// </summary>
+public sealed class GetZonesForDraftObjectsRequest : IRequestWithRootAdditionalData
+{
+    /// <summary>
+    /// Gets the root draft objects to evaluate.
+    /// </summary>
+    [JsonPropertyName("objects")]
+    public List<DraftObjectRequest> Objects { get; set; } = [];
+
+    /// <summary>
+    /// Gets the additional data payload.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalData { get; set; }
+
+    /// <summary>
+    /// Represents one draft object in the zone preview tree.
+    /// </summary>
+    public sealed class DraftObjectRequest : IRequestWithAdditionalData
+    {
+        /// <summary>
+        /// Gets the display name of the draft object.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets the object type.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets the start IP or range value.
+        /// </summary>
+        [JsonPropertyName("ipStart")]
+        public string IpStart { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets the end IP or range value.
+        /// </summary>
+        [JsonPropertyName("ipEnd")]
+        public string IpEnd { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets the child members for draft groups.
+        /// </summary>
+        [JsonPropertyName("members")]
+        public List<DraftObjectRequest> Members { get; set; } = [];
+
+        /// <summary>
+        /// Gets the additional data payload.
+        /// </summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? AdditionalData { get; set; }
+    }
+}

--- a/roles/middleware/files/FWO.Middleware.Server/Requests/GetZonesForDraftObjectsRequestValidator.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Requests/GetZonesForDraftObjectsRequestValidator.cs
@@ -1,0 +1,197 @@
+using FWO.Basics;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+
+namespace FWO.Middleware.Server.Requests;
+
+/// <summary>
+/// Validates requests for draft zone resolution.
+/// </summary>
+public static class GetZonesForDraftObjectsRequestValidator
+{
+    private const string EndpointName = "resolveZonesForObjects";
+
+    private static readonly RequestRootValidationSchema RootSchema = new(
+        EndpointName,
+        [
+            new RequestKeyDefinition("objects", "Draft flow network objects to resolve.")
+        ]);
+
+    private static readonly RequestKeyDefinition[] ObjectKeys =
+    [
+        new("name", "Display name of the draft object."),
+        new("type", "Object type of the draft object."),
+        new("ipStart", "Start IP address or range value of the draft object."),
+        new("ipEnd", "End IP address or range value of the draft object."),
+        new("members", "Nested draft members for draft groups.")
+    ];
+
+    /// <summary>
+    /// Validates the draft object zone request.
+    /// </summary>
+    public static bool TryValidate(GetZonesForDraftObjectsRequest request, out ActionResult? errorResult)
+    {
+        if (request is null)
+        {
+            errorResult = new BadRequestObjectResult("Request body is required.");
+            return false;
+        }
+
+        if (!RequestRootValidator.TryValidate(request, RootSchema, out errorResult))
+        {
+            return false;
+        }
+
+        if (!TryValidateObjects(request.Objects ?? [], "objects", out errorResult))
+        {
+            return false;
+        }
+
+        errorResult = null;
+        return true;
+    }
+
+    private static bool TryValidateObjects(IEnumerable<GetZonesForDraftObjectsRequest.DraftObjectRequest> objects, string collectionName, out ActionResult? errorResult)
+    {
+        int index = 0;
+        foreach (GetZonesForDraftObjectsRequest.DraftObjectRequest? draftObject in objects)
+        {
+            if (draftObject is null)
+            {
+                errorResult = new BadRequestObjectResult($"'{collectionName}' cannot contain null entries.");
+                return false;
+            }
+
+            if (!TryValidateObject(draftObject, $"{collectionName} entry at index {index}", out errorResult))
+            {
+                return false;
+            }
+
+            index++;
+        }
+
+        errorResult = null;
+        return true;
+    }
+
+    private static bool TryValidateObject(GetZonesForDraftObjectsRequest.DraftObjectRequest draftObject, string context, out ActionResult? errorResult)
+    {
+        if (draftObject.AdditionalData is { Count: > 0 })
+        {
+            string allowedShapes = string.Join(" or ", ObjectKeys.Select(key => $"{{ \"{key.JsonName}\": ... }}"));
+            string keyHelp = string.Join(" ", ObjectKeys.Select(key => $"'{key.JsonName}': {key.Description}"));
+            errorResult = new BadRequestObjectResult($"'{context}' only accepts {allowedShapes}. Valid keys: {keyHelp}");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(draftObject.Type))
+        {
+            errorResult = new BadRequestObjectResult($"'{context}' requires a non-empty 'type'.");
+            return false;
+        }
+
+        if (IsGroupType(draftObject.Type))
+        {
+            if (!string.IsNullOrWhiteSpace(draftObject.IpStart) || !string.IsNullOrWhiteSpace(draftObject.IpEnd))
+            {
+                errorResult = new BadRequestObjectResult($"'{context}' entries of type '{ObjectType.Group}' must not define 'ipStart' or 'ipEnd'.");
+                return false;
+            }
+
+            return TryValidateObjects(draftObject.Members ?? [], $"{context}.members", out errorResult);
+        }
+
+        if (!IsLeafType(draftObject.Type))
+        {
+            errorResult = new BadRequestObjectResult(
+                $"'{context}' has an unsupported 'type' value. Allowed values are '{ObjectType.Group}', '{ObjectType.Host}', '{ObjectType.Network}', and '{ObjectType.IPRange}'.");
+            return false;
+        }
+
+        if (draftObject.Members is { Count: > 0 })
+        {
+            errorResult = new BadRequestObjectResult($"'{context}' entries of type '{draftObject.Type}' must not define 'members'.");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(draftObject.IpStart) || string.IsNullOrWhiteSpace(draftObject.IpEnd))
+        {
+            errorResult = new BadRequestObjectResult($"'{context}' entries require non-empty 'ipStart' and 'ipEnd'.");
+            return false;
+        }
+
+        if (!TryValidateIpRange(draftObject.IpStart, draftObject.IpEnd, context, out errorResult))
+        {
+            return false;
+        }
+
+        if (string.Equals(draftObject.Type, ObjectType.Host, StringComparison.OrdinalIgnoreCase)
+            && CompareIpAddresses(IPAddress.Parse(draftObject.IpStart), IPAddress.Parse(draftObject.IpEnd)) != 0)
+        {
+            errorResult = new BadRequestObjectResult($"'{context}' entries of type '{ObjectType.Host}' must use the same 'ipStart' and 'ipEnd'.");
+            return false;
+        }
+
+        errorResult = null;
+        return true;
+    }
+
+    private static bool TryValidateIpRange(string ipStartValue, string ipEndValue, string context, out ActionResult? errorResult)
+    {
+        if (!IPAddress.TryParse(ipStartValue, out IPAddress? ipStart))
+        {
+            errorResult = new BadRequestObjectResult($"'{context}' has an invalid 'ipStart' value.");
+            return false;
+        }
+
+        if (!IPAddress.TryParse(ipEndValue, out IPAddress? ipEnd))
+        {
+            errorResult = new BadRequestObjectResult($"'{context}' has an invalid 'ipEnd' value.");
+            return false;
+        }
+
+        if (ipStart.AddressFamily != ipEnd.AddressFamily)
+        {
+            errorResult = new BadRequestObjectResult($"'{context}' must use the same address family for 'ipStart' and 'ipEnd'.");
+            return false;
+        }
+
+        if (CompareIpAddresses(ipStart, ipEnd) > 0)
+        {
+            errorResult = new BadRequestObjectResult($"'{context}' must satisfy 'ipStart' <= 'ipEnd'.");
+            return false;
+        }
+
+        errorResult = null;
+        return true;
+    }
+
+    private static bool IsGroupType(string objectType)
+    {
+        return string.Equals(objectType, ObjectType.Group, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsLeafType(string objectType)
+    {
+        return string.Equals(objectType, ObjectType.Host, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(objectType, ObjectType.Network, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(objectType, ObjectType.IPRange, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int CompareIpAddresses(IPAddress left, IPAddress right)
+    {
+        byte[] leftBytes = left.GetAddressBytes();
+        byte[] rightBytes = right.GetAddressBytes();
+
+        for (int index = 0; index < leftBytes.Length; index++)
+        {
+            int compare = leftBytes[index].CompareTo(rightBytes[index]);
+            if (compare != 0)
+            {
+                return compare;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/roles/middleware/files/FWO.Middleware.Server/Services/ComplianceZoneService.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/ComplianceZoneService.cs
@@ -1,0 +1,151 @@
+using FWO.Api.Client;
+using FWO.Api.Client.Queries;
+using FWO.Basics;
+using FWO.Compliance;
+using FWO.Config.Api;
+using FWO.Data;
+using FWO.Middleware.Server.Requests;
+using FWO.Middleware.Server.Responses;
+using NetTools;
+
+namespace FWO.Middleware.Server.Services;
+
+/// <summary>
+/// Resolves compliance zones for stored and draft network objects.
+/// </summary>
+public sealed class ComplianceZoneService
+{
+    private readonly ApiConnection apiConnection;
+    private readonly GlobalConfig globalConfig;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComplianceZoneService"/> class.
+    /// </summary>
+    /// <param name="apiConnection">The shared API connection.</param>
+    /// <param name="globalConfig">The global configuration.</param>
+    public ComplianceZoneService(ApiConnection apiConnection, GlobalConfig globalConfig)
+    {
+        this.apiConnection = apiConnection;
+        this.globalConfig = globalConfig;
+    }
+
+    /// <summary>
+    /// Returns the zones defined by the configured designated zone matrix.
+    /// </summary>
+    public async Task<List<ComplianceDesignatedZoneResponse>> GetDesignatedZoneMatrixZonesAsync()
+    {
+        List<ComplianceNetworkZone> zones = await LoadDesignatedZoneMatrixZonesAsync();
+        return zones.Select(MapDesignatedZoneResponse).ToList();
+    }
+
+    /// <summary>
+    /// Returns the zones that a draft object tree would occupy.
+    /// </summary>
+    public async Task<List<ComplianceDesignatedZoneResponse>> ResolveZonesForObjectsAsync(GetZonesForDraftObjectsRequest request)
+    {
+        List<IPAddressRange> ranges = CollectRanges(request.Objects ?? []);
+        if (ranges.Count == 0)
+        {
+            return [];
+        }
+
+        List<ComplianceNetworkZone> zones = await LoadDesignatedZoneMatrixZonesAsync();
+        if (zones.Count == 0)
+        {
+            return [];
+        }
+
+        List<ComplianceNetworkZone> resolvedZones = ComplianceZoneResolver.ResolveZones(
+            ranges,
+            zones,
+            globalConfig.AutoCalculateInternetZone,
+            globalConfig.GetText("internet_local_zone"));
+
+        return resolvedZones
+            .OrderBy(zone => zone.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(zone => zone.Id)
+            .Select(MapDesignatedZoneResponse)
+            .ToList();
+    }
+
+    private async Task<List<ComplianceNetworkZone>> LoadDesignatedZoneMatrixZonesAsync()
+    {
+        if (globalConfig.ComplianceDesignatedZoneMatrixId <= 0)
+        {
+            return [];
+        }
+
+        List<ComplianceCriterion> designatedMatrices = await apiConnection.SendQueryAsync<List<ComplianceCriterion>>(
+            ComplianceQueries.getMatrixById,
+            new { criterionId = globalConfig.ComplianceDesignatedZoneMatrixId }) ?? [];
+
+        if (designatedMatrices.Count == 0)
+        {
+            return [];
+        }
+
+        return await apiConnection.SendQueryAsync<List<ComplianceNetworkZone>>(
+            ComplianceQueries.getNetworkZonesForMatrix,
+            new { criterionId = globalConfig.ComplianceDesignatedZoneMatrixId }) ?? [];
+    }
+
+    private static List<IPAddressRange> CollectRanges(IEnumerable<GetZonesForDraftObjectsRequest.DraftObjectRequest> objects)
+    {
+        List<IPAddressRange> ranges = [];
+
+        foreach (GetZonesForDraftObjectsRequest.DraftObjectRequest draftObject in objects)
+        {
+            ranges.AddRange(CollectRanges(draftObject));
+        }
+
+        return ranges;
+    }
+
+    private static List<IPAddressRange> CollectRanges(GetZonesForDraftObjectsRequest.DraftObjectRequest draftObject)
+    {
+        if (string.Equals(draftObject.Type, ObjectType.Group, StringComparison.OrdinalIgnoreCase))
+        {
+            return CollectRanges(draftObject.Members ?? []);
+        }
+
+        NetworkObject networkObject = new()
+        {
+            Name = draftObject.Name,
+            IP = draftObject.IpStart,
+            IpEnd = draftObject.IpEnd,
+            Type = new NetworkObjectType
+            {
+                Name = NormalizeObjectType(draftObject.Type)
+            }
+        };
+
+        return ComplianceCheck.ParseIpRange(networkObject);
+    }
+
+    private static string NormalizeObjectType(string objectType)
+    {
+        return (objectType ?? string.Empty).ToLowerInvariant() switch
+        {
+            ObjectType.Host => ObjectType.Host,
+            ObjectType.Network => ObjectType.Network,
+            ObjectType.IPRange => ObjectType.IPRange,
+            ObjectType.Group => ObjectType.Group,
+            _ => string.Empty
+        };
+    }
+
+    private static ComplianceDesignatedZoneResponse MapDesignatedZoneResponse(ComplianceNetworkZone zone)
+    {
+        return new ComplianceDesignatedZoneResponse
+        {
+            Id = zone.Id,
+            Name = zone.Name,
+            Description = zone.Description,
+            IpRanges = [.. zone.IPRanges.Select(ipRange => new ComplianceDesignatedZoneIpRangeResponse
+            {
+                IpStart = ipRange.Begin.ToString(),
+                IpEnd = ipRange.End.ToString()
+            })]
+        };
+    }
+}

--- a/roles/tests-unit/files/FWO.Test/ApiExampleCatalogTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ApiExampleCatalogTest.cs
@@ -46,6 +46,11 @@ public class ApiExampleCatalogTest
         Assert.That(json, Does.Contain("\"timeObjectId\""));
         Assert.That(json, Does.Not.Contain("\"RequestorName\""));
         Assert.That(json, Does.Not.Contain("\"TimeObjectId\""));
+
+        Assert.That(catalog.TryGetExample(typeof(GetZonesForDraftObjectsRequest), out object? zoneExample), Is.True);
+        string zoneJson = JsonSerializer.Serialize(zoneExample, zoneExample!.GetType(), serializerOptions);
+        Assert.That(zoneJson, Does.Contain("\"objects\""));
+        Assert.That(zoneJson, Does.Contain("\"members\""));
     }
 
     /// <summary>

--- a/roles/tests-unit/files/FWO.Test/ComplianceControllerTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ComplianceControllerTest.cs
@@ -3,6 +3,7 @@ using FWO.Api.Client.Queries;
 using FWO.Config.Api.Data;
 using FWO.Data;
 using FWO.Middleware.Server.Controllers;
+using FWO.Middleware.Server.Requests;
 using FWO.Middleware.Server.Responses;
 using FWO.Middleware.Server.Services;
 using NUnit.Framework;
@@ -18,7 +19,8 @@ namespace FWO.Test
         [Test]
         public void GetInitialComplianceCheckStatus_ReturnsNotFoundForUnknownJob()
         {
-            ComplianceController controller = new(new DummyApiConnection(), new ComplianceCheckStatusTracker());
+            DummyApiConnection apiConnection = new();
+            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker(), CreateZoneService(apiConnection));
 
             var result = controller.GetInitialComplianceCheckStatus("missing");
 
@@ -30,7 +32,8 @@ namespace FWO.Test
         {
             ComplianceCheckStatusTracker tracker = new();
             tracker.CreateQueuedJob();
-            ComplianceController controller = new(new DummyApiConnection(), tracker);
+            DummyApiConnection apiConnection = new();
+            ComplianceController controller = new(apiConnection, tracker, CreateZoneService(apiConnection));
 
             var result = controller.StartInitialComplianceCheck();
 
@@ -50,7 +53,7 @@ namespace FWO.Test
                     Description = "Demilitarized zone",
                     IPRanges = [new IPAddressRange(IPAddress.Parse("10.0.0.0"), IPAddress.Parse("10.0.0.255"))]
                 }]);
-            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker());
+            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker(), CreateZoneService(apiConnection, 12));
 
             ActionResult<List<ComplianceDesignatedZoneResponse>> result = await controller.GetDesignatedZoneMatrixZones();
 
@@ -75,7 +78,7 @@ namespace FWO.Test
                 [new ConfigItem { Key = "complianceDesignatedZoneMatrix", Value = "12", User = 0 }],
                 [new ComplianceCriterion { Id = 12, Name = "Designated Matrix" }],
                 [new ComplianceNetworkZone { Id = 99, Name = "DMZ" }]);
-            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker());
+            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker(), CreateZoneService(apiConnection, 12));
 
             _ = await controller.GetDesignatedZoneMatrixZones();
 
@@ -92,7 +95,7 @@ namespace FWO.Test
                 [new ConfigItem { Key = "complianceDesignatedZoneMatrix", Value = "12", User = 0 }],
                 [],
                 [new ComplianceNetworkZone { Id = 99, Name = "DMZ" }]);
-            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker());
+            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker(), CreateZoneService(apiConnection, 12));
 
             ActionResult<List<ComplianceDesignatedZoneResponse>> result = await controller.GetDesignatedZoneMatrixZones();
 
@@ -109,7 +112,7 @@ namespace FWO.Test
         public async Task GetDesignatedZoneMatrixZones_ReturnsEmptyListWhenNoMatrixConfigured()
         {
             DummyApiConnection apiConnection = new();
-            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker());
+            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker(), CreateZoneService(apiConnection));
 
             ActionResult<List<ComplianceDesignatedZoneResponse>> result = await controller.GetDesignatedZoneMatrixZones();
 
@@ -118,6 +121,82 @@ namespace FWO.Test
             Assert.That(zones, Is.Empty);
             Assert.That(apiConnection.LastNetworkZoneQuery, Is.Null);
             Assert.That(apiConnection.NetworkZoneQueryCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task ResolveZonesForObjects_ReturnsZonesForNestedDraftGroups()
+        {
+            DummyApiConnection apiConnection = new(
+                [new ConfigItem { Key = "complianceDesignatedZoneMatrix", Value = "12", User = 0 }],
+                [new ComplianceCriterion { Id = 12, Name = "Designated Matrix" }],
+                [
+                    new ComplianceNetworkZone
+                    {
+                        Id = 20,
+                        Name = "Backend",
+                        Description = "Backend zone",
+                        IPRanges = [new IPAddressRange(IPAddress.Parse("10.0.0.1"), IPAddress.Parse("10.0.0.1"))]
+                    },
+                    new ComplianceNetworkZone
+                    {
+                        Id = 10,
+                        Name = "DMZ",
+                        Description = "Demilitarized zone",
+                        IPRanges = [new IPAddressRange(IPAddress.Parse("10.0.1.1"), IPAddress.Parse("10.0.1.1"))]
+                    }
+                ]);
+            ComplianceController controller = new(apiConnection, new ComplianceCheckStatusTracker(), CreateZoneService(apiConnection, 12));
+
+            ActionResult<List<ComplianceDesignatedZoneResponse>> result = await controller.ResolveZonesForObjects(new GetZonesForDraftObjectsRequest
+            {
+                Objects =
+                [
+                    new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                    {
+                        Name = "Root Group",
+                        Type = "group",
+                        Members =
+                        [
+                            new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                            {
+                                Name = "Sub Group",
+                                Type = "group",
+                                Members =
+                                [
+                                    new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                                    {
+                                        Name = "Backend Host",
+                                        Type = "host",
+                                        IpStart = "10.0.0.1",
+                                        IpEnd = "10.0.0.1"
+                                    },
+                                    new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                                    {
+                                        Name = "Backend Host Duplicate",
+                                        Type = "network",
+                                        IpStart = "10.0.0.1",
+                                        IpEnd = "10.0.0.1"
+                                    },
+                                    new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                                    {
+                                        Name = "DMZ Host",
+                                        Type = "ip_range",
+                                        IpStart = "10.0.1.1",
+                                        IpEnd = "10.0.1.1"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            });
+
+            Assert.That(result.Result, Is.InstanceOf<OkObjectResult>());
+            List<ComplianceDesignatedZoneResponse> zones = ((OkObjectResult)result.Result!).Value as List<ComplianceDesignatedZoneResponse> ?? [];
+            Assert.That(zones, Has.Count.EqualTo(2));
+            Assert.That(zones.Select(zone => zone.Name), Is.EqualTo(["Backend", "DMZ"]));
+            Assert.That(apiConnection.MatrixQueryCount, Is.EqualTo(1));
+            Assert.That(apiConnection.NetworkZoneQueryCount, Is.EqualTo(1));
         }
 
         private sealed class DummyApiConnection : ApiConnection
@@ -182,6 +261,16 @@ namespace FWO.Test
             object? value = obj!.GetType().GetProperty(propertyName)?.GetValue(obj);
             Assert.That(value, Is.Not.Null, $"Expected property '{propertyName}' to exist and have a value.");
             return (T)value!;
+        }
+
+        private static ComplianceZoneService CreateZoneService(ApiConnection apiConnection, int matrixId = 0)
+        {
+            SimulatedGlobalConfig globalConfig = new()
+            {
+                ComplianceDesignatedZoneMatrixId = matrixId
+            };
+
+            return new ComplianceZoneService(apiConnection, globalConfig);
         }
     }
 }

--- a/roles/tests-unit/files/FWO.Test/ComplianceZoneServiceTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ComplianceZoneServiceTest.cs
@@ -1,0 +1,170 @@
+using FWO.Api.Client;
+using FWO.Api.Client.Queries;
+using FWO.Config.Api.Data;
+using FWO.Data;
+using FWO.Middleware.Server.Requests;
+using FWO.Middleware.Server.Responses;
+using FWO.Middleware.Server.Services;
+using NUnit.Framework;
+using System.Net;
+
+namespace FWO.Test;
+
+[TestFixture]
+internal class ComplianceZoneServiceTest
+{
+    [Test]
+    public async Task ResolveZonesForObjectsAsync_ReturnsOrderedUniqueZonesForNestedGroups()
+    {
+        ComplianceZoneServiceApiConn apiConnection = new(
+            [new ConfigItem { Key = "complianceDesignatedZoneMatrix", Value = "12", User = 0 }],
+            [new ComplianceCriterion { Id = 12, Name = "Designated Matrix" }],
+            [
+                new ComplianceNetworkZone
+                {
+                    Id = 20,
+                    Name = "Backend",
+                    Description = "Backend zone",
+                    IPRanges = [new NetTools.IPAddressRange(IPAddress.Parse("10.0.0.1"), IPAddress.Parse("10.0.0.1"))]
+                },
+                new ComplianceNetworkZone
+                {
+                    Id = 10,
+                    Name = "DMZ",
+                    Description = "Demilitarized zone",
+                    IPRanges = [new NetTools.IPAddressRange(IPAddress.Parse("10.0.1.1"), IPAddress.Parse("10.0.1.1"))]
+                }
+            ]);
+        ComplianceZoneService service = new(apiConnection, new SimulatedGlobalConfig { ComplianceDesignatedZoneMatrixId = 12 });
+
+        List<ComplianceDesignatedZoneResponse> result = await service.ResolveZonesForObjectsAsync(new GetZonesForDraftObjectsRequest
+        {
+            Objects =
+            [
+                new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                {
+                    Name = "Root Group",
+                    Type = "group",
+                    Members =
+                    [
+                        new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                        {
+                            Name = "Sub Group",
+                            Type = "group",
+                            Members =
+                            [
+                                new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                                {
+                                    Name = "Backend Host",
+                                    Type = "host",
+                                    IpStart = "10.0.0.1",
+                                    IpEnd = "10.0.0.1"
+                                },
+                                new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                                {
+                                    Name = "Backend Host Duplicate",
+                                    Type = "network",
+                                    IpStart = "10.0.0.1",
+                                    IpEnd = "10.0.0.1"
+                                },
+                                new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                                {
+                                    Name = "DMZ Host",
+                                    Type = "ip_range",
+                                    IpStart = "10.0.1.1",
+                                    IpEnd = "10.0.1.1"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Has.Count.EqualTo(2));
+            Assert.That(result.Select(zone => zone.Name), Is.EqualTo(["Backend", "DMZ"]));
+            Assert.That(apiConnection.MatrixQueryCount, Is.EqualTo(1));
+            Assert.That(apiConnection.NetworkZoneQueryCount, Is.EqualTo(1));
+        });
+    }
+
+    private sealed class ComplianceZoneServiceApiConn : SimulatedApiConnection
+    {
+        private readonly ConfigItem[] configItems;
+        private readonly List<ComplianceCriterion> matrices;
+        private readonly List<ComplianceNetworkZone> zones;
+
+        public int MatrixQueryCount { get; private set; }
+        public int NetworkZoneQueryCount { get; private set; }
+
+        public ComplianceZoneServiceApiConn(ConfigItem[] configItems, List<ComplianceCriterion> matrices, List<ComplianceNetworkZone> zones)
+        {
+            this.configItems = configItems;
+            this.matrices = matrices;
+            this.zones = zones;
+        }
+
+        public override Task<QueryResponseType> SendQueryAsync<QueryResponseType>(string query, object? variables = null, string? operationName = null, QueryChunkingOptions? chunkingOptions = null)
+        {
+            if (typeof(QueryResponseType) == typeof(ConfigItem[]) && query == ConfigQueries.getConfigItemsByUser)
+            {
+                return Task.FromResult((QueryResponseType)(object)configItems);
+            }
+
+            if (typeof(QueryResponseType) == typeof(List<ComplianceCriterion>) && query == ComplianceQueries.getMatrixById)
+            {
+                MatrixQueryCount++;
+                return Task.FromResult((QueryResponseType)(object)matrices);
+            }
+
+            if (typeof(QueryResponseType) == typeof(List<ComplianceNetworkZone>) && query == ComplianceQueries.getNetworkZonesForMatrix)
+            {
+                NetworkZoneQueryCount++;
+                return Task.FromResult((QueryResponseType)(object)zones);
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public override Task<ApiResponse<QueryResponseType>> SendQuerySafeAsync<QueryResponseType>(string query, object? variables = null, string? operationName = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override GraphQlApiSubscription<SubscriptionResponseType> GetSubscription<SubscriptionResponseType>(Action<Exception> exceptionHandler, GraphQlApiSubscription<SubscriptionResponseType>.SubscriptionUpdate subscriptionUpdateHandler, string subscription, object? variables = null, string? operationName = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetAuthHeader(string jwt)
+        {
+        }
+
+        public override void SetRole(string role)
+        {
+        }
+
+        public override void SetBestRole(System.Security.Claims.ClaimsPrincipal user, List<string> targetRoleList)
+        {
+        }
+
+        public override void SwitchBack()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+        }
+
+        public override void DisposeSubscriptions<T>()
+        {
+        }
+
+        public override Task ReconnectSubscriptionsAsync(string jwt, CancellationToken ct)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/roles/tests-unit/files/FWO.Test/ComplianceZoneValidationTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ComplianceZoneValidationTest.cs
@@ -1,0 +1,155 @@
+using FWO.Middleware.Server.Requests;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using System.Text.Json;
+
+namespace FWO.Test;
+
+[TestFixture]
+internal class ComplianceZoneValidationTest
+{
+    [Test]
+    public void GetZonesForDraftObjects_AllowsNestedDraftGroups()
+    {
+        string json = """
+        {
+          "objects": [
+            {
+              "name": "Root Group",
+              "type": "group",
+              "members": [
+                {
+                  "name": "Leaf",
+                  "type": "network",
+                  "ipStart": "10.0.0.1",
+                  "ipEnd": "10.0.0.1"
+                },
+                {
+                  "name": "Nested Group",
+                  "type": "group",
+                  "members": [
+                    {
+                      "name": "Nested Leaf",
+                      "type": "ip_range",
+                      "ipStart": "10.0.1.1",
+                      "ipEnd": "10.0.1.10"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+        GetZonesForDraftObjectsRequest request = JsonSerializer.Deserialize<GetZonesForDraftObjectsRequest>(json)!;
+
+        bool valid = GetZonesForDraftObjectsRequestValidator.TryValidate(request, out ActionResult? errorResult);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(valid, Is.True);
+            Assert.That(errorResult, Is.Null);
+        });
+    }
+
+    [Test]
+    public void GetZonesForDraftObjects_RejectsUnknownNestedKey()
+    {
+        string json = """
+        {
+          "objects": [
+            {
+              "name": "Root Group",
+              "type": "group",
+              "members": [
+                {
+                  "name": "Leaf",
+                  "type": "network",
+                  "ipStart": "10.0.0.1",
+                  "ipEnd": "10.0.0.1",
+                  "typo": true
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+        GetZonesForDraftObjectsRequest request = JsonSerializer.Deserialize<GetZonesForDraftObjectsRequest>(json)!;
+
+        bool valid = GetZonesForDraftObjectsRequestValidator.TryValidate(request, out ActionResult? errorResult);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(valid, Is.False);
+            Assert.That(errorResult, Is.TypeOf<BadRequestObjectResult>());
+            Assert.That(((BadRequestObjectResult)errorResult!).Value?.ToString(), Does.Contain("members entry at index 0"));
+            Assert.That(((BadRequestObjectResult)errorResult!).Value?.ToString(), Does.Contain("only accepts"));
+        });
+    }
+
+    [Test]
+    public void GetZonesForDraftObjects_RejectsLeafObjectsWithMembers()
+    {
+        GetZonesForDraftObjectsRequest request = new()
+        {
+            Objects =
+            [
+                new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                {
+                    Name = "Leaf",
+                    Type = "network",
+                    IpStart = "10.0.0.1",
+                    IpEnd = "10.0.0.1",
+                    Members =
+                    [
+                        new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                        {
+                            Name = "Child",
+                            Type = "host",
+                            IpStart = "10.0.0.2",
+                            IpEnd = "10.0.0.2"
+                        }
+                    ]
+                }
+            ]
+        };
+
+        bool valid = GetZonesForDraftObjectsRequestValidator.TryValidate(request, out ActionResult? errorResult);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(valid, Is.False);
+            Assert.That(errorResult, Is.TypeOf<BadRequestObjectResult>());
+            Assert.That(((BadRequestObjectResult)errorResult!).Value?.ToString(), Does.Contain("must not define 'members'"));
+        });
+    }
+
+    [Test]
+    public void GetZonesForDraftObjects_RejectsHostRanges()
+    {
+        GetZonesForDraftObjectsRequest request = new()
+        {
+            Objects =
+            [
+                new GetZonesForDraftObjectsRequest.DraftObjectRequest
+                {
+                    Name = "Host",
+                    Type = "host",
+                    IpStart = "10.0.0.1",
+                    IpEnd = "10.0.0.2"
+                }
+            ]
+        };
+
+        bool valid = GetZonesForDraftObjectsRequestValidator.TryValidate(request, out ActionResult? errorResult);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(valid, Is.False);
+            Assert.That(errorResult, Is.TypeOf<BadRequestObjectResult>());
+            Assert.That(((BadRequestObjectResult)errorResult!).Value?.ToString(), Does.Contain("must use the same 'ipStart' and 'ipEnd'"));
+        });
+    }
+}

--- a/roles/tests-unit/files/FWO.Test/SimulatedUserConfig.cs
+++ b/roles/tests-unit/files/FWO.Test/SimulatedUserConfig.cs
@@ -143,6 +143,7 @@ namespace FWO.Test
             {"host","Host"},
             {"network","Network"},
             {"ip_range","IP Range"},
+            {"internet_local_zone","Internet/Local"},
             {"connections","Connections"},
             {"interfaces","Interfaces"},
             {"own_common_services","Own Common Services"},


### PR DESCRIPTION
Add a new compliance endpoint that resolves network zones for one or more object DTOs, including recursively nested groups, without requiring the objects to exist yet. The endpoint reuses the compliance zone matching logic, returns a stable deduplicated zone list, and includes unit coverage plus OpenAPI examples for the new request shape (though these are created by Codex as I have not encountered them before).