### PR TITLE
fix(middleware): flow sync config subscription

### DIFF
--- a/roles/common/files/fwo-api-calls/config/subscribeFlowSyncConfigChanges.graphql
+++ b/roles/common/files/fwo-api-calls/config/subscribeFlowSyncConfigChanges.graphql
@@ -1,6 +1,7 @@
 subscription subscribeFlowSyncConfigChanges {
   config(where: {_or: [
-        {config_key: {_eq: "flowSyncSleepTime"}}
+        {config_key: {_eq: "flowSyncSleepTime"}},
+        {config_key: {_eq: "flowNamingSourceManagementRanking"}}
     ]}
     ){
     config_key

--- a/roles/tests-unit/files/FWO.Test/ConfigTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ConfigTest.cs
@@ -329,9 +329,10 @@ namespace FWO.Test
         }
 
         [Test]
-        public void FlowSyncSubscription_ContainsFlowSyncSleepTime()
+        public void FlowSyncSubscription_ContainsFlowSyncConfigSettings()
         {
             Assert.That(ConfigQueries.subscribeFlowSyncConfigChanges, Does.Contain("flowSyncSleepTime"));
+            Assert.That(ConfigQueries.subscribeFlowSyncConfigChanges, Does.Contain("flowNamingSourceManagementRanking"));
         }
 
         [Test]


### PR DESCRIPTION
fixes an issue where the flow sync job would not use the (newest) naming setting.

see #4862