### PR TITLE
fix some redhat installer issues

### DIFF
--- a/documentation/installer/basic-installation.md
+++ b/documentation/installer/basic-installation.md
@@ -51,14 +51,18 @@ If this is not the case, install a newer ansible. One possible way is to run the
 Install the required Ansible collections before running the playbook. This is required when using `ansible-core`, including the package commonly available on RedHat-like systems:
 
 ```console
+cd firewall-orchestrator
 ansible-galaxy collection install -r collections/requirements.yml -p collections --force
 ```
 
-If using RedHat-like systems and `scripts/requirements.txt` exists in your checkout, install those Python dependencies as well:
+If using RedHat-like systems and `scripts/requirements.txt` exists in your checkout, install those Python dependencies in the same Python environment that runs Ansible. When you use the installer venv script above this is handled automatically. For a manual Ansible setup, activate that environment first and then run:
 
 ```console
+cd firewall-orchestrator
 pip install -r scripts/requirements.txt
 ```
+
+Do not use `sudo pip` for these controller-side dependencies; it installs packages into the system Python instead of the Ansible environment used by the installer.
 
 Note that if your server is behind a proxy, you will have to set the proxy for pip as follows (to allow for ansible venv download):
 

--- a/documentation/installer/install-advanced.md
+++ b/documentation/installer/install-advanced.md
@@ -127,13 +127,14 @@ In case of timeout issues (you might be behind a security proxy that does intens
 
 In case of errors with existing pip config, do not use the script to create the venv but proceed as follows:
 
-remove any local pip config and install manually:
+remove any local pip config and install manually from the cloned repository directory:
     
     rm -f $HOME/.config/pip/pip.conf
+    cd firewall-orchestrator
     sudo apt-get update
     sudo apt-get install --yes python3-venv
-    python3 -m venv installer-venv
-    source installer-venv/bin/activate
+    python3 -m venv --clear $HOME/.fwo/installer-venv
+    source $HOME/.fwo/installer-venv/bin/activate
     pip install -r requirements.txt
     if [ -f scripts/requirements.txt ]; then pip install -r scripts/requirements.txt; fi
     pip install ansible

--- a/roles/importer/tasks/main.yml
+++ b/roles/importer/tasks/main.yml
@@ -54,6 +54,15 @@
         virtualenv: "{{ importer_venv_dir }}"
       environment: "{{ proxy_env }}"
 
+    - name: Set importer venv ownership and readable permissions
+      file:
+        path: "{{ importer_venv_dir }}"
+        state: directory
+        owner: "{{ fworch_user }}"
+        group: "{{ fworch_group }}"
+        mode: "u=rwX,g=rX,o=rX"
+        recurse: true
+
     - name: set x-flag for importer executables (top level only)
       file:
         path: "{{ item }}"

--- a/roles/importer/tasks/main.yml
+++ b/roles/importer/tasks/main.yml
@@ -61,6 +61,7 @@
         owner: "{{ fworch_user }}"
         group: "{{ fworch_group }}"
         mode: "u=rwX,g=rX,o=rX"
+        follow: false
         recurse: true
 
     - name: set x-flag for importer executables (top level only)

--- a/roles/tests-unit/files/FWO.Test/DataImportBaseTest.cs
+++ b/roles/tests-unit/files/FWO.Test/DataImportBaseTest.cs
@@ -33,7 +33,7 @@ namespace FWO.Test
                 Assert.Ignore("Script execution test requires a Unix-like environment.");
             }
 
-            string tempDir = Path.Combine(Path.GetTempPath(), $"fwo-import-test-{Guid.NewGuid():N}");
+            string tempDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"fwo-import-test-{Guid.NewGuid():N}");
             Directory.CreateDirectory(tempDir);
 
             try

--- a/roles/tests-unit/files/FWO.Test/HtmlToPdfTest.cs
+++ b/roles/tests-unit/files/FWO.Test/HtmlToPdfTest.cs
@@ -62,7 +62,7 @@ namespace FWO.Test
                 executablePath = SystemChromium.GetPath();
                 if (executablePath is null)
                 {
-                    string downloadPath = Path.Combine(Path.GetTempPath(), "fwo-puppeteer");
+                    string downloadPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "fwo-puppeteer");
                     Log.WriteInfo("Browser", $"Browser not found for current system - downloading to {downloadPath}...");
                     browserFetcher = new(new BrowserFetcherOptions() { Platform = platform, Browser = wantedBrowser, Path = downloadPath });
                     await browserFetcher.DownloadAsync();

--- a/roles/tests-unit/tasks/main.yml
+++ b/roles/tests-unit/tasks/main.yml
@@ -43,6 +43,8 @@
         chdir: "/usr/local/fworch/importer"
       command: >
         {{ importer_venv_dir }}/bin/python3 -m pytest -s . -p no:cacheprovider -v
+      become: true
+      become_user: "{{ fworch_user }}"
       register: pytest_tests
       ignore_errors: false
 

--- a/scripts/install-ansible-from-venv.sh
+++ b/scripts/install-ansible-from-venv.sh
@@ -24,6 +24,7 @@ set_pip_config_if_compatible() {
 
 main() {
     local python_bin="python3"
+    local venv_dir="${FWORCH_INSTALLER_VENV:-$HOME/.fwo/installer-venv}"
 
     if [[ ! -f /etc/os-release ]]; then
         echo "Could not detect operating system: /etc/os-release missing."
@@ -49,17 +50,18 @@ main() {
             ;;
     esac
 
-    "$python_bin" -m venv --clear installer-venv || return $?
+    mkdir -p "$(dirname "$venv_dir")" || return $?
+    "$python_bin" -m venv --clear "$venv_dir" || return $?
 
-    source installer-venv/bin/activate || return $?
+    source "$venv_dir/bin/activate" || return $?
     if [[ "${http_proxy:-}" != "" ]];
     then
         set_pip_config_if_compatible global.proxy "$http_proxy" || return $?
     fi
     set_pip_config_if_compatible global.default-timeout 3600 || return $?
     pip install -r requirements.txt || return $?
-    if [[ -f collections/requirements.txt ]]; then
-        pip install -r collections/requirements.txt || return $?
+    if [[ -f scripts/requirements.txt ]]; then
+        pip install -r scripts/requirements.txt || return $?
     fi
     pip install ansible || return $?
     ansible-galaxy collection install -r collections/requirements.yml -p collections --force || return $?


### PR DESCRIPTION
fix some issues with installing on hardened redhat systems
- missing become in roles/tests-unit/tasks/main.yml
- unit test was failing which tried to execute file under /tmp/ with "noexec" 

Tested successfully on rocky 9
