### PR TITLE
fixes sql and graphql sync

### DIFF
--- a/roles/common/tasks/install-api-calls.yml
+++ b/roles/common/tasks/install-api-calls.yml
@@ -16,4 +16,5 @@
     dest: "{{ fworch_home }}"
     rsync_opts:
       - "--chown={{ fworch_user }}:{{ fworch_group }}"
+      - "--delete-delay"
   become: true

--- a/roles/database/files/upgrade/9.1.16.sql
+++ b/roles/database/files/upgrade/9.1.16.sql
@@ -250,6 +250,8 @@ transition_data AS (
 INSERT INTO request.state_matrix_transition (transition_group_id, from_state_id, to_state_id, sort_order)
 SELECT transition_group_id, from_state_id, to_state_id, sort_order
 FROM transition_data
+JOIN request.state from_state ON from_state.id = transition_data.from_state_id
+JOIN request.state to_state ON to_state.id = transition_data.to_state_id
 ON CONFLICT (transition_group_id, from_state_id, to_state_id) DO NOTHING;
 
 WITH phase_data AS (
@@ -273,6 +275,8 @@ derived_state_data AS (
 INSERT INTO request.state_matrix_derived_state (phase_matrix_id, from_state_id, derived_state_id)
 SELECT phase_matrix_id, from_state_id, derived_state_id
 FROM derived_state_data
+JOIN request.state from_state ON from_state.id = derived_state_data.from_state_id
+JOIN request.state derived_state ON derived_state.id = derived_state_data.derived_state_id
 ON CONFLICT (phase_matrix_id, from_state_id) DO NOTHING;
 
 DROP TABLE IF EXISTS pg_temp.tmp_state_matrix_key;


### PR DESCRIPTION
This PR includes two fixes encountered during an upgrade from 9.1.14 to 9.2.3:

1) Fixed the 9.1.16 upgrade migration in [9.1.16.sql (line 250)](/home/tim/dev/fwo-tim/roles/database/files/upgrade/9.1.16.sql:250).
It now imports transitions and derived-state mappings only when both referenced state IDs exist. Thus stale legacy references such as missing state 260 are skipped rather than aborting the upgrade.

2) Fixed the stale GraphQL-file deployment issue in [install-api-calls.yml (line 19)](/home/tim/dev/fwo-tim/roles/common/tasks/install-api-calls.yml:19).
rsync --delete-delay now removes obsolete deployed queries, including the deleted statisticsCurrent.graphql, after copying the current query set. This resolves the naming-convention test failure.