### PR TITLE
Sonar Coverage CI: fix missing develop ref

### DIFF
--- a/.github/workflows/sonarcloud-pr.yml
+++ b/.github/workflows/sonarcloud-pr.yml
@@ -63,6 +63,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # The checkout above only contains the fork's refs; its copy of the base
+      # branch may be months stale, which would make Sonar treat everything
+      # merged upstream since then as new code of this PR.
+      - name: Fetch base branch from upstream
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git remote add base "https://github.com/${{ github.repository }}.git"
+          git fetch base "$BASE_REF"
+          git branch -f "$BASE_REF" "base/$BASE_REF"
+
       - name: Set up Java
         uses: actions/setup-java@v5
         with:
@@ -105,6 +116,10 @@ jobs:
         run: python -m pip install -r roles/importer/files/importer/requirements.txt coverage==7.15.0
 
       - name: Build and analyze pull request
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           for attempt in 1 2 3; do
             if .sonar/scanner/dotnet-sonarscanner begin \
@@ -113,9 +128,9 @@ jobs:
               /d:sonar.token="${SONAR_TOKEN}" \
               /d:sonar.host.url="https://sonarcloud.io" \
               /d:sonar.qualitygate.wait=true \
-              /d:sonar.pullrequest.key="${{ github.event.pull_request.number }}" \
-              /d:sonar.pullrequest.branch="${{ github.event.pull_request.head.ref }}" \
-              /d:sonar.pullrequest.base="${{ github.event.pull_request.base.ref }}" \
+              /d:sonar.pullrequest.key="${PR_NUMBER}" \
+              /d:sonar.pullrequest.branch="${PR_HEAD_REF}" \
+              /d:sonar.pullrequest.base="${PR_BASE_REF}" \
               /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml \
               /d:sonar.python.coverage.reportPaths=python-coverage.xml; then
               break


### PR DESCRIPTION
### What's happening
Sonar reports 156,861 new lines for PR #4936, though the PR itself only adds ~7,000. The chain of causes:

- PR #4936 comes from abarz722's fork (abarz722/firewall-orchestrator-1). Its branch was cut from current upstream develop (merge-base with real develop is 4d69332f6, July 14 — perfectly fresh).
- But [sonarcloud-pr.yml:58-64](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/.github/workflows/sonarcloud-pr.yml#L58-L64) checks out the PR head from the fork repo (head.repo.full_name). With fetch-depth: 0 it fetches all of the fork's branches — so the only develop ref the scanner can see is the fork's copy, which was last synced on 2026-03-04.
- The scanner resolves sonar.pullrequest.base=develop against that stale ref. The merge-base it finds is 06a37c84e from Feb 24, 2026, and the diff from there to the PR head is 1,603 files / ~180k insertions — matching Sonar's 156k "new lines" almost exactly.

So every line merged into upstream develop between late February and now is counted as this PR's new code, and all its uncovered lines land in the PR's quality gate — that's your uncovered lines in files the PR never touched.

Note: the same skew applies whenever a fork's develop is stale. It only looks correct right after someone syncs their fork.

### The fix
Make the real base branch available in the clone before scanning. Simplest patch in sonarcloud-pr.yml, after the checkout step:


```yaml
- name: Fetch base branch from upstream
  run: |
    git remote add base "https://github.com/${{ github.repository }}.git"
    git fetch base "${{ github.event.pull_request.base.ref }}"
    git branch -f "${{ github.event.pull_request.base.ref }}" \
      "base/${{ github.event.pull_request.base.ref }}"
```