### PR TITLE
fix(ui): memory leak in RuleTreeBuilder

### DIFF
--- a/roles/lib/files/FWO.Report/ReportRules.cs
+++ b/roles/lib/files/FWO.Report/ReportRules.cs
@@ -40,7 +40,7 @@ namespace FWO.Report
         /// <summary>
         /// Flattened real rules (non-header) for each device in each management, used for export and JSON output.
         /// </summary>
-        private static Dictionary<(int deviceId, int managementId), Rule[]> _rulesCache = [];
+        private readonly Dictionary<(int deviceId, int managementId), Rule[]> _rulesCache = [];
         private readonly IRuleTreeBuilder? ruleTreeBuilderFromScope = ruleTreeBuilder;
 
         public override async Task Generate(int elementsPerFetch, ApiConnection apiConnection, Func<ReportData, Task> callback, CancellationToken ct)
@@ -154,6 +154,9 @@ namespace FWO.Report
             }
 
             // Build rule tree for each device in each management
+
+            scopedRuleTreeBuilder.ClearCachedRuleTrees();
+            _rulesCache.Clear();
 
             int ruleCount = 0;
 

--- a/roles/lib/files/FWO.Services/RuleTreeBuilder/IRuleTreeBuilder.cs
+++ b/roles/lib/files/FWO.Services/RuleTreeBuilder/IRuleTreeBuilder.cs
@@ -29,5 +29,10 @@ namespace FWO.Services.RuleTreeBuilder
         /// the flattened rules that reports render.
         /// </summary>
         List<Rule> BuildRuleTree(RulebaseReport[] rulebases, RulebaseLink[] links, int managementId, int deviceId, bool suppressEmptyHeaders = false);
+
+        /// <summary>
+        /// Clears cached trees and flattened rows from previous report generations.
+        /// </summary>
+        void ClearCachedRuleTrees();
     }
 }

--- a/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeBuilder.cs
+++ b/roles/lib/files/FWO.Services/RuleTreeBuilder/RuleTreeBuilder.cs
@@ -26,8 +26,8 @@ namespace FWO.Services.RuleTreeBuilder
     /// </list>
     ///
     /// The builder is scoped as a service, so per-build state is reinitialized inside
-    /// <see cref="BuildRuleTree"/>. The only state preserved across builds is the cache of
-    /// completed trees and their flattened rule rows.
+    /// <see cref="BuildRuleTree"/>. Completed trees and their flattened rule rows are kept only
+    /// for the active report generation and can be discarded with <see cref="ClearCachedRuleTrees"/>.
     /// </summary>
     public class RuleTreeBuilder : IRuleTreeBuilder
     {
@@ -123,6 +123,17 @@ namespace FWO.Services.RuleTreeBuilder
         }
 
         /// <summary>
+        /// Clears all cached trees and flattened rule rows. UI report generation calls this once
+        /// before building a fresh report so a long-lived scoped builder does not retain every
+        /// previously rendered report for the lifetime of the Blazor circuit.
+        /// </summary>
+        public void ClearCachedRuleTrees()
+        {
+            RuleTreeCache.Clear();
+            FlattenedRules.Clear();
+        }
+
+        /// <summary>
         /// Builds a rule tree for one management/device pair from normalized rulebases and
         /// rulebase links. The method creates a fresh per-build graph view, traverses ordered
         /// layers, sections, and inline layers by following their graph relationships, then
@@ -144,6 +155,11 @@ namespace FWO.Services.RuleTreeBuilder
 
             TraverseOrderedLayers();
             List<Rule> flattenedRules = FlattenTreeAndAssignDisplayNumbers(suppressEmptyHeaders);
+
+            if (RuleTreeCache.TryGetValue((managementId, deviceId), out RuleTreeItem? previousRuleTree))
+            {
+                FlattenedRules.Remove(previousRuleTree);
+            }
 
             RuleTreeCache[(managementId, deviceId)] = RuleTree;
             FlattenedRules[RuleTree] = [.. flattenedRules];

--- a/roles/tests-unit/files/FWO.Test/ReportRulesTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ReportRulesTest.cs
@@ -468,6 +468,68 @@ namespace FWO.Test
             }
         }
 
+        [Test]
+        public void Test_TryBuildRuleTree_ReplacesScopedRuleTreeCacheBetweenReports()
+        {
+            ManagementReport CreateManagement(int managementId, int firstDeviceId, int deviceCount)
+            {
+                RulebaseReport rulebase = MockReportRules.CreateRulebaseReport($"RB{managementId}", 1);
+                DeviceReport[] devices = [.. Enumerable.Range(firstDeviceId, deviceCount).Select(deviceId =>
+                    MockReportRules.CreateDeviceReport(deviceId, $"Device{deviceId}",
+                    [
+                        new RulebaseLink
+                        {
+                            GatewayId = deviceId,
+                            IsInitial = true,
+                            FromRulebaseId = 0,
+                            NextRulebaseId = rulebase.Id,
+                            LinkType = 2
+                        }
+                    ]))];
+
+                return new ManagementReport
+                {
+                    Id = managementId,
+                    Name = $"Management{managementId}",
+                    Devices = devices,
+                    Rulebases = [rulebase]
+                };
+            }
+
+            IServiceProvider? originalServices = FWO.Services.ServiceProvider.Services;
+            ServiceCollection services = new();
+            services.AddSingleton<IRuleTreeBuilder>(_ruleTreeBuilder);
+            FWO.Services.ServiceProvider.Services = services.BuildServiceProvider();
+
+            try
+            {
+                MockReportRules firstReport = new(new DynGraphqlQuery(""), new SimulatedUserConfig(), ReportType.ResolvedRules, () =>
+                [
+                    CreateManagement(1, 1, 2)
+                ]);
+                firstReport.TryBuildMockRuleTree();
+
+                Assert.That(_ruleTreeBuilder.RuleTreeCache, Has.Count.EqualTo(2));
+                Assert.That(_ruleTreeBuilder.FlattenedRules, Has.Count.EqualTo(2));
+
+                MockReportRules secondReport = new(new DynGraphqlQuery(""), new SimulatedUserConfig(), ReportType.ResolvedRules, () =>
+                [
+                    CreateManagement(2, 10, 1)
+                ]);
+                secondReport.TryBuildMockRuleTree();
+
+                Assert.That(_ruleTreeBuilder.RuleTreeCache, Has.Count.EqualTo(1));
+                Assert.That(_ruleTreeBuilder.FlattenedRules, Has.Count.EqualTo(1));
+                Assert.That(_ruleTreeBuilder.RuleTreeCache.ContainsKey((1, 1)), Is.False);
+                Assert.That(_ruleTreeBuilder.RuleTreeCache.ContainsKey((1, 2)), Is.False);
+                Assert.That(_ruleTreeBuilder.RuleTreeCache.ContainsKey((2, 10)), Is.True);
+            }
+            finally
+            {
+                FWO.Services.ServiceProvider.Services = originalServices;
+            }
+        }
+
         [TestCase(PreferredCollapseState.Collapsed, false)]
         [TestCase(PreferredCollapseState.Expanded, true)]
         [TestCase(PreferredCollapseState.Intermediate, true)]

--- a/roles/tests-unit/files/FWO.Test/ReportRulesTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ReportRulesTest.cs
@@ -499,7 +499,8 @@ namespace FWO.Test
             IServiceProvider? originalServices = FWO.Services.ServiceProvider.Services;
             ServiceCollection services = new();
             services.AddSingleton<IRuleTreeBuilder>(_ruleTreeBuilder);
-            FWO.Services.ServiceProvider.Services = services.BuildServiceProvider();
+            using var scopedServices = services.BuildServiceProvider();
+            FWO.Services.ServiceProvider.Services = scopedServices;
 
             try
             {

--- a/roles/tests-unit/files/FWO.Test/ReportRulesTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ReportRulesTest.cs
@@ -9,7 +9,6 @@ using FWO.Test.Mocks;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
-using System.Reflection;
 
 namespace FWO.Test
 {
@@ -104,20 +103,7 @@ namespace FWO.Test
 
             _managementReport = _managementReports.First();
 
-            // Cache manuell fill mit der Reihenfolge: RB2 (initial) zuerst
             _rules = _rb2.Rules.Concat(_rb1.Rules).Concat(_rb3.Rules).ToArray();
-            typeof(ReportRules)
-                .GetField("_rulesCache", BindingFlags.NonPublic | BindingFlags.Static)!
-                .SetValue(null, new Dictionary<(int, int), Rule[]> { [(_deviceReport.Id, _managementReport.Id)] = _rules });
-
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            typeof(ReportRules)
-                .GetField("_rulesCache", BindingFlags.NonPublic | BindingFlags.Static)!
-                .SetValue(null, new Dictionary<(int, int), Rule[]>());
         }
 
         [Test]
@@ -258,11 +244,6 @@ namespace FWO.Test
             var management = new ManagementReport();
             management.Id = 1;
             var rules = new Rule[] { new Rule { Id = 1, RulebaseId = 1 } };
-
-            // Cache manuell setzen
-            typeof(ReportRules)
-                .GetField("_rulesCache", BindingFlags.NonPublic | BindingFlags.Static)!
-                .SetValue(null, new Dictionary<(int, int), Rule[]> { [(device.Id, management.Id)] = rules });
 
             RuleTreeBuilder ruleTreeBuilder = new RuleTreeBuilder();
             ruleTreeBuilder.RuleTreeCache[(management.Id, device.Id)] = ruleTreeBuilder.RuleTree;


### PR DESCRIPTION
Because the RuleTreeBuilder is being used as a service, the cache needs to be reset or memory usage will grow over time.

Likely related to #4910