### PR TITLE
ci: fix 'deployments' being shown in repo

### DIFF
--- a/.github/workflows/fast-forward-main-to-release-tag.yml
+++ b/.github/workflows/fast-forward-main-to-release-tag.yml
@@ -14,7 +14,9 @@ concurrency:
 
 jobs:
   fast-forward-main:
-    environment: stable-release
+    environment:
+      name: stable-release
+      deployment: false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The workflow uses the `stable-release` environment to access its protected GitHub App credentials. By default, GitHub treats every job referencing an environment as a deployment, so it created a misleading `stable-release` deployment entry on the repository and displayed deployment information on every PR—even though this workflow only fast-forwards `main` and deploys nothing.

Setting `deployment: false` keeps the environment’s secrets, variables, and protection rules available to the workflow while preventing GitHub from creating deployment records for future runs. Existing historical deployment records are unaffected.