### PR TITLE
hotfix: keep jwt below header limit, skip inactive ldaps

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -256,3 +256,6 @@ apache_security_headers:
 apache_global_settings_file: "{{ '/etc/httpd/conf.d/security.conf' if ansible_facts['os_family'] == 'RedHat' else '/etc/apache2/conf-available/security.conf' }}"
 apache_ssl_protocol: "SSLProtocol -all +TLSv1.2 +TLSv1.3"
 apache_ssl_cipher_suite: "SSLCipherSuite ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:!aNULL:!MD5:!DSS:!SHA1"
+# max size of a single request header field; the apache default of 8190 bytes is too small for the
+# jwt in the "Authorization" header of users with many roles, owners or visible devices
+apache_limit_request_field_size: 32768

--- a/roles/api/templates/httpd.conf.j2
+++ b/roles/api/templates/httpd.conf.j2
@@ -12,6 +12,10 @@
     #     LimitRequestBody 250M
     # </Location>
 
+	# the jwt is sent in the "Authorization" header and grows with the permissions of the user,
+	# so raise the per-header limit from the 8190 byte default to the kestrel default of 32KB
+	LimitRequestFieldSize {{ apache_limit_request_field_size }}
+
 	# set buffer to 128KB
 	ProxyIOBufferSize 131072
 	

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
@@ -529,38 +529,15 @@ namespace FWO.Middleware.Server.Controllers
             return jwtWriter.CreateJWT(authenticatedUser, accessLifetime);
         }
 
+        /// <summary>
+        /// Resolves the ldap group memberships of the given user.
+        /// </summary>
+        /// <param name="ldapUser">Ldap entry of the user.</param>
+        /// <param name="ldap">Ldap connection hosting the user.</param>
+        /// <returns>Distinct list of group dns the user belongs to.</returns>
         public async Task<List<string>> GetGroups(LdapEntry ldapUser, Ldap ldap)
         {
-            HashSet<string> userGroups = new(DistName.DnComparer);
-            userGroups.UnionWith(ldap.GetGroups(ldapUser));
-            string? groupPath = !string.IsNullOrWhiteSpace(ldap.GroupSearchPath) ? ldap.GroupSearchPath : ldap.GroupWritePath;
-            AddResolvedGroupMemberships(userGroups, await ldap.GetGroups([ldapUser.Dn]), groupPath);
-            if (!ldap.IsInternal())
-            {
-                object groupsLock = new();
-                List<Task> ldapRoleRequests = [];
-
-                foreach (Ldap currentLdap in ldaps.Where(l => l.IsInternal()))
-                {
-                    ldapRoleRequests.Add(Task.Run(async () =>
-                    {
-                        // Get groups from current Ldap
-                        List<string> currentGroups = await currentLdap.GetGroups([ldapUser.Dn]);
-                        lock (groupsLock)
-                        {
-                            string? groupPath = !string.IsNullOrWhiteSpace(currentLdap.GroupSearchPath) ? currentLdap.GroupSearchPath : currentLdap.GroupWritePath;
-                            AddResolvedGroupMemberships(userGroups, currentGroups, groupPath);
-                        }
-                    }));
-                }
-                await Task.WhenAll(ldapRoleRequests);
-            }
-            return userGroups.ToList();
-        }
-
-        private static void AddResolvedGroupMemberships(HashSet<string> userGroups, IEnumerable<string> groupNames, string? groupPath)
-        {
-            userGroups.UnionWith(Ldap.BuildGroupDns(groupNames, groupPath));
+            return await new UserGroupResolver(ldaps).GetGroups(ldapUser, ldap);
         }
 
         public async Task<(LdapEntry, Ldap)> AuthenticateInAnyLdap(UiUser user, bool validatePassword)

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/AuthenticationTokenController.cs
@@ -635,7 +635,9 @@ namespace FWO.Middleware.Server.Controllers
 
             List<Task> ldapRoleRequests = [];
 
-            foreach (Ldap currentLdap in ldaps.Where(l => l.HasRoleHandling()))
+            // inactive connections must not contribute roles: the injected ldap list is a startup snapshot
+            // that still contains deactivated connections, and login itself only binds against active ones
+            foreach (Ldap currentLdap in ldaps.Where(l => l.Active && l.HasRoleHandling()))
             {
                 // if current Ldap has roles stored
                 ldapRoleRequests.Add(Task.Run(async () =>

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/WorkflowController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/WorkflowController.cs
@@ -29,6 +29,7 @@ namespace FWO.Middleware.Server.Controllers
         private readonly JwtWriter jwtWriter;
         private readonly TokenLifetimeProvider tokenLifetimeProvider;
         private static readonly ConcurrentDictionary<long, SemaphoreSlim> TicketActionLocks = new();
+        private static readonly List<string> kNoGroups = [];
 
         /// <summary>
         /// Constructor.
@@ -180,7 +181,7 @@ namespace FWO.Middleware.Server.Controllers
                 return result;
             }
 
-            if (!CallerCanAccessVisibility(User, wfHandler, scope, statefulObject))
+            if (!await CallerCanAccessVisibility(User, wfHandler, scope, statefulObject))
             {
                 SetWarning(result, $"User is not authorized to access workflow visibility for scope '{scope}' and state {statefulObject.StateId}.");
                 return result;
@@ -382,7 +383,7 @@ namespace FWO.Middleware.Server.Controllers
             return editableOwnerIds.Count > 0 && ticket.Tasks.Any(task => CallerOwnsTask(task, editableOwnerIds));
         }
 
-        private static bool CallerCanAccessVisibility(ClaimsPrincipal user, WfHandler wfHandler, WfObjectScopes scope, WfStatefulObject statefulObject)
+        private async Task<bool> CallerCanAccessVisibility(ClaimsPrincipal user, WfHandler wfHandler, WfObjectScopes scope, WfStatefulObject statefulObject)
         {
             if (!wfHandler.userConfig.ReqVisibilityBased)
             {
@@ -391,9 +392,31 @@ namespace FWO.Middleware.Server.Controllers
 
             StateMatrix stateMatrix = scope == WfObjectScopes.Ticket ? wfHandler.MasterStateMatrix : wfHandler.ActStateMatrix;
             HashSet<int> visibilityGroupIds = GetClaimIds(user, "x-hasura-workflow-visibility-groups");
-            List<string> userGroups = GetClaimStrings(user, "x-hasura-groups");
-            return WorkflowVisibilityHelper.CanAccessStatefulObject(statefulObject, stateMatrix, visibilityGroupIds, wfHandler.GetWorkflowExclusiveVisibilityGroupIds())
-                || IsExplicitlyAssigned(user, userGroups, statefulObject);
+            if (WorkflowVisibilityHelper.CanAccessStatefulObject(statefulObject, stateMatrix, visibilityGroupIds, wfHandler.GetWorkflowExclusiveVisibilityGroupIds()))
+            {
+                return true;
+            }
+            return await IsExplicitlyAssigned(user, statefulObject);
+        }
+
+        /// <summary>
+        /// Decides whether the caller is explicitly assigned, resolving the ldap group memberships only if a
+        /// group assignment exists that could match at all. The group dns are no longer part of the jwt, so
+        /// every lookup costs an ldap round trip.
+        /// </summary>
+        private async Task<bool> IsExplicitlyAssigned(ClaimsPrincipal user, WfStatefulObject statefulObject)
+        {
+            if (IsExplicitlyAssignedToUserOrGroups(user, statefulObject, kNoGroups))
+            {
+                return true;
+            }
+            if (CollectAssignedGroupDns(statefulObject).Count == 0)
+            {
+                return false;
+            }
+
+            List<string> userGroups = await new UserGroupResolver(ldaps).GetGroupsForUserDn(GetClaimValue(user, "x-hasura-uuid") ?? "");
+            return IsExplicitlyAssignedToUserOrGroups(user, statefulObject, userGroups);
         }
 
         private static bool CallerCanUseRole(ClaimsPrincipal user, string executionMode, string role)
@@ -432,30 +455,26 @@ namespace FWO.Middleware.Server.Controllers
             return int.TryParse(GetClaimValue(user, claimName), out int value) ? value : null;
         }
 
-        private static List<string> GetClaimStrings(ClaimsPrincipal user, string claimName)
-        {
-            string? claimValue = GetClaimValue(user, claimName);
-            if (string.IsNullOrWhiteSpace(claimValue))
-            {
-                return [];
-            }
-
-            try
-            {
-                return System.Text.Json.JsonSerializer.Deserialize<List<string>>(claimValue) ?? [];
-            }
-            catch (System.Text.Json.JsonException)
-            {
-                return [];
-            }
-        }
-
-        private static bool IsExplicitlyAssigned(ClaimsPrincipal user, List<string> userGroups, WfStatefulObject statefulObject)
+        private static bool IsExplicitlyAssignedToUserOrGroups(ClaimsPrincipal user, WfStatefulObject statefulObject, List<string> userGroups)
         {
             return IsAssignedToCurrentUser(user, statefulObject.CurrentHandler)
                 || IsAssignedToCurrentUserGroup(userGroups, statefulObject.AssignedGroup)
                 || (statefulObject is WfApproval approval && (IsAssignedToCurrentUserDn(user, approval.ApproverDn)
                     || IsAssignedToCurrentUserGroup(userGroups, approval.ApproverGroup)));
+        }
+
+        private static List<string> CollectAssignedGroupDns(WfStatefulObject statefulObject)
+        {
+            List<string> assignedGroupDns = [];
+            if (!string.IsNullOrWhiteSpace(statefulObject.AssignedGroup))
+            {
+                assignedGroupDns.Add(statefulObject.AssignedGroup);
+            }
+            if (statefulObject is WfApproval approval && !string.IsNullOrWhiteSpace(approval.ApproverGroup))
+            {
+                assignedGroupDns.Add(approval.ApproverGroup);
+            }
+            return assignedGroupDns;
         }
 
         private static bool IsAssignedToCurrentUser(ClaimsPrincipal user, UiUser? handler)

--- a/roles/middleware/files/FWO.Middleware.Server/JwtWriter.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/JwtWriter.cs
@@ -127,7 +127,11 @@ namespace FWO.Middleware.Server
             // even when tenant resolution fails, to avoid runtime "missing session variable" errors.
             claimsIdentity.AddClaim(new Claim("x-hasura-visible-managements", ToHasuraIdSet(visibleManagementIds)));
             claimsIdentity.AddClaim(new Claim("x-hasura-visible-devices", ToHasuraIdSet(visibleGatewayIds)));
-            claimsIdentity.AddClaim(new Claim("x-hasura-groups", JsonSerializer.Serialize(user.Groups ?? [])));
+            // NB: the user's ldap group dns are deliberately NOT added as a claim. The list grows with the
+            // number of group memberships and pushed the "Authorization: Bearer ..." header past the web
+            // server's per-header limit (apache LimitRequestFieldSize, 8190 bytes by default), which made
+            // login fail with "400 Bad Request" for users with many groups. Group memberships are resolved
+            // on demand instead, see WorkflowController.ResolveCallerGroups.
             claimsIdentity.AddClaim(new Claim("x-hasura-editable-owners", $"{{ {string.Join(",", user.Ownerships)} }}"));
             claimsIdentity.AddClaim(new Claim("x-hasura-recertifiable-owners", $"{{ {string.Join(",", user.RecertOwnerships)} }}"));
             claimsIdentity.AddClaim(new Claim("x-hasura-workflow-visibility-groups", ToHasuraIdSet(user.WorkflowVisibilityGroupIds)));

--- a/roles/middleware/files/FWO.Middleware.Server/Services/UserGroupResolver.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/UserGroupResolver.cs
@@ -55,7 +55,7 @@ public class UserGroupResolver
             return [];
         }
 
-        foreach (Ldap ldap in ldaps)
+        foreach (Ldap ldap in ldaps.Where(ldap => ldap.Active))
         {
             // GetUserDetailsFromLdap logs and swallows connection problems itself, returning null
             LdapEntry? ldapUser = await ldap.GetUserDetailsFromLdap(userDn);
@@ -74,7 +74,7 @@ public class UserGroupResolver
         object groupsLock = new();
         List<Task> ldapRoleRequests = [];
 
-        foreach (Ldap currentLdap in ldaps.Where(ldap => ldap.IsInternal()))
+        foreach (Ldap currentLdap in ldaps.Where(ldap => ldap.Active && ldap.IsInternal()))
         {
             ldapRoleRequests.Add(Task.Run(async () =>
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Services/UserGroupResolver.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/UserGroupResolver.cs
@@ -1,0 +1,118 @@
+using FWO.Basics;
+using FWO.Data;
+using FWO.Logging;
+using Novell.Directory.Ldap;
+
+namespace FWO.Middleware.Server.Services;
+
+/// <summary>
+/// Resolves the ldap group memberships of a user.
+/// The group dns are deliberately not carried in the JWT: their number grows with the group memberships of
+/// the user and made the "Authorization" header exceed the web server's per-header size limit. They are
+/// therefore resolved from ldap when they are actually needed.
+/// </summary>
+public class UserGroupResolver
+{
+    private readonly List<Ldap> ldaps;
+
+    /// <summary>
+    /// Constructor taking the list of configured ldap connections.
+    /// </summary>
+    /// <param name="ldaps">All configured ldap connections.</param>
+    public UserGroupResolver(List<Ldap> ldaps)
+    {
+        this.ldaps = ldaps;
+    }
+
+    /// <summary>
+    /// Resolves the group dns of an already loaded ldap entry.
+    /// </summary>
+    /// <param name="ldapUser">Ldap entry of the user.</param>
+    /// <param name="hostingLdap">Ldap connection the entry was read from.</param>
+    /// <returns>Distinct list of group dns the user belongs to.</returns>
+    public async Task<List<string>> GetGroups(LdapEntry ldapUser, Ldap hostingLdap)
+    {
+        HashSet<string> userGroups = new(DistName.DnComparer);
+        userGroups.UnionWith(hostingLdap.GetGroups(ldapUser));
+        AddResolvedGroupMemberships(userGroups, await GetGroupsForDn(hostingLdap, ldapUser.Dn), GetGroupPath(hostingLdap));
+        if (!hostingLdap.IsInternal())
+        {
+            await AddInternalLdapMemberships(userGroups, ldapUser.Dn);
+        }
+        return userGroups.ToList();
+    }
+
+    /// <summary>
+    /// Resolves the group dns of a user identified by its dn, locating the hosting ldap first.
+    /// Used outside the login flow, where no ldap entry has been read yet.
+    /// </summary>
+    /// <param name="userDn">Distinguished name of the user.</param>
+    /// <returns>Distinct list of group dns the user belongs to, empty if the user cannot be located.</returns>
+    public async Task<List<string>> GetGroupsForUserDn(string userDn)
+    {
+        if (string.IsNullOrWhiteSpace(userDn))
+        {
+            return [];
+        }
+
+        foreach (Ldap ldap in ldaps)
+        {
+            LdapEntry? ldapUser = await GetUserEntry(ldap, userDn);
+            if (ldapUser != null)
+            {
+                return await GetGroups(ldapUser, ldap);
+            }
+        }
+
+        Log.WriteWarning("Resolve user groups", $"User {userDn} could not be found in any ldap, assuming no group memberships.");
+        return [];
+    }
+
+    private async Task AddInternalLdapMemberships(HashSet<string> userGroups, string userDn)
+    {
+        object groupsLock = new();
+        List<Task> ldapRoleRequests = [];
+
+        foreach (Ldap currentLdap in ldaps.Where(ldap => ldap.IsInternal()))
+        {
+            ldapRoleRequests.Add(Task.Run(async () =>
+            {
+                List<string> currentGroups = await GetGroupsForDn(currentLdap, userDn);
+                lock (groupsLock)
+                {
+                    AddResolvedGroupMemberships(userGroups, currentGroups, GetGroupPath(currentLdap));
+                }
+            }));
+        }
+        await Task.WhenAll(ldapRoleRequests);
+    }
+
+    private static async Task<List<string>> GetGroupsForDn(Ldap ldap, string userDn)
+    {
+        List<string> userDnList = [userDn];
+        return await ldap.GetGroups(userDnList);
+    }
+
+    private static async Task<LdapEntry?> GetUserEntry(Ldap ldap, string userDn)
+    {
+        try
+        {
+            return await ldap.GetUserDetailsFromLdap(userDn);
+        }
+        catch (Exception exception)
+        {
+            Log.WriteError("Resolve user groups", $"Could not read user {userDn} from ldap {ldap.Address}:{ldap.Port}.", exception);
+            return null;
+        }
+    }
+
+    private static string? GetGroupPath(Ldap ldap)
+    {
+        return !string.IsNullOrWhiteSpace(ldap.GroupSearchPath) ? ldap.GroupSearchPath : ldap.GroupWritePath;
+    }
+
+    private static void AddResolvedGroupMemberships(HashSet<string> userGroups, IEnumerable<string> groupNames, string? groupPath)
+    {
+        userGroups.UnionWith(Ldap.BuildGroupDns(groupNames, groupPath));
+    }
+}

--- a/roles/middleware/files/FWO.Middleware.Server/Services/UserGroupResolver.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/UserGroupResolver.cs
@@ -57,7 +57,8 @@ public class UserGroupResolver
 
         foreach (Ldap ldap in ldaps)
         {
-            LdapEntry? ldapUser = await GetUserEntry(ldap, userDn);
+            // GetUserDetailsFromLdap logs and swallows connection problems itself, returning null
+            LdapEntry? ldapUser = await ldap.GetUserDetailsFromLdap(userDn);
             if (ldapUser != null)
             {
                 return await GetGroups(ldapUser, ldap);
@@ -91,19 +92,6 @@ public class UserGroupResolver
     {
         List<string> userDnList = [userDn];
         return await ldap.GetGroups(userDnList);
-    }
-
-    private static async Task<LdapEntry?> GetUserEntry(Ldap ldap, string userDn)
-    {
-        try
-        {
-            return await ldap.GetUserDetailsFromLdap(userDn);
-        }
-        catch (Exception exception)
-        {
-            Log.WriteError("Resolve user groups", $"Could not read user {userDn} from ldap {ldap.Address}:{ldap.Port}.", exception);
-            return null;
-        }
     }
 
     private static string? GetGroupPath(Ldap ldap)

--- a/roles/middleware/templates/httpd.conf
+++ b/roles/middleware/templates/httpd.conf
@@ -3,6 +3,10 @@
 	ServerAdmin {{ server_admin }}
 	Timeout {{ apache_mw_timeout }}
 
+	# the jwt is sent in the "Authorization" header and grows with the permissions of the user,
+	# so raise the per-header limit from the 8190 byte default to the kestrel default of 32KB
+	LimitRequestFieldSize {{ apache_limit_request_field_size }}
+
 	ProxyPreserveHost On
 	ProxyPass / http://127.0.0.1:{{ middleware_internal_port }}/
 	ProxyPassReverse / http://127.0.0.1:{{ middleware_internal_port }}/

--- a/roles/tests-unit/files/FWO.Test/AuthenticationTokenControllerTest.cs
+++ b/roles/tests-unit/files/FWO.Test/AuthenticationTokenControllerTest.cs
@@ -38,6 +38,8 @@ namespace FWO.Test
             }
         };
         private static readonly string kSearchPassword = LdapTestSupport.CreateEncryptedSecret("searchpwd");
+        private const string kRoleSearchPath = "ou=roles,dc=fworch,dc=internal";
+        private const string kRoleUserDn = "uid=login-user,ou=users,dc=fworch,dc=internal";
 
         [Test]
         public async Task GetAsync_ReturnsAnonymousJwt_WhenCredentialsAreMissing()
@@ -471,6 +473,54 @@ namespace FWO.Test
             });
         }
 
+        [Test]
+        public async Task AuthManagerGetRoles_DoesNotQueryInactiveLdap()
+        {
+            // a retired but still reachable directory must not be consulted for roles, while the active one is
+            TestableLdap inactiveLdap = CreateRoleLdap();
+            inactiveLdap.Active = false;
+            TestableLdap activeLdap = CreateRoleLdap();
+            object authManager = CreateAuthManager(new RecordingApiConnection(), new FixedTokenLifetimeProvider(),
+                new List<Ldap> { inactiveLdap, activeLdap });
+
+            await InvokeAuthManagerAsync<List<string>>(authManager, "GetRoles", CreateRoleUser());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(inactiveLdap.ConnectCount, Is.Zero);
+                Assert.That(activeLdap.ConnectCount, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public async Task AuthManagerGetRoles_FallsBackToAnonymousWhenEveryRoleLdapIsInactive()
+        {
+            TestableLdap inactiveLdap = CreateRoleLdap();
+            inactiveLdap.Active = false;
+            object authManager = CreateAuthManager(new RecordingApiConnection(), new FixedTokenLifetimeProvider(),
+                new List<Ldap> { inactiveLdap });
+
+            List<string> roles = await InvokeAuthManagerAsync<List<string>>(authManager, "GetRoles", CreateRoleUser());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(roles, Is.EqualTo(new List<string> { Roles.Anonymous }));
+                Assert.That(inactiveLdap.ConnectCount, Is.Zero);
+            });
+        }
+
+        [Test]
+        public async Task AuthManagerGetRoles_SkipsActiveLdapWithoutRoleHandling()
+        {
+            TestableLdap ldapWithoutRoles = CreateRoleLdap(roleSearchPath: "");
+            object authManager = CreateAuthManager(new RecordingApiConnection(), new FixedTokenLifetimeProvider(),
+                new List<Ldap> { ldapWithoutRoles });
+
+            await InvokeAuthManagerAsync<List<string>>(authManager, "GetRoles", CreateRoleUser());
+
+            Assert.That(ldapWithoutRoles.ConnectCount, Is.Zero);
+        }
+
         private static AuthenticationTokenController CreateController()
         {
             return CreateController(new RecordingApiConnection());
@@ -506,16 +556,37 @@ namespace FWO.Test
             };
         }
 
-        private static object CreateAuthManager(ApiConnection apiConnection, TokenLifetimeProvider? tokenLifetimeProvider = null)
+        private static object CreateAuthManager(ApiConnection apiConnection, TokenLifetimeProvider? tokenLifetimeProvider = null, List<Ldap>? ldaps = null)
         {
             Type authManagerType = typeof(AuthenticationTokenController).Assembly.GetType("FWO.Middleware.Server.Controllers.AuthManager", throwOnError: true)!;
             RSA rsa = RSA.Create(2048);
             return Activator.CreateInstance(
                 authManagerType,
                 new JwtWriter(new RsaSecurityKey(rsa)),
-                new List<Ldap>(),
+                ldaps ?? new List<Ldap>(),
                 apiConnection,
                 tokenLifetimeProvider ?? new FixedTokenLifetimeProvider())!;
+        }
+
+        private static UiUser CreateRoleUser()
+        {
+            return new UiUser { Name = "login-user", Dn = kRoleUserDn };
+        }
+
+        /// <summary>
+        /// Builds an ldap for the role lookup. An empty role search path turns role handling off.
+        /// </summary>
+        private static TestableLdap CreateRoleLdap(string roleSearchPath = kRoleSearchPath)
+        {
+            return new TestableLdap(new RecordingLdapClient())
+            {
+                Address = "ldap.example.test",
+                Port = 389,
+                SearchUser = "cn=search,dc=fworch,dc=internal",
+                SearchUserPwd = kSearchPassword,
+                RoleSearchPath = roleSearchPath,
+                UserSearchPath = "ou=users,dc=fworch,dc=internal"
+            };
         }
 
         private static async Task<ReturnType> InvokeAuthManagerAsync<ReturnType>(object authManager, string methodName, params object?[] arguments)

--- a/roles/tests-unit/files/FWO.Test/AuthenticationTokenDelegationTest.cs
+++ b/roles/tests-unit/files/FWO.Test/AuthenticationTokenDelegationTest.cs
@@ -33,9 +33,8 @@ namespace FWO.Test
         [Test]
         public void AddResolvedGroupMemberships_MergesResolvedGroupDnsIntoExistingMemberships()
         {
-            Type authManagerType = typeof(AuthenticationTokenController).Assembly.GetType("FWO.Middleware.Server.Controllers.AuthManager", throwOnError: true)!;
-            MethodInfo addResolvedGroupMemberships = authManagerType.GetMethod("AddResolvedGroupMemberships", BindingFlags.NonPublic | BindingFlags.Static)
-                ?? throw new MissingMethodException(authManagerType.FullName, "AddResolvedGroupMemberships");
+            MethodInfo addResolvedGroupMemberships = typeof(UserGroupResolver).GetMethod("AddResolvedGroupMemberships", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new MissingMethodException(typeof(UserGroupResolver).FullName, "AddResolvedGroupMemberships");
 
             HashSet<string> userGroups = new(DistName.DnComparer)
             {

--- a/roles/tests-unit/files/FWO.Test/JwtWriterClaimsTest.cs
+++ b/roles/tests-unit/files/FWO.Test/JwtWriterClaimsTest.cs
@@ -1,9 +1,11 @@
+using FWO.Basics;
 using FWO.Data;
 using FWO.Middleware.Server;
 using Microsoft.IdentityModel.Tokens;
 using NUnit.Framework;
 using System.Reflection;
 using System.Security.Claims;
+using System.IdentityModel.Tokens.Jwt;
 using System.Security.Cryptography;
 
 namespace FWO.Test
@@ -103,6 +105,66 @@ namespace FWO.Test
             Assert.That("Authorization: Bearer ".Length + jwt.Length, Is.LessThan(kApacheHeaderFieldLimit));
         }
 
+        [TestCase(Roles.Admin, Roles.Admin)]
+        [TestCase(Roles.Auditor, Roles.Auditor)]
+        [TestCase(Roles.FwAdmin, Roles.FwAdmin)]
+        [TestCase(Roles.ReporterViewAll, Roles.ReporterViewAll)]
+        [TestCase(Roles.Reporter, Roles.Reporter)]
+        [TestCase(Roles.Recertifier, Roles.Recertifier)]
+        [TestCase(Roles.Modeller, Roles.Modeller)]
+        public void SetClaimsPicksTheHighestRankedRoleAsDefaultRole(string role, string expectedDefaultRole)
+        {
+            // every user also holds the lowest ranked role, so the ranking decides
+            UiUser user = new()
+            {
+                Name = "test-user",
+                Roles = [Roles.Requester, role]
+            };
+
+            ClaimsIdentity claimsIdentity = InvokeSetClaims(user);
+
+            Assert.That(claimsIdentity.FindFirst("x-hasura-default-role")?.Value, Is.EqualTo(expectedDefaultRole));
+        }
+
+        [Test]
+        public void SetClaimsFallsBackToTheFirstRoleWhenNoneIsRanked()
+        {
+            UiUser user = new()
+            {
+                Name = "test-user",
+                Roles = [Roles.Requester, Roles.Approver]
+            };
+
+            ClaimsIdentity claimsIdentity = InvokeSetClaims(user);
+
+            Assert.That(claimsIdentity.FindFirst("x-hasura-default-role")?.Value, Is.EqualTo(Roles.Requester));
+        }
+
+        [Test]
+        public void SetClaimsLeavesDefaultRoleEmptyForUserWithoutRoles()
+        {
+            UiUser user = new() { Name = "test-user", Roles = [] };
+
+            ClaimsIdentity claimsIdentity = InvokeSetClaims(user);
+
+            Assert.That(claimsIdentity.FindFirst("x-hasura-default-role")?.Value, Is.Empty);
+        }
+
+        [Test]
+        public void CreateJwtForInternalRolesIssuesSingleRoleTokens()
+        {
+            JwtWriter writer = new(new RsaSecurityKey(RSA.Create(2048)));
+
+            string middlewareToken = writer.CreateJWTMiddlewareServer(TimeSpan.FromMinutes(5));
+            string reporterToken = writer.CreateJWTReporterViewall(TimeSpan.FromMinutes(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReadDefaultRole(middlewareToken), Is.EqualTo(Roles.MiddlewareServer));
+                Assert.That(ReadDefaultRole(reporterToken), Is.EqualTo(Roles.ReporterViewAll));
+            });
+        }
+
         [Test]
         public void SetClaimsAddsJwtIdClaim()
         {
@@ -117,6 +179,12 @@ namespace FWO.Test
 
             Assert.That(jtiClaim, Is.Not.Null);
             Assert.That(Guid.TryParse(jtiClaim!.Value, out _), Is.True);
+        }
+
+        private static string? ReadDefaultRole(string jwt)
+        {
+            return new JwtSecurityTokenHandler().ReadJwtToken(jwt).Claims
+                .FirstOrDefault(claim => claim.Type == "x-hasura-default-role")?.Value;
         }
 
         private static ClaimsIdentity InvokeSetClaims(UiUser user)

--- a/roles/tests-unit/files/FWO.Test/JwtWriterClaimsTest.cs
+++ b/roles/tests-unit/files/FWO.Test/JwtWriterClaimsTest.cs
@@ -1,15 +1,19 @@
 using FWO.Data;
 using FWO.Middleware.Server;
+using Microsoft.IdentityModel.Tokens;
 using NUnit.Framework;
 using System.Reflection;
 using System.Security.Claims;
-using System.Text.Json;
+using System.Security.Cryptography;
 
 namespace FWO.Test
 {
     [TestFixture]
     public class JwtWriterClaimsTest
     {
+        // apache rejects a single request header field larger than this by default (LimitRequestFieldSize)
+        private const int kApacheHeaderFieldLimit = 8190;
+
         [Test]
         public void SetClaimsAddsVisibleScopeClaimsWhenTenantIsMissing()
         {
@@ -63,7 +67,7 @@ namespace FWO.Test
         }
 
         [Test]
-        public void SetClaimsAddsHasuraGroupClaimAsJsonText()
+        public void SetClaimsOmitsGroupDnsToKeepTokenSmall()
         {
             UiUser user = new()
             {
@@ -74,24 +78,29 @@ namespace FWO.Test
 
             ClaimsIdentity claimsIdentity = InvokeSetClaims(user);
 
-            Assert.That(claimsIdentity.FindFirst("x-hasura-groups")?.Value,
-                Is.EqualTo(JsonSerializer.Serialize(user.Groups)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(claimsIdentity.FindFirst("x-hasura-groups"), Is.Null);
+                Assert.That(claimsIdentity.Claims.Any(claim => claim.Value.Contains("ou=groups,dc=example,dc=com")), Is.False);
+            });
         }
 
         [Test]
-        public void SetClaimsAddsHasuraGroupClaimThatCanBeParsedBack()
+        public void CreateJwtStaysBelowWebServerHeaderLimitForManyGroups()
         {
+            // apache rejects a single request header field above 8190 bytes by default. The jwt travels in
+            // "Authorization: Bearer ...", so a user with many group memberships must not blow that budget.
             UiUser user = new()
             {
                 Name = "test-user",
-                Roles = ["reporter"],
-                Groups = ["cn=approver,ou=groups,dc=example,dc=com", "cn=auditor,ou=groups,dc=example,dc=com"]
+                Dn = "cn=test-user,ou=users,ou=operator,dc=fworch,dc=internal",
+                Roles = ["reporter", "modeller", "requester"],
+                Groups = [.. Enumerable.Range(0, 500).Select(index => $"cn=app-owner-group-{index:D4},ou=groups,ou=operator,dc=fworch,dc=internal")]
             };
 
-            ClaimsIdentity claimsIdentity = InvokeSetClaims(user);
-            List<string> parsedGroups = FWO.Basics.JwtClaimParser.ExtractStringClaimValues(claimsIdentity.Claims, "x-hasura-groups");
+            string jwt = new JwtWriter(new RsaSecurityKey(RSA.Create(2048))).CreateJWT(user, TimeSpan.FromHours(1));
 
-            Assert.That(parsedGroups, Is.EqualTo(user.Groups));
+            Assert.That("Authorization: Bearer ".Length + jwt.Length, Is.LessThan(kApacheHeaderFieldLimit));
         }
 
         [Test]

--- a/roles/tests-unit/files/FWO.Test/LdapTestSupport.cs
+++ b/roles/tests-unit/files/FWO.Test/LdapTestSupport.cs
@@ -38,14 +38,22 @@ namespace FWO.Test
     internal sealed class TestableLdap : FWO.Middleware.Server.Ldap
     {
         private readonly ILdapClient connection;
+        private int connectCount;
 
         public TestableLdap(ILdapClient connection)
         {
             this.connection = connection;
         }
 
+        /// <summary>
+        /// Number of times a connection to this ldap was opened. Lets tests assert that an ldap was skipped
+        /// entirely, independently of whether the subsequent bind or search succeeds.
+        /// </summary>
+        public int ConnectCount => Volatile.Read(ref connectCount);
+
         protected override Task<ILdapClient> Connect()
         {
+            Interlocked.Increment(ref connectCount);
             return Task.FromResult(connection);
         }
     }

--- a/roles/tests-unit/files/FWO.Test/UserGroupResolverTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UserGroupResolverTest.cs
@@ -1,5 +1,6 @@
 using FWO.Middleware.Server;
 using FWO.Middleware.Server.Services;
+using Novell.Directory.Ldap;
 using NUnit.Framework;
 
 namespace FWO.Test
@@ -7,7 +8,20 @@ namespace FWO.Test
     [TestFixture]
     internal class UserGroupResolverTest
     {
+        private const string kUserDn = "cn=testuser,ou=users,ou=operator,dc=fworch,dc=internal";
+        private const string kInternalUserPath = "ou=users,ou=operator,dc=fworch,dc=internal";
+        private const string kExternalUserPath = "ou=users,dc=example,dc=com";
+        private const string kInternalGroupPath = "ou=groups,ou=operator,dc=fworch,dc=internal";
+        private const string kExternalGroupPath = "ou=groups,dc=example,dc=com";
+        private const string kSearchUser = "cn=search,dc=example,dc=com";
+
+        private static readonly string kSearchPassword = LdapTestSupport.CreateEncryptedSecret("searchpwd");
         private static readonly List<Ldap> kNoLdaps = [];
+        private static readonly string[] kMemberOfValues =
+        [
+            "cn=direct-group,ou=groups,ou=operator,dc=fworch,dc=internal",
+            "cn=unrelated,ou=elsewhere,dc=example,dc=com"
+        ];
 
         [Test]
         public async Task GetGroupsForUserDn_ReturnsEmptyForMissingDn()
@@ -32,11 +46,173 @@ namespace FWO.Test
         [Test]
         public async Task GetGroupsForUserDn_ReturnsEmptyWhenNoLdapKnowsTheUser()
         {
-            UserGroupResolver resolver = new(kNoLdaps);
+            // ReadAsync returns null, so the user cannot be located in any configured ldap
+            Ldap ldap = CreateLdap(new RecordingLdapClient(), kInternalUserPath, kInternalGroupPath);
+            UserGroupResolver resolver = new([ldap]);
 
-            List<string> groups = await resolver.GetGroupsForUserDn("uid=unknown,ou=users,dc=fworch,dc=internal");
+            List<string> groups = await resolver.GetGroupsForUserDn(kUserDn);
 
             Assert.That(groups, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetGroupsForUserDn_ResolvesMemberOfGroupsWithinTheConfiguredGroupPath()
+        {
+            RecordingLdapClient connection = new()
+            {
+                ReadResult = LdapTestSupport.CreateEntry(kUserDn, new LdapAttribute("memberOf", kMemberOfValues))
+            };
+            Ldap ldap = CreateLdap(connection, kInternalUserPath, kInternalGroupPath);
+            UserGroupResolver resolver = new([ldap]);
+
+            List<string> groups = await resolver.GetGroupsForUserDn(kUserDn);
+
+            // only the group inside the configured group path is kept, the unrelated one is dropped
+            Assert.That(groups, Is.EqualTo(new List<string> { "cn=direct-group,ou=groups,ou=operator,dc=fworch,dc=internal" }));
+        }
+
+        [Test]
+        public async Task GetGroupsForUserDn_ReturnsEmptyWhenTheUserHasNoMemberships()
+        {
+            RecordingLdapClient connection = new()
+            {
+                ReadResult = LdapTestSupport.CreateEntry(kUserDn)
+            };
+            Ldap ldap = CreateLdap(connection, kInternalUserPath, kInternalGroupPath);
+            UserGroupResolver resolver = new([ldap]);
+
+            List<string> groups = await resolver.GetGroupsForUserDn(kUserDn);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(groups, Is.Empty);
+                Assert.That(connection.ReadCalls, Does.Contain(kUserDn));
+            });
+        }
+
+        [Test]
+        public async Task GetGroupsForUserDn_SkipsLdapsThatDoNotKnowTheUser()
+        {
+            Ldap unknowing = CreateLdap(new RecordingLdapClient(), kInternalUserPath, kInternalGroupPath);
+            RecordingLdapClient knowingConnection = new()
+            {
+                ReadResult = LdapTestSupport.CreateEntry(kUserDn, new LdapAttribute("memberOf", kMemberOfValues))
+            };
+            Ldap knowing = CreateLdap(knowingConnection, kInternalUserPath, kInternalGroupPath);
+            UserGroupResolver resolver = new([unknowing, knowing]);
+
+            List<string> groups = await resolver.GetGroupsForUserDn(kUserDn);
+
+            Assert.That(groups, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task GetGroups_ResolvesMemberOfForAnInternalUserWithoutFanOut()
+        {
+            Ldap hosting = CreateLdap(new RecordingLdapClient(), kInternalUserPath, kInternalGroupPath);
+            RecordingLdapClient otherInternalConnection = new();
+            Ldap otherInternal = CreateLdap(otherInternalConnection, kInternalUserPath, kInternalGroupPath);
+            UserGroupResolver resolver = new([hosting, otherInternal]);
+            LdapEntry userEntry = LdapTestSupport.CreateEntry(kUserDn, new LdapAttribute("memberOf", kMemberOfValues));
+
+            List<string> groups = await resolver.GetGroups(userEntry, hosting);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(groups, Is.EqualTo(new List<string> { "cn=direct-group,ou=groups,ou=operator,dc=fworch,dc=internal" }));
+                // the hosting ldap is already internal, so no fan-out to the other internal ldaps happens
+                Assert.That(otherInternalConnection.SearchCalls, Is.Empty);
+            });
+        }
+
+        [Test]
+        public async Task GetGroups_FansOutToInternalLdapsForAnExternalUser()
+        {
+            string externalUserDn = "cn=testuser,ou=users,dc=example,dc=com";
+            string externalGroupDn = $"cn=external-group,{kExternalGroupPath}";
+            Ldap hosting = CreateLdap(new RecordingLdapClient(), kExternalUserPath, kExternalGroupPath);
+            Ldap internalLdap = CreateLdap(new RecordingLdapClient(), kInternalUserPath, kInternalGroupPath);
+            UserGroupResolver resolver = new([hosting, internalLdap]);
+            LdapEntry userEntry = LdapTestSupport.CreateEntry(externalUserDn, new LdapAttribute("memberOf", externalGroupDn));
+
+            List<string> groups = await resolver.GetGroups(userEntry, hosting);
+
+            // the external hosting ldap triggers the internal fan-out; the memberOf groups survive it
+            Assert.That(groups, Is.EqualTo(new List<string> { externalGroupDn }));
+        }
+
+        [Test]
+        public async Task GetGroups_DeduplicatesRepeatedMemberOfEntries()
+        {
+            string groupDn = $"cn=both,{kInternalGroupPath}";
+            Ldap ldap = CreateLdap(new RecordingLdapClient(), kInternalUserPath, kInternalGroupPath);
+            UserGroupResolver resolver = new([ldap]);
+            LdapEntry userEntry = LdapTestSupport.CreateEntry(kUserDn, new LdapAttribute("memberOf", new string[] { groupDn, groupDn.ToUpperInvariant() }));
+
+            List<string> groups = await resolver.GetGroups(userEntry, ldap);
+
+            // dn comparison is case insensitive, so the duplicate collapses into one entry
+            Assert.That(groups, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task GetGroups_FallsBackToGroupWritePathWhenSearchPathIsEmpty()
+        {
+            string groupDn = $"cn=write-path-group,{kInternalGroupPath}";
+            TestableLdap ldap = new(new RecordingLdapClient())
+            {
+                SearchUser = kSearchUser,
+                SearchUserPwd = kSearchPassword,
+                UserSearchPath = kInternalUserPath,
+                GroupSearchPath = "",
+                GroupWritePath = kInternalGroupPath
+            };
+            UserGroupResolver resolver = new([ldap]);
+            LdapEntry userEntry = LdapTestSupport.CreateEntry(kUserDn, new LdapAttribute("memberOf", groupDn));
+
+            List<string> groups = await resolver.GetGroups(userEntry, ldap);
+
+            Assert.That(groups, Is.EqualTo(new List<string> { groupDn }));
+        }
+
+        [Test]
+        public async Task GetGroups_ReturnsEmptyWhenNoGroupPathIsConfigured()
+        {
+            TestableLdap ldap = new(new RecordingLdapClient())
+            {
+                SearchUser = kSearchUser,
+                SearchUserPwd = kSearchPassword,
+                UserSearchPath = kInternalUserPath,
+                GroupSearchPath = "",
+                GroupWritePath = ""
+            };
+            UserGroupResolver resolver = new([ldap]);
+            LdapEntry userEntry = LdapTestSupport.CreateEntry(kUserDn, new LdapAttribute("memberOf", kMemberOfValues));
+
+            List<string> groups = await resolver.GetGroups(userEntry, ldap);
+
+            // without a group path nothing can be matched, so no membership survives
+            Assert.That(groups, Is.Empty);
+        }
+
+        private static TestableLdap CreateLdap(RecordingLdapClient connection, string userSearchPath, string groupSearchPath)
+        {
+            return new TestableLdap(connection)
+            {
+                SearchUser = kSearchUser,
+                SearchUserPwd = kSearchPassword,
+                UserSearchPath = userSearchPath,
+                GroupSearchPath = groupSearchPath
+            };
+        }
+
+        private static FakeSearchResults GroupSearchResultFor(string groupName, string memberDn, string groupPath = kInternalGroupPath)
+        {
+            return LdapTestSupport.CreateSearchResults(
+                LdapTestSupport.CreateEntry(
+                    $"cn={groupName},{groupPath}",
+                    new LdapAttribute("cn", groupName),
+                    new LdapAttribute("uniqueMember", memberDn)));
         }
     }
 }

--- a/roles/tests-unit/files/FWO.Test/UserGroupResolverTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UserGroupResolverTest.cs
@@ -1,0 +1,42 @@
+using FWO.Middleware.Server;
+using FWO.Middleware.Server.Services;
+using NUnit.Framework;
+
+namespace FWO.Test
+{
+    [TestFixture]
+    internal class UserGroupResolverTest
+    {
+        private static readonly List<Ldap> kNoLdaps = [];
+
+        [Test]
+        public async Task GetGroupsForUserDn_ReturnsEmptyForMissingDn()
+        {
+            UserGroupResolver resolver = new(kNoLdaps);
+
+            List<string> groups = await resolver.GetGroupsForUserDn("");
+
+            Assert.That(groups, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetGroupsForUserDn_ReturnsEmptyForWhitespaceDn()
+        {
+            UserGroupResolver resolver = new(kNoLdaps);
+
+            List<string> groups = await resolver.GetGroupsForUserDn("   ");
+
+            Assert.That(groups, Is.Empty);
+        }
+
+        [Test]
+        public async Task GetGroupsForUserDn_ReturnsEmptyWhenNoLdapKnowsTheUser()
+        {
+            UserGroupResolver resolver = new(kNoLdaps);
+
+            List<string> groups = await resolver.GetGroupsForUserDn("uid=unknown,ou=users,dc=fworch,dc=internal");
+
+            Assert.That(groups, Is.Empty);
+        }
+    }
+}

--- a/roles/tests-unit/files/FWO.Test/UserGroupResolverTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UserGroupResolverTest.cs
@@ -107,6 +107,33 @@ namespace FWO.Test
         }
 
         [Test]
+        public async Task GetGroupsForUserDn_IgnoresInactiveLdapBeforeActiveLdap()
+        {
+            RecordingLdapClient inactiveConnection = new()
+            {
+                ReadResult = LdapTestSupport.CreateEntry(kUserDn, new LdapAttribute("memberOf", $"cn=inactive,{kInternalGroupPath}"))
+            };
+            Ldap inactive = CreateLdap(inactiveConnection, kInternalUserPath, kInternalGroupPath);
+            inactive.Active = false;
+            RecordingLdapClient activeConnection = new()
+            {
+                ReadResult = LdapTestSupport.CreateEntry(kUserDn, new LdapAttribute("memberOf", $"cn=active,{kInternalGroupPath}"))
+            };
+            Ldap active = CreateLdap(activeConnection, kInternalUserPath, kInternalGroupPath);
+            List<Ldap> configuredLdaps = new() { inactive, active };
+            UserGroupResolver resolver = new(configuredLdaps);
+
+            List<string> groups = await resolver.GetGroupsForUserDn(kUserDn);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(groups, Is.EqualTo(new List<string> { $"cn=active,{kInternalGroupPath}" }));
+                Assert.That(inactiveConnection.ReadCalls, Is.Empty);
+                Assert.That(activeConnection.ReadCalls, Does.Contain(kUserDn));
+            });
+        }
+
+        [Test]
         public async Task GetGroups_ResolvesMemberOfForAnInternalUserWithoutFanOut()
         {
             Ldap hosting = CreateLdap(new RecordingLdapClient(), kInternalUserPath, kInternalGroupPath);
@@ -139,6 +166,28 @@ namespace FWO.Test
 
             // the external hosting ldap triggers the internal fan-out; the memberOf groups survive it
             Assert.That(groups, Is.EqualTo(new List<string> { externalGroupDn }));
+        }
+
+        [Test]
+        public async Task GetGroups_DoesNotFanOutToInactiveInternalLdap()
+        {
+            string externalUserDn = "cn=testuser,ou=users,dc=example,dc=com";
+            string externalGroupDn = $"cn=external-group,{kExternalGroupPath}";
+            Ldap hosting = CreateLdap(new RecordingLdapClient(), kExternalUserPath, kExternalGroupPath);
+            RecordingLdapClient inactiveConnection = new();
+            Ldap inactiveInternal = CreateLdap(inactiveConnection, kInternalUserPath, kInternalGroupPath);
+            inactiveInternal.Active = false;
+            List<Ldap> configuredLdaps = new() { hosting, inactiveInternal };
+            UserGroupResolver resolver = new(configuredLdaps);
+            LdapEntry userEntry = LdapTestSupport.CreateEntry(externalUserDn, new LdapAttribute("memberOf", externalGroupDn));
+
+            List<string> groups = await resolver.GetGroups(userEntry, hosting);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(groups, Is.EqualTo(new List<string> { externalGroupDn }));
+                Assert.That(inactiveConnection.SearchCalls, Is.Empty);
+            });
         }
 
         [Test]

--- a/roles/tests-unit/files/FWO.Test/WorkflowMiddlewareUnitTest.cs
+++ b/roles/tests-unit/files/FWO.Test/WorkflowMiddlewareUnitTest.cs
@@ -24,10 +24,11 @@ namespace FWO.Test
     [TestFixture]
     internal class WorkflowMiddlewareUnitTest
     {
-        private static readonly string[] kExpectedParsedGroups =
+        private static readonly List<string> kNoUserGroups = [];
+        private static readonly string[] kExpectedAssignedGroupDns =
         [
-            "cn=a,dc=fworch,dc=internal",
-            "cn=b,dc=fworch,dc=internal"
+            "cn=assignees,ou=groups,dc=fworch,dc=internal",
+            "cn=approvers,ou=groups,dc=fworch,dc=internal"
         ];
         private static readonly string[] kGetUserEmailsQuery = [AuthQueries.getUserEmails];
         private static readonly string[] kExpectedResolvedUserDns = ["uid=user,ou=users,dc=test"];
@@ -884,7 +885,7 @@ namespace FWO.Test
         }
 
         [Test]
-        public void WorkflowController_CallerCanAccessVisibility_RequiresMatchingVisibilityGroup()
+        public async Task WorkflowController_CallerCanAccessVisibility_RequiresMatchingVisibilityGroup()
         {
             WfHandler handler = new()
             {
@@ -908,9 +909,9 @@ namespace FWO.Test
                 }
             };
 
-            bool allowed = InvokePrivateStatic<bool>(typeof(WorkflowController), "CallerCanAccessVisibility",
+            bool allowed = await InvokeCallerCanAccessVisibility(
                 PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-workflow-visibility-groups", "{7}")), handler, WfObjectScopes.Ticket, new WfTicket { StateId = 10 });
-            bool rejected = InvokePrivateStatic<bool>(typeof(WorkflowController), "CallerCanAccessVisibility",
+            bool rejected = await InvokeCallerCanAccessVisibility(
                 PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-workflow-visibility-groups", "{9}")), handler, WfObjectScopes.Ticket, new WfTicket { StateId = 10 });
 
             Assert.Multiple(() =>
@@ -921,7 +922,7 @@ namespace FWO.Test
         }
 
         [Test]
-        public void WorkflowController_CallerCanAccessVisibility_DeniesUntaggedObjectsForExclusiveMembers()
+        public async Task WorkflowController_CallerCanAccessVisibility_DeniesUntaggedObjectsForExclusiveMembers()
         {
             WfHandler handler = new()
             {
@@ -935,14 +936,14 @@ namespace FWO.Test
                 }
             };
 
-            bool allowed = InvokePrivateStatic<bool>(typeof(WorkflowController), "CallerCanAccessVisibility",
+            bool allowed = await InvokeCallerCanAccessVisibility(
                 PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-workflow-visibility-groups", "{7}")), handler, WfObjectScopes.Ticket, new WfTicket { StateId = 10 });
 
             Assert.That(allowed, Is.False);
         }
 
         [Test]
-        public void WorkflowController_CallerCanAccessVisibility_SkipsChecksWhenFeatureIsDisabled()
+        public async Task WorkflowController_CallerCanAccessVisibility_SkipsChecksWhenFeatureIsDisabled()
         {
             WfHandler handler = new()
             {
@@ -959,48 +960,38 @@ namespace FWO.Test
                 }
             };
 
-            bool allowed = InvokePrivateStatic<bool>(typeof(WorkflowController), "CallerCanAccessVisibility",
+            bool allowed = await InvokeCallerCanAccessVisibility(
                 PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-workflow-visibility-groups", "{9}")), handler, WfObjectScopes.Ticket, new WfTicket { StateId = 10 });
 
             Assert.That(allowed, Is.True);
         }
 
         [Test]
-        public void WorkflowController_CallerCanAccessVisibility_AllowsExplicitApprovalGroupAssignment()
+        public void WorkflowController_IsExplicitlyAssigned_AllowsExplicitApprovalGroupAssignment()
         {
             string approvalGroupDn = "cn=approvers,ou=groups,dc=fworch,dc=internal";
-            WfHandler handler = new()
-            {
-                userConfig = new SimulatedUserConfig
-                {
-                    ReqVisibilityBased = true
-                },
-                MasterStateMatrix = new StateMatrix
-                {
-                    StateVisibilityGroupIds = new Dictionary<int, List<int>>
-                    {
-                        [10] = [7]
-                    }
-                }
-            };
             WfApproval approval = new()
             {
                 Id = 31,
                 StateId = 10,
                 ApproverGroup = approvalGroupDn
             };
+            List<string> userGroups = [approvalGroupDn];
 
-            bool allowed = InvokePrivateStatic<bool>(typeof(WorkflowController), "CallerCanAccessVisibility",
-                PrincipalWithRolesAndClaims(
-                    [Roles.Approver],
-                    new Claim("x-hasura-groups", System.Text.Json.JsonSerializer.Serialize(new List<string> { approvalGroupDn }))),
-                handler, WfObjectScopes.Approval, approval);
+            bool allowed = InvokePrivateStatic<bool>(typeof(WorkflowController), "IsExplicitlyAssignedToUserOrGroups",
+                PrincipalWithRolesAndClaims([Roles.Approver]), approval, userGroups);
+            bool rejected = InvokePrivateStatic<bool>(typeof(WorkflowController), "IsExplicitlyAssignedToUserOrGroups",
+                PrincipalWithRolesAndClaims([Roles.Approver]), approval, kNoUserGroups);
 
-            Assert.That(allowed, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(allowed, Is.True);
+                Assert.That(rejected, Is.False);
+            });
         }
 
         [Test]
-        public void WorkflowController_CallerCanAccessVisibility_AllowsExplicitHandlerAssignment()
+        public async Task WorkflowController_CallerCanAccessVisibility_AllowsExplicitHandlerAssignment()
         {
             WfHandler handler = new()
             {
@@ -1022,41 +1013,53 @@ namespace FWO.Test
                 CurrentHandler = new UiUser { DbId = 7, Dn = "uid=handler,dc=fworch,dc=internal" }
             };
 
-            bool allowed = InvokePrivateStatic<bool>(typeof(WorkflowController), "CallerCanAccessVisibility",
+            bool allowed = await InvokeCallerCanAccessVisibility(
                 PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-user-id", "7")), handler, WfObjectScopes.Ticket, ticket);
 
             Assert.That(allowed, Is.True);
         }
 
         [Test]
-        public void WorkflowController_CallerCanAccessVisibility_AllowsExplicitStatefulGroupAssignment()
+        public void WorkflowController_IsExplicitlyAssigned_AllowsExplicitStatefulGroupAssignment()
         {
             string assignedGroupDn = "cn=assignees,ou=groups,dc=fworch,dc=internal";
-            WfHandler handler = new()
-            {
-                userConfig = new SimulatedUserConfig
-                {
-                    ReqVisibilityBased = true
-                },
-                MasterStateMatrix = new StateMatrix
-                {
-                    StateVisibilityGroupIds = new Dictionary<int, List<int>>
-                    {
-                        [10] = [7]
-                    }
-                }
-            };
             WfTicket ticket = new()
             {
                 StateId = 10,
                 AssignedGroup = assignedGroupDn
             };
+            List<string> userGroups = [assignedGroupDn];
 
-            bool allowed = InvokePrivateStatic<bool>(typeof(WorkflowController), "CallerCanAccessVisibility",
-                PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-groups", System.Text.Json.JsonSerializer.Serialize(new List<string> { assignedGroupDn }))),
-                handler, WfObjectScopes.Ticket, ticket);
+            bool allowed = InvokePrivateStatic<bool>(typeof(WorkflowController), "IsExplicitlyAssignedToUserOrGroups",
+                PrincipalWithRolesAndClaims([Roles.Approver]), ticket, userGroups);
+            bool rejected = InvokePrivateStatic<bool>(typeof(WorkflowController), "IsExplicitlyAssignedToUserOrGroups",
+                PrincipalWithRolesAndClaims([Roles.Approver]), ticket, kNoUserGroups);
 
-            Assert.That(allowed, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(allowed, Is.True);
+                Assert.That(rejected, Is.False);
+            });
+        }
+
+        [Test]
+        public void WorkflowController_CollectAssignedGroupDns_ReturnsOnlyNonEmptyGroupDns()
+        {
+            WfApproval approvalWithBoth = new()
+            {
+                AssignedGroup = "cn=assignees,ou=groups,dc=fworch,dc=internal",
+                ApproverGroup = "cn=approvers,ou=groups,dc=fworch,dc=internal"
+            };
+            WfTicket ticketWithout = new() { AssignedGroup = "  " };
+
+            List<string> both = InvokePrivateStatic<List<string>>(typeof(WorkflowController), "CollectAssignedGroupDns", approvalWithBoth);
+            List<string> none = InvokePrivateStatic<List<string>>(typeof(WorkflowController), "CollectAssignedGroupDns", ticketWithout);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(both, Is.EqualTo(kExpectedAssignedGroupDns));
+                Assert.That(none, Is.Empty);
+            });
         }
 
         [Test]
@@ -1080,31 +1083,18 @@ namespace FWO.Test
                 [Roles.Approver],
                 new Claim("x-hasura-user-id", "17"),
                 new Claim("x-hasura-uuid", "uid=test,dc=fworch,dc=internal"),
-                new Claim("x-hasura-workflow-visibility-groups", "{ 2, 4, x, 9 }"),
-                new Claim("x-hasura-groups", "[\"cn=a,dc=fworch,dc=internal\", \"cn=b,dc=fworch,dc=internal\"]"));
+                new Claim("x-hasura-workflow-visibility-groups", "{ 2, 4, x, 9 }"));
 
             HashSet<int> ids = InvokePrivateStatic<HashSet<int>>(typeof(WorkflowController), "GetClaimIds", user, "x-hasura-workflow-visibility-groups");
             int? userId = InvokePrivateStatic<int?>(typeof(WorkflowController), "GetClaimInt", user, "x-hasura-user-id");
-            List<string> groups = InvokePrivateStatic<List<string>>(typeof(WorkflowController), "GetClaimStrings", user, "x-hasura-groups");
             string? uuid = InvokePrivateStatic<string?>(typeof(WorkflowController), "GetClaimValue", user, "x-hasura-uuid");
 
             Assert.Multiple(() =>
             {
                 Assert.That(ids, Is.EquivalentTo([2, 4, 9]));
                 Assert.That(userId, Is.EqualTo(17));
-                Assert.That(groups, Is.EqualTo(kExpectedParsedGroups));
                 Assert.That(uuid, Is.EqualTo("uid=test,dc=fworch,dc=internal"));
             });
-        }
-
-        [Test]
-        public void WorkflowController_GetClaimStrings_ReturnsEmptyListForInvalidJson()
-        {
-            ClaimsPrincipal user = PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-groups", "not-json"));
-
-            List<string> groups = InvokePrivateStatic<List<string>>(typeof(WorkflowController), "GetClaimStrings", user, "x-hasura-groups");
-
-            Assert.That(groups, Is.Empty);
         }
 
         [Test]
@@ -1311,6 +1301,15 @@ namespace FWO.Test
             MethodInfo method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)
                 ?? throw new InvalidOperationException($"{methodName} not found.");
             return (T)method.Invoke(null, parameters)!;
+        }
+
+        private static async Task<bool> InvokeCallerCanAccessVisibility(ClaimsPrincipal user, WfHandler handler,
+            WfObjectScopes scope, WfStatefulObject statefulObject)
+        {
+            WorkflowController controller = CreateWorkflowController(user);
+            MethodInfo method = typeof(WorkflowController).GetMethod("CallerCanAccessVisibility", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException("CallerCanAccessVisibility not found.");
+            return await (Task<bool>)method.Invoke(controller, [user, handler, scope, statefulObject])!;
         }
 
         private static async Task<T> InvokePrivateStaticAsync<T>(Type type, string methodName, params object?[] parameters)

--- a/roles/tests-unit/files/FWO.Test/WorkflowMiddlewareUnitTest.cs
+++ b/roles/tests-unit/files/FWO.Test/WorkflowMiddlewareUnitTest.cs
@@ -1,6 +1,7 @@
 using FWO.Api.Client;
 using FWO.Api.Client.Queries;
 using FWO.Basics;
+using Novell.Directory.Ldap;
 using FWO.Config.Api.Data;
 using FWO.Config.Api;
 using FWO.Data;
@@ -25,6 +26,11 @@ namespace FWO.Test
     internal class WorkflowMiddlewareUnitTest
     {
         private static readonly List<string> kNoUserGroups = [];
+        private static readonly List<Ldap> kNoLdaps = [];
+        private const string kVisibilityUserPath = "ou=users,ou=operator,dc=fworch,dc=internal";
+        private const string kVisibilityGroupPath = "ou=groups,ou=operator,dc=fworch,dc=internal";
+        private const string kLdapSearchUser = "cn=search,dc=example,dc=com";
+        private static readonly string kLdapSearchPassword = LdapTestSupport.CreateEncryptedSecret("searchpwd");
         private static readonly string[] kExpectedAssignedGroupDns =
         [
             "cn=assignees,ou=groups,dc=fworch,dc=internal",
@@ -1043,6 +1049,166 @@ namespace FWO.Test
         }
 
         [Test]
+        public async Task WorkflowController_CallerCanAccessVisibility_ResolvesGroupAssignmentFromLdap()
+        {
+            // the group dns are no longer in the jwt, so an assigned group must be resolved from ldap
+            string userDn = "cn=approver,ou=users,ou=operator,dc=fworch,dc=internal";
+            WfTicket ticket = new()
+            {
+                StateId = 10,
+                AssignedGroup = $"cn=assignees,{kVisibilityGroupPath}"
+            };
+
+            bool allowed = await InvokeCallerCanAccessVisibility(
+                PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-uuid", userDn)),
+                CreateVisibilityHandler(), WfObjectScopes.Ticket, ticket,
+                [CreateGroupResolvingLdap("assignees", userDn)]);
+
+            Assert.That(allowed, Is.True);
+        }
+
+        [Test]
+        public async Task WorkflowController_CallerCanAccessVisibility_DeniesWhenLdapReportsNoMatchingGroup()
+        {
+            string userDn = "cn=outsider,ou=users,ou=operator,dc=fworch,dc=internal";
+            WfTicket ticket = new()
+            {
+                StateId = 10,
+                AssignedGroup = $"cn=assignees,{kVisibilityGroupPath}"
+            };
+
+            bool allowed = await InvokeCallerCanAccessVisibility(
+                PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-uuid", userDn)),
+                CreateVisibilityHandler(), WfObjectScopes.Ticket, ticket,
+                [CreateGroupResolvingLdap("some-other-group", userDn)]);
+
+            Assert.That(allowed, Is.False);
+        }
+
+        [Test]
+        public async Task WorkflowController_CallerCanAccessVisibility_SkipsLdapWhenNoGroupIsAssigned()
+        {
+            RecordingLdapClient connection = new();
+            TestableLdap ldap = new(connection)
+            {
+                SearchUser = kLdapSearchUser,
+                SearchUserPwd = kLdapSearchPassword,
+                UserSearchPath = kVisibilityUserPath,
+                GroupSearchPath = kVisibilityGroupPath
+            };
+
+            bool allowed = await InvokeCallerCanAccessVisibility(
+                PrincipalWithRolesAndClaims([Roles.Approver], new Claim("x-hasura-uuid", "cn=nobody,ou=users,ou=operator,dc=fworch,dc=internal")),
+                CreateVisibilityHandler(), WfObjectScopes.Ticket, new WfTicket { StateId = 10 },
+                [ldap]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(allowed, Is.False);
+                // no group assignment exists, so the expensive ldap lookup must be skipped entirely
+                Assert.That(connection.ReadCalls, Is.Empty);
+                Assert.That(connection.SearchCalls, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void WorkflowController_CallerCanExecutePhase_MapsEveryPhaseToItsRole()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(InvokeCallerCanExecutePhase(Roles.Planner, WorkflowPhases.planning), Is.True);
+                Assert.That(InvokeCallerCanExecutePhase(Roles.Implementer, WorkflowPhases.implementation), Is.True);
+                Assert.That(InvokeCallerCanExecutePhase(Roles.Reviewer, WorkflowPhases.review), Is.True);
+                Assert.That(InvokeCallerCanExecutePhase(Roles.Requester, WorkflowPhases.request), Is.True);
+                Assert.That(InvokeCallerCanExecutePhase(Roles.Approver, WorkflowPhases.approval), Is.True);
+                // a role from a different phase must not unlock the phase
+                Assert.That(InvokeCallerCanExecutePhase(Roles.Reviewer, WorkflowPhases.planning), Is.False);
+            });
+        }
+
+        [Test]
+        public void WorkflowController_ResolveAffectedReqTask_ResolvesPerScope()
+        {
+            WfReqTask reqTask = new() { Id = 5, TicketId = 1 };
+            WfImplTask implTask = new() { Id = 9, ReqTaskId = 5 };
+            WfTicket ticket = new() { Id = 1, Tasks = [reqTask] };
+
+            WfReqTask? direct = InvokePrivateStatic<WfReqTask?>(typeof(WorkflowController), "ResolveAffectedReqTask",
+                ticket, WfObjectScopes.RequestTask, reqTask, 5L);
+            WfReqTask? byId = InvokePrivateStatic<WfReqTask?>(typeof(WorkflowController), "ResolveAffectedReqTask",
+                ticket, WfObjectScopes.RequestTask, new WfTicket(), 5L);
+            WfReqTask? viaImplTask = InvokePrivateStatic<WfReqTask?>(typeof(WorkflowController), "ResolveAffectedReqTask",
+                ticket, WfObjectScopes.ImplementationTask, implTask, 0L);
+            WfReqTask? unsupported = InvokePrivateStatic<WfReqTask?>(typeof(WorkflowController), "ResolveAffectedReqTask",
+                ticket, WfObjectScopes.Approval, reqTask, 5L);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(direct, Is.SameAs(reqTask));
+                Assert.That(byId, Is.SameAs(reqTask));
+                Assert.That(viaImplTask, Is.SameAs(reqTask));
+                Assert.That(unsupported, Is.Null);
+            });
+        }
+
+        [Test]
+        public void WorkflowController_IsInternalWorkTask_DetectsInternalWorkTarget()
+        {
+            WfReqTask internalWork = new();
+            internalWork.SetAddInfo(AdditionalInfoKeys.FwConfigChangeTarget, ManagementFwConfigChangeTargets.InternalWork);
+            WfReqTask other = new();
+            other.SetAddInfo(AdditionalInfoKeys.FwConfigChangeTarget, "something-else");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(InvokePrivateStatic<bool>(typeof(WorkflowController), "IsInternalWorkTask", internalWork), Is.True);
+                Assert.That(InvokePrivateStatic<bool>(typeof(WorkflowController), "IsInternalWorkTask", other), Is.False);
+                Assert.That(InvokePrivateStatic<bool>(typeof(WorkflowController), "IsInternalWorkTask", (WfReqTask?)null), Is.False);
+            });
+        }
+
+        [Test]
+        public void WorkflowController_ValidatePersistedStateTransition_RejectsNonTransitions()
+        {
+            WorkflowActionResult noChangeResult = new();
+            WorkflowActionResult staleResult = new();
+            WorkflowActionResult okResult = new();
+
+            bool noChange = InvokePrivateStatic<bool>(typeof(WorkflowController), "ValidatePersistedStateTransition",
+                new WorkflowActionParameters { OldStateId = 10, NewStateId = 10 }, new WfTicket { StateId = 10 }, noChangeResult);
+            bool stale = InvokePrivateStatic<bool>(typeof(WorkflowController), "ValidatePersistedStateTransition",
+                new WorkflowActionParameters { OldStateId = 10, NewStateId = 20 }, new WfTicket { StateId = 10 }, staleResult);
+            bool valid = InvokePrivateStatic<bool>(typeof(WorkflowController), "ValidatePersistedStateTransition",
+                new WorkflowActionParameters { OldStateId = 10, NewStateId = 20 }, new WfTicket { StateId = 20 }, okResult);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(noChange, Is.False);
+                Assert.That(stale, Is.False);
+                Assert.That(valid, Is.True);
+                Assert.That(staleResult.ErrorMessage, Does.Contain("not 20"));
+            });
+        }
+
+        [Test]
+        public void WorkflowController_ResolveActionContext_ReturnsEmptyContextForUnknownObjects()
+        {
+            WfHandler handler = CreateVisibilityHandler();
+            WfTicket ticket = new() { Id = 3, Tasks = [] };
+
+            (WfStatefulObject? implObject, _, _, _) = InvokePrivateStatic<(WfStatefulObject?, FwoOwner?, long?, string?)>(
+                typeof(WorkflowController), "ResolveImplementationTask", handler, ticket, 404L);
+            (WfStatefulObject? approvalObject, _, _, _) = InvokePrivateStatic<(WfStatefulObject?, FwoOwner?, long?, string?)>(
+                typeof(WorkflowController), "ResolveApproval", handler, ticket, 404L);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(implObject, Is.Null);
+                Assert.That(approvalObject, Is.Null);
+            });
+        }
+
+        [Test]
         public void WorkflowController_CollectAssignedGroupDns_ReturnsOnlyNonEmptyGroupDns()
         {
             WfApproval approvalWithBoth = new()
@@ -1306,7 +1472,13 @@ namespace FWO.Test
         private static async Task<bool> InvokeCallerCanAccessVisibility(ClaimsPrincipal user, WfHandler handler,
             WfObjectScopes scope, WfStatefulObject statefulObject)
         {
-            WorkflowController controller = CreateWorkflowController(user);
+            return await InvokeCallerCanAccessVisibility(user, handler, scope, statefulObject, kNoLdaps);
+        }
+
+        private static async Task<bool> InvokeCallerCanAccessVisibility(ClaimsPrincipal user, WfHandler handler,
+            WfObjectScopes scope, WfStatefulObject statefulObject, List<Ldap> ldaps)
+        {
+            WorkflowController controller = CreateWorkflowController(user, ldaps);
             MethodInfo method = typeof(WorkflowController).GetMethod("CallerCanAccessVisibility", BindingFlags.NonPublic | BindingFlags.Instance)
                 ?? throw new InvalidOperationException("CallerCanAccessVisibility not found.");
             return await (Task<bool>)method.Invoke(controller, [user, handler, scope, statefulObject])!;
@@ -1363,8 +1535,53 @@ namespace FWO.Test
 
         private static WorkflowController CreateWorkflowController(ClaimsPrincipal user)
         {
+            return CreateWorkflowController(user, kNoLdaps);
+        }
+
+        private static bool InvokeCallerCanExecutePhase(string role, WorkflowPhases phase)
+        {
+            return InvokePrivateStatic<bool>(typeof(WorkflowController), "CallerCanExecutePhase",
+                PrincipalWithRoles([role]), GlobalConst.kUserRolesSelection, phase);
+        }
+
+        private static WfHandler CreateVisibilityHandler()
+        {
+            return new WfHandler
+            {
+                userConfig = new SimulatedUserConfig
+                {
+                    ReqVisibilityBased = true
+                },
+                MasterStateMatrix = new StateMatrix
+                {
+                    StateVisibilityGroupIds = new Dictionary<int, List<int>>
+                    {
+                        [10] = [7]
+                    }
+                }
+            };
+        }
+
+        private static TestableLdap CreateGroupResolvingLdap(string groupName, string memberDn)
+        {
+            RecordingLdapClient connection = new()
+            {
+                ReadResult = LdapTestSupport.CreateEntry(memberDn,
+                    new LdapAttribute("memberOf", $"cn={groupName},{kVisibilityGroupPath}"))
+            };
+            return new TestableLdap(connection)
+            {
+                SearchUser = kLdapSearchUser,
+                SearchUserPwd = kLdapSearchPassword,
+                UserSearchPath = kVisibilityUserPath,
+                GroupSearchPath = kVisibilityGroupPath
+            };
+        }
+
+        private static WorkflowController CreateWorkflowController(ClaimsPrincipal user, List<Ldap> ldaps)
+        {
             RSA rsa = RSA.Create(2048);
-            WorkflowController controller = new(new SimulatedGlobalConfig(), [], new JwtWriter(new RsaSecurityKey(rsa)), new TokenLifetimeProvider())
+            WorkflowController controller = new(new SimulatedGlobalConfig(), ldaps, new JwtWriter(new RsaSecurityKey(rsa)), new TokenLifetimeProvider())
             {
                 ControllerContext = new ControllerContext
                 {

--- a/roles/ui/templates/httpd.conf
+++ b/roles/ui/templates/httpd.conf
@@ -38,6 +38,10 @@
 	ServerAlias {{ ui_server_alias }}
 	Timeout {{ apache_ui_timeout }}
 
+	# the jwt is sent in the "Authorization" header and grows with the permissions of the user,
+	# so raise the per-header limit from the 8190 byte default to the kestrel default of 32KB
+	LimitRequestFieldSize {{ apache_limit_request_field_size }}
+
 	# rewriting upgrade to websocket
     RewriteEngine on
     RewriteCond %{HTTP:Upgrade} websocket [NC]


### PR DESCRIPTION
The user's ldap group dns were added to the jwt as "x-hasura-groups". That list grows with the group memberships of the user and pushed the "Authorization: Bearer ..." header past apache's LimitRequestFieldSize (8190 bytes by default), so login failed with "400 Bad Request - Size of a request header field exceeds server limit" for users with many groups while others could still log in.

The claim was never referenced by any hasura permission, its only consumer was WorkflowController when checking an explicit group assignment. The group memberships are now resolved from ldap on demand instead, and only when the visibility and user checks have already failed and a group assignment exists that could match at all.

The resolution logic is moved into UserGroupResolver so that the login path and the workflow path share the exact same semantics.

Additionally raise LimitRequestFieldSize to the kestrel default of 32KB on the api, ui and mw vhosts, so the remaining per-user claims cannot hit the limit again.

## Inactive ldap connections are no longer used for authorization

Two follow-up fixes from the review of this pr. Both share a root cause: the `List<Ldap>` injected into the controllers is a startup snapshot taken with `getAllLdapConnections`, which has no `active` filter. The active-only subscription only reassigns a local variable, so the list handed to the controllers keeps every deactivated connection for the lifetime of the process. Each consumer therefore has to filter for itself, and only the login bind did.

- `UserGroupResolver.GetGroupsForUserDn` iterated every configured ldap and returned on the first one that knew the dn. A retired but still reachable directory could shadow the real hosting ldap, replacing a user's group memberships with stale ones. Since `getAllLdapConnections` orders by `ldap_connection_id: desc`, a directory added after installation sorts ahead of the internal ldap, so this is the likely ordering rather than a corner case. That decides workflow visibility for explicitly group-assigned items in both directions: wrongly granting access, and wrongly denying it to legitimately assigned users. The internal fan-out in `GetGroups` had the same gap.
- `AuthenticationTokenController.GetRoles` fanned out over every ldap with role handling without checking `Active`, so a deactivated directory could still grant roles at login. This one is not a regression from this pr, it predates it in develop, but it is the same bug on the path that drives every authorization check.

Both now filter on `Active`, matching what `AuthenticateInAnyLdap` already did.

Note for reviewers on the new tests: the role lookup decrypts the search user password with the main key file, so a unit test can never make a role *search* succeed. The tests assert on a new `TestableLdap.ConnectCount` instead, which proves an ldap was skipped entirely without depending on decryption.
