### PR TITLE
Fix: annotation and remove netaddr_pydantic from requirements

### DIFF
--- a/roles/importer/files/importer/fw_modules/opnsense25ff/opnsense_model.py
+++ b/roles/importer/files/importer/fw_modules/opnsense25ff/opnsense_model.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Any, cast
+from typing import Annotated, Any, cast
 
+import netaddr
 from fw_modules.opnsense25ff.opnsense_constants import OPNSENSE_UUID_ALIAS
-from pydantic import AliasPath, BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasPath, BaseModel, ConfigDict, Field, PlainSerializer, PlainValidator, field_validator
 
-if TYPE_CHECKING:
-    from netaddr import IPAddress, IPNetwork
-else:
-    from netaddr_pydantic import IPAddress, IPNetwork  # noqa: TC002
+# netaddr_pydantic only supports Python >= 3.11, but this importer still supports 3.10, so we
+# inline its (trivial) IPAddress/IPNetwork wrappers here instead of depending on it: validate
+# from str/int via the netaddr constructors, serialize back to str.
+IPAddress = Annotated[netaddr.IPAddress, PlainValidator(netaddr.IPAddress), PlainSerializer(str)]
+IPNetwork = Annotated[netaddr.IPNetwork, PlainValidator(netaddr.IPNetwork), PlainSerializer(str)]
 
 
 def _normalize_to_str_list(value: Any, separator: str = ",") -> list[str]:

--- a/roles/importer/files/importer/requirements.txt
+++ b/roles/importer/files/importer/requirements.txt
@@ -29,4 +29,3 @@ pyright==1.1.411
 
 # OPNsense import
 xmltodict==1.0.4
-netaddr_pydantic==0.2.1


### PR DESCRIPTION
implemented the annotated like described in https://pypi.org/project/netaddr-pydantic/

watch out, this is untested since I do not have a test environment for opnsense
@Y4nnikH Maybe you can test or can deligate to someone who is able to