### PR TITLE
Feat/add config param for changeID - 2 missed minor fixes 

### DIFF
--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -4407,6 +4407,8 @@ INSERT INTO txt VALUES ('E5504', 'German',  'Bitte eine Eigent&uuml;merzuordnung
 INSERT INTO txt VALUES ('E5504', 'English', 'Please select an owner mapping source.');
 INSERT INTO txt VALUES ('E5505', 'German',  'Bitte den benutzerdefinierten Feldschl&uuml;ssel ausf&uuml;llen.');
 INSERT INTO txt VALUES ('E5505', 'English', 'Please fill the custom field key.');
+INSERT INTO txt VALUES ('E5506', 'German',  'Nur die &Auml;nderungs-ID-Schl&uuml;ssel wurden gespeichert, die Eigent&uuml;merzuordnung blieb unver&auml;ndert.');
+INSERT INTO txt VALUES ('E5506', 'English', 'Only the change-ID keys were saved, the owner mapping was left unchanged.');
 
 INSERT INTO txt VALUES ('E6001', 'German', 	'Der Re-Login war nicht erfolgreich. Haben Sie ein falsches Passwort eingegeben? Schauen Sie f&uuml;r Details bitte in die Logs.');
 INSERT INTO txt VALUES ('E6001', 'English', 'Re-login failed. Did you enter a wrong password? See log for details.');

--- a/roles/lib/files/FWO.Data/CustomFieldKeyMatching.cs
+++ b/roles/lib/files/FWO.Data/CustomFieldKeyMatching.cs
@@ -1,0 +1,19 @@
+namespace FWO.Data
+{
+    /// <summary>
+    /// Controls how configured custom field keys are matched against the field names of a rule.
+    /// </summary>
+    public enum CustomFieldKeyMatching
+    {
+        /// <summary>
+        /// Field names must match the configured key exactly.
+        /// </summary>
+        CaseSensitive,
+
+        /// <summary>
+        /// Field names match the configured key regardless of casing, for vendors that export
+        /// the same field with inconsistent casing.
+        /// </summary>
+        IgnoreCase
+    }
+}

--- a/roles/lib/files/FWO.Data/CustomFieldResolver.cs
+++ b/roles/lib/files/FWO.Data/CustomFieldResolver.cs
@@ -42,13 +42,15 @@ namespace FWO.Data
         /// <param name="rule">The rule containing the serialized custom fields.</param>
         /// <param name="keysJson">A JSON array of candidate custom field keys, or a legacy plain-text key.</param>
         /// <param name="errorMessage">Description of an unreadable custom field value, otherwise <see langword="null"/>.</param>
+        /// <param name="keyMatching">Whether the field names have to match the configured key exactly.</param>
         /// <returns>
         /// The deserialized custom field value when a matching key is found and can be converted to <typeparamref name="T"/>;
         /// otherwise, <see langword="default"/>.
         /// </returns>
-        public static T? ExtractCustomFieldValue<T>(Rule? rule, string keysJson, out string? errorMessage)
+        public static T? ExtractCustomFieldValue<T>(Rule? rule, string keysJson, out string? errorMessage,
+            CustomFieldKeyMatching keyMatching = CustomFieldKeyMatching.CaseSensitive)
         {
-            return ExtractCustomFieldValue<T>(rule, NormalizeCustomFieldKeys(keysJson), out errorMessage);
+            return ExtractCustomFieldValue<T>(rule, NormalizeCustomFieldKeys(keysJson), out errorMessage, keyMatching);
         }
 
         /// <summary>
@@ -59,11 +61,13 @@ namespace FWO.Data
         /// <param name="rule">The rule containing the serialized custom fields.</param>
         /// <param name="keys">Candidate custom field keys, checked in order.</param>
         /// <param name="errorMessage">Description of an unreadable custom field value, otherwise <see langword="null"/>.</param>
+        /// <param name="keyMatching">Whether the field names have to match the configured key exactly.</param>
         /// <returns>
         /// The deserialized custom field value when a matching key is found and can be converted to <typeparamref name="T"/>;
         /// otherwise, <see langword="default"/>.
         /// </returns>
-        public static T? ExtractCustomFieldValue<T>(Rule? rule, IReadOnlyList<string> keys, out string? errorMessage)
+        public static T? ExtractCustomFieldValue<T>(Rule? rule, IReadOnlyList<string> keys, out string? errorMessage,
+            CustomFieldKeyMatching keyMatching = CustomFieldKeyMatching.CaseSensitive)
         {
             errorMessage = null;
 
@@ -76,8 +80,8 @@ namespace FWO.Data
 
             try
             {
-                customFields = ToCaseInsensitiveFields(
-                    JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(nonNullableRule.CustomFields.Replace("'", "\"")));
+                customFields = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
+                    nonNullableRule.CustomFields.Replace("'", "\"")) ?? [];
             }
             catch (JsonException e)
             {
@@ -93,7 +97,7 @@ namespace FWO.Data
 
             foreach (var key in keys)
             {
-                if (!customFields.TryGetValue(key, out var value))
+                if (!TryGetFieldValue(customFields, key, keyMatching, out JsonElement value))
                 {
                     continue;
                 }
@@ -120,20 +124,39 @@ namespace FWO.Data
         }
 
         /// <summary>
-        /// Rebuilds the deserialized custom fields with a case-insensitive lookup, because the field names
-        /// exported by the firewall vendors do not reliably match the casing of the configured keys.
+        /// Looks up a single configured key in the custom fields of a rule.
+        /// An exact match always wins; only <see cref="CustomFieldKeyMatching.IgnoreCase"/> falls back to a
+        /// casing-insensitive scan, because the field names exported by the firewall vendors do not reliably
+        /// match the casing of the configured key.
         /// </summary>
         /// <param name="customFields">Custom fields as deserialized from the rule.</param>
-        /// <returns>The custom fields, keyed case-insensitively.</returns>
-        private static Dictionary<string, JsonElement> ToCaseInsensitiveFields(Dictionary<string, JsonElement>? customFields)
+        /// <param name="key">Configured custom field key.</param>
+        /// <param name="keyMatching">Whether the field names have to match the configured key exactly.</param>
+        /// <param name="value">The value found for the key.</param>
+        /// <returns>True if the rule holds a field for the key.</returns>
+        private static bool TryGetFieldValue(Dictionary<string, JsonElement> customFields, string key,
+            CustomFieldKeyMatching keyMatching, out JsonElement value)
         {
-            Dictionary<string, JsonElement> caseInsensitiveFields = new(StringComparer.OrdinalIgnoreCase);
-            foreach (KeyValuePair<string, JsonElement> customField in customFields ?? [])
+            if (customFields.TryGetValue(key, out value))
             {
-                // a payload holding keys that differ only in casing keeps the first one instead of throwing
-                caseInsensitiveFields.TryAdd(customField.Key, customField.Value);
+                return true;
             }
-            return caseInsensitiveFields;
+            if (keyMatching == CustomFieldKeyMatching.CaseSensitive)
+            {
+                return false;
+            }
+
+            // scanned instead of rebuilt into a case-insensitive dictionary, because this runs per rule
+            // and a rule holds only a handful of custom fields
+            foreach (KeyValuePair<string, JsonElement> customField in customFields)
+            {
+                if (string.Equals(customField.Key, key, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = customField.Value;
+                    return true;
+                }
+            }
+            return false;
         }
 
         /// <summary>

--- a/roles/lib/files/FWO.Data/CustomFieldResolver.cs
+++ b/roles/lib/files/FWO.Data/CustomFieldResolver.cs
@@ -76,7 +76,8 @@ namespace FWO.Data
 
             try
             {
-                customFields = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(nonNullableRule.CustomFields.Replace("'", "\"")) ?? [];
+                customFields = ToCaseInsensitiveFields(
+                    JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(nonNullableRule.CustomFields.Replace("'", "\"")));
             }
             catch (JsonException e)
             {
@@ -116,6 +117,23 @@ namespace FWO.Data
                 }
             }
             return default;
+        }
+
+        /// <summary>
+        /// Rebuilds the deserialized custom fields with a case-insensitive lookup, because the field names
+        /// exported by the firewall vendors do not reliably match the casing of the configured keys.
+        /// </summary>
+        /// <param name="customFields">Custom fields as deserialized from the rule.</param>
+        /// <returns>The custom fields, keyed case-insensitively.</returns>
+        private static Dictionary<string, JsonElement> ToCaseInsensitiveFields(Dictionary<string, JsonElement>? customFields)
+        {
+            Dictionary<string, JsonElement> caseInsensitiveFields = new(StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, JsonElement> customField in customFields ?? [])
+            {
+                // a payload holding keys that differ only in casing keeps the first one instead of throwing
+                caseInsensitiveFields.TryAdd(customField.Key, customField.Value);
+            }
+            return caseInsensitiveFields;
         }
 
         /// <summary>

--- a/roles/lib/files/FWO.Report/Display/RuleDisplayBase.cs
+++ b/roles/lib/files/FWO.Report/Display/RuleDisplayBase.cs
@@ -21,7 +21,8 @@ namespace FWO.Ui.Display
         public string DisplayChangeId(Rule rule)
         {
             string keysJson = userConfig.GlobalConfig?.CustomFieldChangeIdKey ?? GlobalConst.kDefaultChangeIdKeys;
-            string? value = CustomFieldResolver.ExtractCustomFieldValue<string>(rule, changeIdKeyCache.GetKeys(keysJson), out string? errorMessage);
+            string? value = CustomFieldResolver.ExtractCustomFieldValue<string>(rule, changeIdKeyCache.GetKeys(keysJson),
+                out string? errorMessage, CustomFieldKeyMatching.IgnoreCase);
             return value ?? errorMessage ?? "";
         }
 

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/RuleFieldSourceResolver.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/RuleFieldSourceResolver.cs
@@ -64,7 +64,8 @@ public static class RuleFieldSourceResolver
     {
         return new AdditionalInformation
         {
-            ChangeId = CustomFieldResolver.ExtractCustomFieldValue<string>(rule, changeIdKeys, out _)
+            ChangeId = CustomFieldResolver.ExtractCustomFieldValue<string>(rule, changeIdKeys, out _,
+                CustomFieldKeyMatching.IgnoreCase)
         };
     }
 

--- a/roles/middleware/files/FWO.Middleware.Server/RuleNotificationBodyBase.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/RuleNotificationBodyBase.cs
@@ -88,7 +88,8 @@ namespace FWO.Middleware.Server
             string? changeId = CustomFieldResolver.ExtractCustomFieldValue<string>(
                 rule,
                 changeIdKeyCache.GetKeys(GlobalConfig.CustomFieldChangeIdKey),
-                out _);
+                out _,
+                CustomFieldKeyMatching.IgnoreCase);
             return changeId ?? "";
         }
 

--- a/roles/tests-unit/files/FWO.Test/CustomFieldKeyNormalizationTest.cs
+++ b/roles/tests-unit/files/FWO.Test/CustomFieldKeyNormalizationTest.cs
@@ -88,35 +88,47 @@ namespace FWO.Test
         }
 
         [Test]
-        public void ExtractCustomFieldValue_MatchesConfiguredKeyRegardlessOfCasing()
+        public void ExtractCustomFieldValue_IgnoreCase_MatchesConfiguredKeyRegardlessOfCasing()
         {
             Rule camelCaseRule = new() { CustomFields = "{'ChangeId':'CHG-7'}" };
             Rule lowerCaseRule = new() { CustomFields = "{'changeid':'CHG-8'}" };
 
-            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(camelCaseRule, GlobalConst.kDefaultChangeIdKeys, out _),
-                Is.EqualTo("CHG-7"));
-            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(lowerCaseRule, GlobalConst.kDefaultChangeIdKeys, out _),
-                Is.EqualTo("CHG-8"));
+            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(camelCaseRule, GlobalConst.kDefaultChangeIdKeys, out _,
+                CustomFieldKeyMatching.IgnoreCase), Is.EqualTo("CHG-7"));
+            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(lowerCaseRule, GlobalConst.kDefaultChangeIdKeys, out _,
+                CustomFieldKeyMatching.IgnoreCase), Is.EqualTo("CHG-8"));
         }
 
         [Test]
-        public void ExtractCustomFieldValue_KeysDifferingOnlyInCasing_KeepFirstWithoutThrowing()
+        public void ExtractCustomFieldValue_DefaultsToCaseSensitiveMatching()
         {
-            Rule rule = new() { CustomFields = "{'ChangeID':'first','changeid':'second'}" };
+            Rule rule = new() { CustomFields = "{'ChangeId':'CHG-7'}" };
 
-            string? result = CustomFieldResolver.ExtractCustomFieldValue<string>(rule, GlobalConst.kDefaultChangeIdKeys, out string? errorMessage);
+            // the owner mapping relies on exact matching, so casing must only be ignored where asked for
+            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(rule, GlobalConst.kDefaultChangeIdKeys, out _), Is.Null);
+            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(rule, GlobalConst.kDefaultChangeIdKeys, out _,
+                CustomFieldKeyMatching.CaseSensitive), Is.Null);
+        }
 
-            Assert.That(result, Is.EqualTo("first"));
+        [Test]
+        public void ExtractCustomFieldValue_IgnoreCase_PrefersExactMatchOverCasingVariant()
+        {
+            Rule rule = new() { CustomFields = "{'changeid':'variant','ChangeID':'exact'}" };
+
+            string? result = CustomFieldResolver.ExtractCustomFieldValue<string>(rule, GlobalConst.kDefaultChangeIdKeys, out string? errorMessage,
+                CustomFieldKeyMatching.IgnoreCase);
+
+            Assert.That(result, Is.EqualTo("exact"));
             Assert.That(errorMessage, Is.Null);
         }
 
         [Test]
-        public void ExtractCustomFieldValue_ConfiguredKeyOrderWinsOverPayloadOrder()
+        public void ExtractCustomFieldValue_IgnoreCase_ConfiguredKeyOrderWinsOverPayloadOrder()
         {
             Rule rule = new() { CustomFields = "{'changeid':'fallback','FIELD-2':'preferred'}" };
 
-            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(rule, GlobalConst.kDefaultChangeIdKeys, out _),
-                Is.EqualTo("preferred"));
+            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(rule, GlobalConst.kDefaultChangeIdKeys, out _,
+                CustomFieldKeyMatching.IgnoreCase), Is.EqualTo("preferred"));
         }
 
         [Test]

--- a/roles/tests-unit/files/FWO.Test/CustomFieldKeyNormalizationTest.cs
+++ b/roles/tests-unit/files/FWO.Test/CustomFieldKeyNormalizationTest.cs
@@ -88,6 +88,38 @@ namespace FWO.Test
         }
 
         [Test]
+        public void ExtractCustomFieldValue_MatchesConfiguredKeyRegardlessOfCasing()
+        {
+            Rule camelCaseRule = new() { CustomFields = "{'ChangeId':'CHG-7'}" };
+            Rule lowerCaseRule = new() { CustomFields = "{'changeid':'CHG-8'}" };
+
+            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(camelCaseRule, GlobalConst.kDefaultChangeIdKeys, out _),
+                Is.EqualTo("CHG-7"));
+            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(lowerCaseRule, GlobalConst.kDefaultChangeIdKeys, out _),
+                Is.EqualTo("CHG-8"));
+        }
+
+        [Test]
+        public void ExtractCustomFieldValue_KeysDifferingOnlyInCasing_KeepFirstWithoutThrowing()
+        {
+            Rule rule = new() { CustomFields = "{'ChangeID':'first','changeid':'second'}" };
+
+            string? result = CustomFieldResolver.ExtractCustomFieldValue<string>(rule, GlobalConst.kDefaultChangeIdKeys, out string? errorMessage);
+
+            Assert.That(result, Is.EqualTo("first"));
+            Assert.That(errorMessage, Is.Null);
+        }
+
+        [Test]
+        public void ExtractCustomFieldValue_ConfiguredKeyOrderWinsOverPayloadOrder()
+        {
+            Rule rule = new() { CustomFields = "{'changeid':'fallback','FIELD-2':'preferred'}" };
+
+            Assert.That(CustomFieldResolver.ExtractCustomFieldValue<string>(rule, GlobalConst.kDefaultChangeIdKeys, out _),
+                Is.EqualTo("preferred"));
+        }
+
+        [Test]
         public void KeyCache_ReturnsSameInstanceForUnchangedSetting()
         {
             CustomFieldKeyCache cache = new();

--- a/roles/tests-unit/files/FWO.Test/RuleFieldSourceResolverTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleFieldSourceResolverTest.cs
@@ -57,6 +57,33 @@ namespace FWO.Test
         }
 
         [Test]
+        public void ResolveAdditionalInformation_ShouldIgnoreCustomFieldCasing()
+        {
+            Rule rule = CreateRule(
+                OwnerMappingSourceStm.CustomField,
+                "{'Change_Key':'chg-4711'}",
+                123);
+
+            AdditionalInformation value = RuleFieldSourceResolver.ResolveAdditionalInformation(rule, @"[""change_key""]");
+
+            ClassicAssert.AreEqual("chg-4711", value.ChangeId);
+        }
+
+        [Test]
+        public void ResolveOwnerInformation_ShouldKeepExactCustomFieldCasing()
+        {
+            Rule rule = CreateRule(
+                OwnerMappingSourceStm.CustomField,
+                "{'Owner_Key':'owner-from-custom'}",
+                123);
+
+            // owner mapping stays case sensitive, so an upgrade cannot silently remap rules to other owners
+            OwnerInformation value = RuleFieldSourceResolver.ResolveOwnerInformation(rule, @"[""owner_key""]");
+
+            ClassicAssert.IsNull(value.ExtAppId);
+        }
+
+        [Test]
         public void ResolveAdditionalInformation_ShouldReturnEmptyObjectWhenNoMappingIsConfigured()
         {
             Rule rule = CreateRule(

--- a/roles/tests-unit/files/FWO.Test/RuleViewDataTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleViewDataTest.cs
@@ -126,6 +126,25 @@ namespace FWO.Test
         }
 
         [Test]
+        public void RuleViewData_ResolvesChangeIdRegardlessOfCustomFieldCasing()
+        {
+            GlobalConfig globalConfig = new SimulatedGlobalConfig
+            {
+                CustomFieldChangeIdKey = "[\"ChangeID\"]"
+            };
+            UserConfig userConfig = UserConfig.ForTextOnly(globalConfig, registerOnChangeHandler: false);
+            NatRuleDisplayHtml ruleDisplay = new(userConfig);
+            Rule rule = new()
+            {
+                CustomFields = "{'changeid':'CHG-77'}"
+            };
+
+            RuleViewData viewData = new(rule, ruleDisplay, OutputLocation.report, true);
+
+            Assert.That(viewData.ChangeID, Is.EqualTo("CHG-77"));
+        }
+
+        [Test]
         public void RuleViewData_UsesDefaultChangeIdCustomFieldKeys()
         {
             UserConfig userConfig = new();

--- a/roles/tests-unit/files/FWO.Test/UiMainLayoutTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiMainLayoutTest.cs
@@ -41,9 +41,9 @@ namespace FWO.Test
                 ?? throw new MissingFieldException(typeof(MainLayout).FullName, name);
         }
 
-        private static void InvokeDisplayMessage(MainLayout layout, Exception? exception, string title, string message, bool errorFlag)
+        private static Task InvokeDisplayMessage(MainLayout layout, Exception? exception, string title, string message, bool errorFlag)
         {
-            GetPrivateMethod("DisplayMessageInUi").Invoke(layout, [exception, title, message, errorFlag]);
+            return (Task)GetPrivateMethod("DisplayMessageInUiAsync").Invoke(layout, [exception, title, message, errorFlag])!;
         }
 
         private static T GetPrivateFieldValue<T>(MainLayout layout, string name)
@@ -72,7 +72,7 @@ namespace FWO.Test
             await using MainLayoutFixture fixture = new();
             MainLayout layout = fixture.Layout.Instance;
 
-            InvokeDisplayMessage(layout, null, "Save", "Done", false);
+            await InvokeDisplayMessage(layout, null, "Save", "Done", false);
 
             fixture.Layout.WaitForAssertion(() =>
             {
@@ -89,7 +89,7 @@ namespace FWO.Test
             await using MainLayoutFixture fixture = new();
             MainLayout layout = fixture.Layout.Instance;
 
-            InvokeDisplayMessage(layout, null, "Careful", "Check this", true);
+            await InvokeDisplayMessage(layout, null, "Careful", "Check this", true);
 
             fixture.Layout.WaitForAssertion(() =>
             {
@@ -106,7 +106,7 @@ namespace FWO.Test
             await using MainLayoutFixture fixture = new();
             MainLayout layout = fixture.Layout.Instance;
 
-            InvokeDisplayMessage(layout, new Exception("no such type exists in the schema: 'cidr'"), "", "", false);
+            await InvokeDisplayMessage(layout, new Exception("no such type exists in the schema: 'cidr'"), "", "", false);
 
             fixture.Layout.WaitForAssertion(() => Assert.That(fixture.Layout.Markup, Does.Contain("api_access - E0004")));
             fixture.ApiConnection.WaitForLogCount(1);
@@ -119,7 +119,7 @@ namespace FWO.Test
             await using MainLayoutFixture fixture = new();
             MainLayout layout = fixture.Layout.Instance;
 
-            InvokeDisplayMessage(layout, new InvalidOperationException("exploded"), "Load", "Could not load", true);
+            await InvokeDisplayMessage(layout, new InvalidOperationException("exploded"), "Load", "Could not load", true);
 
             fixture.Layout.WaitForAssertion(() => Assert.That(fixture.Layout.Markup, Does.Contain("Load - Could not load: exploded . E0002")));
 
@@ -361,8 +361,23 @@ namespace FWO.Test
             MainLayout layout = fixture.Layout.Instance;
             SetPrivateFieldValue<List<FWO.Ui.Data.UIMessage>?>(layout, "UIMessages", null);
 
-            Assert.DoesNotThrow(() => InvokeDisplayMessage(layout, null, "Save", "Done", false));
+            Assert.DoesNotThrowAsync(async () => await InvokeDisplayMessage(layout, null, "Save", "Done", false));
             Assert.That(fixture.ApiConnection.UiLogs, Is.Empty);
+        }
+
+        [Test]
+        public async Task DisplayMessageInUiFunction_IsWiredToDisplayMessageInUiAsync()
+        {
+            await using MainLayoutFixture fixture = new();
+            MainLayout layout = fixture.Layout.Instance;
+
+            Action<Exception?, string, string, bool> displayMessage =
+                GetPrivateFieldValue<Action<Exception?, string, string, bool>>(layout, "DisplayMessageInUiFunction");
+            displayMessage(null, "Save", "Done", false);
+
+            fixture.Layout.WaitForAssertion(() => Assert.That(fixture.Layout.Markup, Does.Contain("Save - Done")));
+            fixture.ApiConnection.WaitForLogCount(1);
+            Assert.That(fixture.ApiConnection.UiLogs[0], Is.EqualTo(new UiLogEntry(0, "Save", "Done")));
         }
 
         private sealed class MainLayoutFixture : IAsyncDisposable

--- a/roles/tests-unit/files/FWO.Test/UiSettingsImportTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiSettingsImportTest.cs
@@ -1,3 +1,6 @@
+using FWO.Basics;
+using FWO.Config.Api;
+using FWO.Data;
 using FWO.Ui.Pages.Settings;
 using NUnit.Framework;
 using System.Reflection;
@@ -76,6 +79,66 @@ namespace FWO.Test
             Assert.That(GetField<List<string>>(component, "ChangeIdKeys"), Is.EqualTo(new List<string> { "field-2", "ChangeId" }));
             Assert.That(GetField<List<string>>(component, "ChangeIdKeysToAdd"), Is.Empty);
             Assert.That(GetField<List<string>>(component, "ChangeIdKeysToDelete"), Is.Empty);
+        }
+
+        [Test]
+        public void PrepareOwnerMapping_ReportsMissingSourceAndMissingOwnerKey()
+        {
+            SettingsImport component = CreateComponentWithTexts();
+            SetField(component, "OwnerKeys", new List<string>());
+            SetField(component, "OwnerKeysToAdd", new List<string>());
+            SetField(component, "OwnerKeysToDelete", new List<string>());
+
+            SetField<OwnerMappingSourceStm?>(component, "SelectedOwnerMappingSource", null);
+            Assert.That(InvokePrepareOwnerMapping(component), Is.EqualTo("no source selected"));
+
+            SetField<OwnerMappingSourceStm?>(component, "SelectedOwnerMappingSource", OwnerMappingSourceStm.CustomField);
+            Assert.That(InvokePrepareOwnerMapping(component), Is.EqualTo("no owner key"));
+        }
+
+        [Test]
+        public void PrepareOwnerMapping_AppliesPendingOwnerKeys_WhenMappingIsValid()
+        {
+            SettingsImport component = CreateComponentWithTexts();
+            SetField<OwnerMappingSourceStm?>(component, "SelectedOwnerMappingSource", OwnerMappingSourceStm.CustomField);
+            SetField(component, "OwnerKeys", new List<string> { "obsolete" });
+            SetField(component, "OwnerKeysToAdd", new List<string> { "app-id" });
+            SetField(component, "OwnerKeysToDelete", new List<string> { "obsolete" });
+
+            Assert.That(InvokePrepareOwnerMapping(component), Is.Null);
+            Assert.That(GetField<List<string>>(component, "OwnerKeys"), Is.EqualTo(new List<string> { "app-id" }));
+        }
+
+        [Test]
+        public void PrepareOwnerMapping_LeavesChangeIdKeysUntouched_WhenOwnerMappingIsInvalid()
+        {
+            SettingsImport component = CreateComponentWithTexts();
+            SetField<OwnerMappingSourceStm?>(component, "SelectedOwnerMappingSource", null);
+            SetField(component, "ChangeIdKeys", new List<string> { "field-2" });
+            SetField(component, "ChangeIdKeysToAdd", new List<string> { "ChangeID" });
+            SetField(component, "ChangeIdKeysToDelete", new List<string>());
+
+            // an invalid owner mapping must not discard the pending change-ID edits, they are saved independently
+            Assert.That(InvokePrepareOwnerMapping(component), Is.Not.Null);
+            Assert.That(InvokeMergeChangeIdKeys(component), Is.EqualTo(new List<string> { "field-2", "ChangeID" }));
+        }
+
+        private static SettingsImport CreateComponentWithTexts()
+        {
+            SimulatedGlobalConfig globalConfig = new();
+            globalConfig.LangDict[GlobalConst.kEnglish]["E5504"] = "no source selected";
+            globalConfig.LangDict[GlobalConst.kEnglish]["E5505"] = "no owner key";
+
+            SettingsImport component = new();
+            PropertyInfo userConfigProperty = typeof(SettingsImport).GetProperty("userConfig", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new MissingMemberException(typeof(SettingsImport).FullName, "userConfig");
+            userConfigProperty.SetValue(component, UserConfig.ForTextOnly(globalConfig, registerOnChangeHandler: false));
+            return component;
+        }
+
+        private static string? InvokePrepareOwnerMapping(SettingsImport component)
+        {
+            return (string?)GetMethod("PrepareOwnerMapping", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(component, null);
         }
 
         private static List<string> InvokeDeserialize(string value)

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsImport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsImport.razor
@@ -214,23 +214,22 @@ else
                 string oldOwnerKey = configData.CustomFieldOwnerKey ?? "";
                 string oldModelledMarker = configData.ModModelledMarker ?? "";
 
-                if (SelectedOwnerMappingSource == null)
-                {
-                    DisplayMessageInUi(null, userConfig.GetText("modelling_settings"), userConfig.GetText("E5504"), true);
-                    return;
-                }
-                PrepareOwnerKeys();
-                if (SelectedOwnerMappingSource == OwnerMappingSourceStm.CustomField && !OwnerKeys.Any())
-                {
-                    DisplayMessageInUi(null, userConfig.GetText("modelling_settings"), userConfig.GetText("E5505"), true);
-                    return;
-                }
-
                 List<string> mergedChangeIdKeys = MergeChangeIdKeys();
-
-                configData.OwnerSoruceMappingID = (int)SelectedOwnerMappingSource.Value;
-                configData.CustomFieldOwnerKey = JsonSerializer.Serialize(OwnerKeys);
+                // the change-ID keys are read by rule reports, notification mails and the rule REST API,
+                // so an incomplete owner mapping must not block them
                 configData.CustomFieldChangeIdKey = JsonSerializer.Serialize(mergedChangeIdKeys);
+
+                string? ownerMappingError = PrepareOwnerMapping();
+                if (ownerMappingError != null)
+                {
+                    await globalConfig.WriteToDatabase(configData, apiConnection);
+                    CommitChangeIdKeys(mergedChangeIdKeys);
+                    DisplayMessageInUi(null, userConfig.GetText("modelling_settings"), $"{ownerMappingError} {userConfig.GetText("E5506")}", true);
+                    return;
+                }
+
+                configData.OwnerSoruceMappingID = (int)SelectedOwnerMappingSource!.Value;
+                configData.CustomFieldOwnerKey = JsonSerializer.Serialize(OwnerKeys);
                 configData.ModModelledMarker = actModelledMarker;
 
                 await globalConfig.WriteToDatabase(configData, apiConnection);
@@ -257,6 +256,24 @@ else
         {
             DisplayMessageInUi(exception, userConfig.GetText("change_default"), "", true);
         }
+    }
+
+    /// <summary>
+    /// Applies the pending owner key edits and checks that the owner mapping part of the form can be persisted.
+    /// </summary>
+    /// <returns>The error text to display, or <see langword="null"/> when the owner mapping is valid.</returns>
+    private string? PrepareOwnerMapping()
+    {
+        if (SelectedOwnerMappingSource == null)
+        {
+            return userConfig.GetText("E5504");
+        }
+        PrepareOwnerKeys();
+        if (SelectedOwnerMappingSource == OwnerMappingSourceStm.CustomField && !OwnerKeys.Any())
+        {
+            return userConfig.GetText("E5505");
+        }
+        return null;
     }
 
     private static bool ShouldTriggerRuleOwnerReinitialize(int oldSource, string oldOwnerKey, string oldModelledMarker, ConfigData configData)

--- a/roles/ui/files/FWO.UI/Pages/Settings/SettingsImport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Settings/SettingsImport.razor
@@ -215,19 +215,21 @@ else
                 string oldModelledMarker = configData.ModModelledMarker ?? "";
 
                 List<string> mergedChangeIdKeys = MergeChangeIdKeys();
-                // the change-ID keys are read by rule reports, notification mails and the rule REST API,
-                // so an incomplete owner mapping must not block them
-                configData.CustomFieldChangeIdKey = JsonSerializer.Serialize(mergedChangeIdKeys);
+                string serializedChangeIdKeys = JsonSerializer.Serialize(mergedChangeIdKeys);
 
                 string? ownerMappingError = PrepareOwnerMapping();
                 if (ownerMappingError != null)
                 {
-                    await globalConfig.WriteToDatabase(configData, apiConnection);
+                    // the change-ID keys are read by rule reports, notification mails and the rule REST API,
+                    // so an incomplete owner mapping must not block them
+                    await SaveChangeIdKeysOnly(serializedChangeIdKeys);
+                    configData.CustomFieldChangeIdKey = serializedChangeIdKeys;
                     CommitChangeIdKeys(mergedChangeIdKeys);
                     DisplayMessageInUi(null, userConfig.GetText("modelling_settings"), $"{ownerMappingError} {userConfig.GetText("E5506")}", true);
                     return;
                 }
 
+                configData.CustomFieldChangeIdKey = serializedChangeIdKeys;
                 configData.OwnerSoruceMappingID = (int)SelectedOwnerMappingSource!.Value;
                 configData.CustomFieldOwnerKey = JsonSerializer.Serialize(OwnerKeys);
                 configData.ModModelledMarker = actModelledMarker;
@@ -256,6 +258,19 @@ else
         {
             DisplayMessageInUi(exception, userConfig.GetText("change_default"), "", true);
         }
+    }
+
+    /// <summary>
+    /// Persists the change-ID keys on their own, leaving every other importer setting on this page untouched.
+    /// A fresh config copy is used because <see cref="configData"/> is two-way bound to the other settings of
+    /// the form, which must not reach the database while the form is rejected.
+    /// </summary>
+    /// <param name="serializedChangeIdKeys">Serialized change-ID key list.</param>
+    private async Task SaveChangeIdKeysOnly(string serializedChangeIdKeys)
+    {
+        ConfigData changeIdKeyConfig = await globalConfig.GetEditableConfig();
+        changeIdKeyConfig.CustomFieldChangeIdKey = serializedChangeIdKeys;
+        await globalConfig.WriteToDatabase(changeIdKeyConfig, apiConnection);
     }
 
     /// <summary>

--- a/roles/ui/files/FWO.UI/Shared/MainLayout.razor
+++ b/roles/ui/files/FWO.UI/Shared/MainLayout.razor
@@ -127,7 +127,8 @@
         apiConnection.OnExecutionModeChanged += OnExecutionModeChanged;
         authenticationProvider.AuthenticationStateChanged += OnAuthenticationStateChanged;
 
-        DisplayMessageInUiFunction = DisplayMessageInUi;
+        DisplayMessageInUiFunction = (exception, title, message, errorFlag) =>
+            _ = DisplayMessageInUiAsync(exception, title, message, errorFlag);
 
         locationChangingRegistration = NavigationManager.RegisterLocationChangingHandler(OnLocationChanging);
 
@@ -483,7 +484,16 @@
         InvokeAsync(StateHasChanged);
     }
 
-    private async void DisplayMessageInUi(Exception? exception = null, string title = "", string message = "", bool errorFlag = false)
+    /// <summary>
+    /// Displays a user or exception message in the UI and writes the corresponding log entry.
+    /// Invoked in a fire-and-forget manner via <see cref="DisplayMessageInUiFunction"/>, therefore
+    /// all exceptions are handled internally.
+    /// </summary>
+    /// <param name="exception">Exception to report, or null for a plain user message.</param>
+    /// <param name="title">Title of the message.</param>
+    /// <param name="message">Message text.</param>
+    /// <param name="errorFlag">Marks the message as an error.</param>
+    private async Task DisplayMessageInUiAsync(Exception? exception = null, string title = "", string message = "", bool errorFlag = false)
     {
         try
         {


### PR DESCRIPTION
Follow-up to #5063, fixing two issues that were missed in that PR's review rounds.

### Opt-in case-insensitive custom field key matching

- `CustomFieldResolver.ExtractCustomFieldValue` resolved keys through the `Dictionary<string, JsonElement>` produced by `JsonSerializer`, i.e. with the default ordinal, **case-sensitive** comparer. #5063 needed a dedicated commit ("fix case-sensitivity issue with ChangeID") to align the shipped literals to `ChangeID`, but that only fixed the symptom: a rule whose firewall exports the field as `ChangeId` or `changeid` still resolved to an empty value, silently and without any error.
- The matching mode is now an explicit parameter (`CustomFieldKeyMatching.CaseSensitive` / `IgnoreCase`) that defaults to the previous, case-sensitive behaviour. An exact match always wins; only `IgnoreCase` falls back to a casing-insensitive scan over the fields of the rule. The scan is done per lookup instead of rebuilding a case-insensitive dictionary, since a rule carries only a handful of custom fields.
- The configured key order still takes precedence over the key order in the payload.
- `IgnoreCase` is passed at the three **change-ID** call sites only: rule reports (`RuleDisplayBase.DisplayChangeId`), notification mails (`RuleNotificationBodyBase`) and the rule REST API (`RuleFieldSourceResolver.ResolveAdditionalInformation`). The change-ID is display/reporting data, so a casing variant can only make an otherwise empty cell resolve.
- **Owner mapping resolution stays case-sensitive**, deliberately: `RuleFieldSourceResolver.ResolveOwnerInformation` and `UpdateRuleOwnerMappingCustomField` keep the default, so an upgrade cannot silently remap rules to a different owner because of a casing variant in the exported field name.

### Change-ID keys were tied to the owner mapping validation

- #5063 moved the change-ID key editor out of the `CustomField` branch so it is shown for every owner mapping source — correct, since the keys are read by rule reports, notification mails and the rule REST API regardless. `Save()` however still aborted on `E5504` (no owner mapping source) and `E5505` (source = custom field with no owner key) *before* the change-ID keys were written, so they could not be saved at all while the owner mapping was incomplete, and the error shown was about modelling settings.
- `MergeChangeIdKeys()` now runs before the validation; the `E5504`/`E5505` checks move into a new `PrepareOwnerMapping()` that returns the error text or `null`.
- When the owner mapping is invalid, the change-ID keys are still persisted and committed and the message appends the new text `E5506`, so it is clear what was and was not saved. The owner mapping fields are only touched on the valid path, so nothing partial is written there.
- On that error path the keys are written through `SaveChangeIdKeysOnly()`, which persists a **fresh `GetEditableConfig()` copy** carrying only `CustomFieldChangeIdKey`. `configData` is two-way bound to the other importer settings on this page (`ImportSleepTime`, the certificate flags, `FwApiElementsPerFetch`, …) and `WriteToDatabase` persists every changed property, so writing `configData` here would have leaked unrelated, rejected form edits into the database while the message claims only the change-ID keys were saved.

### Side fix: `MainLayout.DisplayMessageInUi`

- The new error path made the page call `DisplayMessageInUi` and then `return`, which surfaced that the handler was an `async void`: an exception after the first `await` would have been thrown on the synchronization context instead of being handled.
- It is now `private async Task DisplayMessageInUiAsync(...)`, with `DisplayMessageInUiFunction` wrapping it in an explicit fire-and-forget lambda. All exceptions remain handled inside the method.

### Notes
- Not addressed here: `PrepareOwnerMapping()` still applies the pending owner key edits before the `E5505` check, so a failed save leaves the owner key editor showing unpersisted state. Fixing that means giving the owner keys the same merge/commit split the change-ID keys now have.
