### PR TITLE
fix code coverage test

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
       - name: Cache SonarCloud packages
         uses: actions/cache@v5
         with:
@@ -59,6 +64,12 @@ jobs:
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         run: dotnet tool update dotnet-sonarscanner --tool-path .sonar/scanner
 
+      - name: Install .NET coverage collector
+        run: dotnet tool update dotnet-coverage --tool-path .sonar/scanner
+
+      - name: Install Python dependencies
+        run: python -m pip install -r roles/importer/files/importer/requirements.txt coverage==7.15.0
+
       - name: Build and analyze
         run: |
           for attempt in 1 2 3; do
@@ -67,7 +78,9 @@ jobs:
               /o:"${SONAR_ORGANIZATION}" \
               /d:sonar.token="${SONAR_TOKEN}" \
               /d:sonar.host.url="https://sonarcloud.io" \
-              /d:sonar.qualitygate.wait=true; then
+              /d:sonar.qualitygate.wait=true \
+              /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml \
+              /d:sonar.python.coverage.reportPaths=python-coverage.xml; then
               break
             else
               status=$?
@@ -81,6 +94,12 @@ jobs:
             sleep $((attempt * 30))
           done
           dotnet build roles/FWO.sln --configuration Debug --no-incremental
+          .sonar/scanner/dotnet-coverage collect \
+            "dotnet test roles/tests-unit/files/FWO.Test/FWO.Test.csproj --configuration Debug --no-build --settings FWO.default.runsettings" \
+            -f xml \
+            -o coverage.xml
+          python -m coverage run -m pytest -q roles/importer/files/importer/test
+          python -m coverage xml -o python-coverage.xml
           for attempt in 1 2 3; do
             if .sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${SONAR_TOKEN}"; then
               break

--- a/roles/tests-unit/files/FWO.Test/PeriodicTaskRunnerTest.cs
+++ b/roles/tests-unit/files/FWO.Test/PeriodicTaskRunnerTest.cs
@@ -60,5 +60,50 @@ namespace FWO.Test
 
             Assert.That(executionCount, Is.EqualTo(executionCountAfterDispose));
         }
+
+        [Test]
+        public async Task Start_CalledTwice_SecondCallIsIgnored()
+        {
+            int executionCount = 0;
+            TaskCompletionSource<bool> firstTickReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using PeriodicTaskRunner runner = new(async () =>
+            {
+                if (Interlocked.Increment(ref executionCount) == 1)
+                {
+                    firstTickReached.TrySetResult(true);
+                }
+
+                await Task.CompletedTask;
+            }, TimeSpan.FromMilliseconds(20));
+
+            runner.Start();
+            Assert.DoesNotThrow(runner.Start);
+
+            Task completedTask = await Task.WhenAny(firstTickReached.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+
+            Assert.That(completedTask, Is.EqualTo(firstTickReached.Task));
+        }
+
+        [Test]
+        public void Dispose_CalledTwice_IsIdempotent()
+        {
+            PeriodicTaskRunner runner = new(() => Task.CompletedTask, TimeSpan.FromMilliseconds(20));
+
+            runner.Start();
+            runner.Dispose();
+
+            Assert.DoesNotThrow(runner.Dispose);
+        }
+
+        [Test]
+        public void Start_AfterDispose_Throws()
+        {
+            PeriodicTaskRunner runner = new(() => Task.CompletedTask, TimeSpan.FromMilliseconds(20));
+
+            runner.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(runner.Start);
+        }
     }
 }


### PR DESCRIPTION
### Root cause
The develop/main analysis workflow [sonarcloud.yml](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/.github/workflows/sonarcloud.yml) only built the solution and never ran tests or imported coverage reports — unlike [sonarcloud-pr.yml](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/.github/workflows/sonarcloud-pr.yml). Without an imported report, Sonar counts every executable new line as uncovered, which is why all 13 files showed exactly 0.0% (and the PRs that introduced this code passed their gates fine, because the PR workflow does collect coverage).

### Changes

- [sonarcloud.yml](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/.github/workflows/sonarcloud.yml) — brought in line with the PR workflow: Python 3.11 setup, dotnet-coverage tool, pinned Python deps, dotnet test under dotnet-coverage collect, pytest under coverage run, and the two sonar.cs.vscoveragexml.reportsPaths / sonar.python.coverage.reportPaths scanner parameters.
- [PeriodicTaskRunnerTest.cs](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/roles/tests-unit/files/FWO.Test/PeriodicTaskRunnerTest.cs) — three new tests (double Start(), double Dispose(), Start() after dispose) closing the only real coverable gaps I found.

### Verification
I ran both suites locally with coverage and cross-referenced every new line since v9.2.0 (the new-code baseline). Python: 400 tests pass, all new lines in all 6 flagged files already covered. C#: 2721 tests pass, all new lines covered except two spots that stay uncovered deliberately — [NotificationEmailLayoutHelper.cs:68](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/roles/lib/files/FWO.Services/EmailNotification/NotificationEmailLayoutHelper.cs#L68) (PDF branch needs a real Chrome; the suite already skips browser-dependent tests) and [PeriodicTaskRunner.cs:88-89](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/roles/ui/files/FWO.UI/Services/PeriodicTaskRunner.cs#L88-L89) (a race guard that can't be hit deterministically). That leaves new-code coverage around 97%, well above the gate.