### PR TITLE
fix: handle FortiManager VIP objects with empty mappedip in NAT normalization

### DIFF
--- a/roles/importer/files/importer/fw_modules/fortiadom5ff/fmgr_network.py
+++ b/roles/importer/files/importer/fw_modules/fortiadom5ff/fmgr_network.py
@@ -169,39 +169,45 @@ def normalize_network_object_ipv6(obj_orig: dict[str, Any], obj: dict[str, Any])
 
 
 def normalize_vip_object(obj_orig: dict[str, Any], obj: dict[str, Any], nw_objects: list[dict[str, Any]]) -> None:
-    obj_zone = "global"
     obj.update({"obj_typ": "host"})
     if "extip" not in obj_orig or len(obj_orig["extip"]) == 0:
         FWOLogger.error("vip (extip): found empty extip field for " + obj_orig["name"])
-    else:
-        if len(obj_orig["extip"]) > 1:
-            FWOLogger.warning(
-                "vip (extip): found more than one extip, just using the first one for " + obj_orig["name"]
-            )
-        set_ip_in_obj(obj, obj_orig["extip"][0])  # resolving nat range if there is one
-        nat_obj: dict[str, Any] = {}
-        nat_obj.update({"obj_typ": "host"})
-        nat_obj.update({"obj_color": "black"})
-        nat_obj.update({"obj_comment": "FWO-auto-generated nat object for VIP"})
-        if (
-            "obj_ip_end" in obj
-        ):  # this obj is a range - include the end ip in name and uid as well to avoid akey conflicts
-            nat_obj.update({"obj_ip_end": str(obj["obj_ip_end"])})
+        return
 
-        normalize_vip_object_nat_ip(obj_orig, obj, nat_obj)
+    if len(obj_orig["extip"]) > 1:
+        FWOLogger.warning("vip (extip): found more than one extip, just using the first one for " + obj_orig["name"])
+    set_ip_in_obj(obj, obj_orig["extip"][0])  # resolving nat range if there is one
+    nat_obj: dict[str, Any] = {}
+    nat_obj.update({"obj_typ": "host"})
+    nat_obj.update({"obj_color": "black"})
+    nat_obj.update({"obj_comment": "FWO-auto-generated nat object for VIP"})
+    if "obj_ip_end" in obj:  # this obj is a range - include the end ip in name and uid as well to avoid akey conflicts
+        nat_obj.update({"obj_ip_end": str(obj["obj_ip_end"])})
 
-        if "obj_ip_end" not in nat_obj:
-            nat_obj.update({"obj_ip_end": str(obj["obj_nat_ip"])})
+    normalize_vip_object_nat_ip(obj_orig, obj, nat_obj)
 
-        if (
-            "associated-interface" in obj_orig and len(obj_orig["associated-interface"]) > 0
-        ):  # and obj_orig['associated-interface'][0] != 'any':
-            obj_zone = obj_orig["associated-interface"][0]
-        nat_obj.update({"obj_zone": obj_zone})
-        if (
-            nat_obj not in nw_objects
-        ):  # rare case when a destination nat is down for two different orig ips to the same dest ip
-            nw_objects.append(nat_obj)
+    if "obj_nat_ip" not in obj:
+        return
+
+    finalize_vip_nat_object(obj_orig, obj, nat_obj, nw_objects)
+
+
+def finalize_vip_nat_object(
+    obj_orig: dict[str, Any], obj: dict[str, Any], nat_obj: dict[str, Any], nw_objects: list[dict[str, Any]]
+) -> None:
+    if "obj_ip_end" not in nat_obj:
+        nat_obj.update({"obj_ip_end": str(obj["obj_nat_ip"])})
+
+    obj_zone = "global"
+    if (
+        "associated-interface" in obj_orig and len(obj_orig["associated-interface"]) > 0
+    ):  # and obj_orig['associated-interface'][0] != 'any':
+        obj_zone = obj_orig["associated-interface"][0]
+    nat_obj.update({"obj_zone": obj_zone})
+    if (
+        nat_obj not in nw_objects
+    ):  # rare case when a destination nat is down for two different orig ips to the same dest ip
+        nw_objects.append(nat_obj)
 
 
 def normalize_vip_object_nat_ip(obj_orig: dict[str, Any], obj: dict[str, Any], nat_obj: dict[str, Any]) -> None:

--- a/roles/importer/files/importer/fw_modules/fortiadom5ff/fmgr_network.py
+++ b/roles/importer/files/importer/fw_modules/fortiadom5ff/fmgr_network.py
@@ -189,10 +189,10 @@ def normalize_vip_object(obj_orig: dict[str, Any], obj: dict[str, Any], nw_objec
     if "obj_nat_ip" not in obj:
         return
 
-    finalize_vip_nat_object(obj_orig, obj, nat_obj, nw_objects)
+    _finalize_vip_nat_object(obj_orig, obj, nat_obj, nw_objects)
 
 
-def finalize_vip_nat_object(
+def _finalize_vip_nat_object(
     obj_orig: dict[str, Any], obj: dict[str, Any], nat_obj: dict[str, Any], nw_objects: list[dict[str, Any]]
 ) -> None:
     if "obj_ip_end" not in nat_obj:
@@ -213,11 +213,13 @@ def finalize_vip_nat_object(
 def normalize_vip_object_nat_ip(obj_orig: dict[str, Any], obj: dict[str, Any], nat_obj: dict[str, Any]) -> None:
     # now dealing with the nat ip obj (mappedip)
     if "mappedip" not in obj_orig or len(obj_orig["mappedip"]) == 0:
-        FWOLogger.warning("vip (extip): found empty mappedip field for " + obj_orig["name"])
+        FWOLogger.warning("vip (mappedip): found empty mappedip field for " + obj_orig["name"])
         return
 
     if len(obj_orig["mappedip"]) > 1:
-        FWOLogger.warning("vip (extip): found more than one mappedip, just using the first one for " + obj_orig["name"])
+        FWOLogger.warning(
+            "vip (mappedip): found more than one mappedip, just using the first one for " + obj_orig["name"]
+        )
     nat_ip = obj_orig["mappedip"][0]
     set_ip_in_obj(nat_obj, str(nat_ip))
     obj.update({"obj_nat_ip": str(nat_obj["obj_ip"])})  # save nat ip in vip obj
@@ -233,16 +235,19 @@ def normalize_vip_object_nat_ip(obj_orig: dict[str, Any], obj: dict[str, Any], n
     ###### range handling
 
 
-def set_ip_in_obj(
-    nw_obj: dict[str, Any], ip: str
-) -> None:  # add start and end ip in nw_obj if it is a range, otherwise do nothing
+def set_ip_in_obj(nw_obj: dict[str, Any], ip: str) -> None:
+    # sets start and end ip in nw_obj for a range, or just the ip for a host - clearing any
+    # previously set obj_ip_end so a stale range end can't leak in from an earlier ip in nw_obj
     if "-" in ip:  # dealing with range
         ip_start, ip_end = ip.split("-")
         nw_obj.update({"obj_ip": str(ip_start)})
         if ip_end != ip_start:
             nw_obj.update({"obj_ip_end": str(ip_end)})
+        else:
+            nw_obj.pop("obj_ip_end", None)
     else:
         nw_obj.update({"obj_ip": str(ip)})
+        nw_obj.pop("obj_ip_end", None)
 
 
 # for members of groups, the name of the member obj needs to be fetched separately (starting from API v1.?)

--- a/roles/importer/files/importer/test/test_fmgr_network.py
+++ b/roles/importer/files/importer/test/test_fmgr_network.py
@@ -85,6 +85,19 @@ def test_normalize_vip_object_with_extip_range_sets_obj_ip_end():
     assert obj["obj_ip_end"] == "203.0.113.10"
 
 
+def test_normalize_vip_object_with_extip_range_and_host_mappedip_does_not_leak_extip_end():
+    obj_orig = {"name": "vip_range_host_nat", "extip": ["1.1.1.1-1.1.1.5"], "mappedip": ["10.0.0.1"]}
+    obj: dict[str, Any] = {}
+    nw_objects: list[dict[str, Any]] = []
+
+    normalize_vip_object(obj_orig, obj, nw_objects)
+
+    assert obj["obj_nat_ip_end"] == "10.0.0.1"
+    nat_obj = nw_objects[0]
+    assert nat_obj["obj_ip_end"] == "10.0.0.1"
+    assert nat_obj["obj_name"] == "10.0.0.1_NatNwObj"
+
+
 def test_normalize_vip_object_with_associated_interface_sets_nat_obj_zone():
     obj_orig = {
         "name": "vip_zone",

--- a/roles/importer/files/importer/test/test_fmgr_network.py
+++ b/roles/importer/files/importer/test/test_fmgr_network.py
@@ -1,0 +1,132 @@
+from typing import Any
+
+from fw_modules.fortiadom5ff.fmgr_network import normalize_vip_object, normalize_vip_object_nat_ip
+
+
+def test_normalize_vip_object_with_mappedip_creates_nat_object():
+    obj_orig = {"name": "vip1", "extip": ["203.0.113.5"], "mappedip": ["10.0.0.5"]}
+    obj: dict[str, Any] = {}
+    nw_objects: list[dict[str, Any]] = []
+
+    normalize_vip_object(obj_orig, obj, nw_objects)
+
+    assert obj["obj_nat_ip"] == "10.0.0.5"
+    assert obj["obj_nat_ip_end"] == "10.0.0.5"
+    assert len(nw_objects) == 1
+    nat_obj = nw_objects[0]
+    assert nat_obj["obj_ip"] == "10.0.0.5"
+    assert nat_obj["obj_name"] == "10.0.0.5_NatNwObj"
+    assert nat_obj["obj_uid"] == "10.0.0.5_NatNwObj"
+
+
+def test_normalize_vip_object_with_empty_mappedip_does_not_crash():
+    obj_orig = {"name": "LB-SSMTP", "extip": ["203.0.113.5"], "mappedip": []}
+    obj: dict[str, Any] = {}
+    nw_objects: list[dict[str, Any]] = []
+
+    normalize_vip_object(obj_orig, obj, nw_objects)
+
+    assert "obj_nat_ip" not in obj
+    assert nw_objects == []
+
+
+def test_normalize_vip_object_with_missing_mappedip_key_does_not_crash():
+    obj_orig = {"name": "LB-SSMTP", "extip": ["203.0.113.5"]}
+    obj: dict[str, Any] = {}
+    nw_objects: list[dict[str, Any]] = []
+
+    normalize_vip_object(obj_orig, obj, nw_objects)
+
+    assert "obj_nat_ip" not in obj
+    assert nw_objects == []
+
+
+def test_normalize_vip_object_nat_ip_leaves_obj_untouched_when_mappedip_missing():
+    obj_orig = {"name": "LB-SSMTP"}
+    obj: dict[str, Any] = {}
+    nat_obj: dict[str, Any] = {}
+
+    normalize_vip_object_nat_ip(obj_orig, obj, nat_obj)
+
+    assert "obj_nat_ip" not in obj
+    assert nat_obj == {}
+
+
+def test_normalize_vip_object_without_extip_field_skips_nat_handling():
+    obj_orig = {"name": "vip_no_extip", "mappedip": ["10.0.0.5"]}
+    obj: dict[str, Any] = {}
+    nw_objects: list[dict[str, Any]] = []
+
+    normalize_vip_object(obj_orig, obj, nw_objects)
+
+    assert obj["obj_typ"] == "host"
+    assert "obj_nat_ip" not in obj
+    assert nw_objects == []
+
+
+def test_normalize_vip_object_with_multiple_extip_uses_first():
+    obj_orig = {"name": "vip_multi_extip", "extip": ["203.0.113.7", "203.0.113.8"], "mappedip": ["10.0.0.7"]}
+    obj: dict[str, Any] = {}
+    nw_objects: list[dict[str, Any]] = []
+
+    normalize_vip_object(obj_orig, obj, nw_objects)
+
+    assert obj["obj_ip"] == "203.0.113.7"
+
+
+def test_normalize_vip_object_with_extip_range_sets_obj_ip_end():
+    obj_orig = {"name": "vip_range", "extip": ["203.0.113.1-203.0.113.10"], "mappedip": []}
+    obj: dict[str, Any] = {}
+    nw_objects: list[dict[str, Any]] = []
+
+    normalize_vip_object(obj_orig, obj, nw_objects)
+
+    assert obj["obj_ip"] == "203.0.113.1"
+    assert obj["obj_ip_end"] == "203.0.113.10"
+
+
+def test_normalize_vip_object_with_associated_interface_sets_nat_obj_zone():
+    obj_orig = {
+        "name": "vip_zone",
+        "extip": ["203.0.113.9"],
+        "mappedip": ["10.0.0.9"],
+        "associated-interface": ["port1"],
+    }
+    obj: dict[str, Any] = {}
+    nw_objects: list[dict[str, Any]] = []
+
+    normalize_vip_object(obj_orig, obj, nw_objects)
+
+    assert nw_objects[0]["obj_zone"] == "port1"
+
+
+def test_normalize_vip_object_does_not_append_duplicate_nat_object():
+    obj_orig = {"name": "vip_dup", "extip": ["203.0.113.11"], "mappedip": ["10.0.0.11"]}
+    nw_objects: list[dict[str, Any]] = []
+
+    normalize_vip_object(obj_orig, {}, nw_objects)
+    normalize_vip_object(obj_orig, {}, nw_objects)
+
+    assert len(nw_objects) == 1
+
+
+def test_normalize_vip_object_nat_ip_with_multiple_mappedip_uses_first():
+    obj_orig = {"name": "vip_multi_mappedip", "mappedip": ["10.0.0.1", "10.0.0.2"]}
+    obj: dict[str, Any] = {}
+    nat_obj: dict[str, Any] = {}
+
+    normalize_vip_object_nat_ip(obj_orig, obj, nat_obj)
+
+    assert obj["obj_nat_ip"] == "10.0.0.1"
+
+
+def test_normalize_vip_object_nat_ip_with_range_mappedip_sets_range_fields():
+    obj_orig = {"name": "vip_range_mappedip", "mappedip": ["10.0.0.5-10.0.0.10"]}
+    obj: dict[str, Any] = {}
+    nat_obj: dict[str, Any] = {}
+
+    normalize_vip_object_nat_ip(obj_orig, obj, nat_obj)
+
+    assert obj["obj_nat_ip"] == "10.0.0.5"
+    assert obj["obj_nat_ip_end"] == "10.0.0.10"
+    assert nat_obj["obj_name"] == "10.0.0.5-10.0.0.10_NatNwObj"


### PR DESCRIPTION
closes #5020

Fixes the FortiManager import crash (`KeyError: 'obj_nat_ip'`) when a VIP has an empty or missing `mappedip`.

Follow-up for the missing NAT information of virtual server VIPs (`realservers`), on the NAT support branch of #4547: weichwaren-schmiede/firewall-orchestrator#3
