### PR TITLE
Partial fix for duplicated Group Bug

### DIFF
--- a/roles/common/files/fwo-api-calls/rule/getActiveRulesByOwner.graphql
+++ b/roles/common/files/fwo-api-calls/rule/getActiveRulesByOwner.graphql
@@ -11,7 +11,13 @@ query getActiveRulesByOwner($ownerId: Int!) {
     rule_uid
     rule_id
     mgm_id
-    rule_froms(order_by:{ object: {obj_id: asc}}){
+    rule_froms(
+      where: {
+        active: { _eq: true }
+        removed: { _is_null: true }
+      }
+      order_by:{ object: {obj_id: asc}}
+    ){
       object{
         obj_name
         obj_ip
@@ -36,7 +42,13 @@ query getActiveRulesByOwner($ownerId: Int!) {
         }
       }
     }
-    rule_tos(order_by: { object: { obj_name: asc } }) {
+    rule_tos(
+      where: {
+        active: { _eq: true }
+        removed: { _is_null: true }
+      }
+      order_by: { object: { obj_name: asc } }
+    ) {
       object {
         obj_name
         obj_ip
@@ -61,7 +73,13 @@ query getActiveRulesByOwner($ownerId: Int!) {
         }
       }
     }
-    rule_services(order_by: { service: { svc_name: asc } }) {
+    rule_services(
+      where: {
+        active: { _eq: true }
+        removed: { _is_null: true }
+      }
+      order_by: { service: { svc_name: asc } }
+    ) {
       service {
         svc_name
         ip_proto_id

--- a/roles/common/files/fwo-api-calls/rule/getRuleDetailByID.graphql
+++ b/roles/common/files/fwo-api-calls/rule/getRuleDetailByID.graphql
@@ -12,7 +12,13 @@ query RuleDetailById(
         rule_uid
         rule_id
         mgm_id
-        rule_froms(order_by:{ object: {obj_id: asc}}){
+        rule_froms(
+            where: {
+                active: { _eq: true }
+                removed: { _is_null: true }
+            }
+            order_by:{ object: {obj_id: asc}}
+        ){
             object{
                 obj_id
                 obj_name
@@ -41,7 +47,13 @@ query RuleDetailById(
                 }
             }
         }
-        rule_tos(order_by: { object: { obj_name: asc } }) {
+        rule_tos(
+            where: {
+                active: { _eq: true }
+                removed: { _is_null: true }
+            }
+            order_by: { object: { obj_name: asc } }
+        ) {
             object {
                 obj_id
                 obj_name
@@ -70,7 +82,13 @@ query RuleDetailById(
                 }
             }
         }
-        rule_services(order_by: { service: { svc_name: asc } }) {
+        rule_services(
+            where: {
+                active: { _eq: true }
+                removed: { _is_null: true }
+            }
+            order_by: { service: { svc_name: asc } }
+        ) {
             service {
                 svc_id
                 svc_uid

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/RuleController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/RuleController.cs
@@ -360,11 +360,8 @@ public class RuleController(ApiConnection apiConnection) : ControllerBase
             string objectKey = networkObject.Id > 0
                 ? networkObject.Id.ToString()
                 : $"{networkObject.Type?.Name}|{networkObject.Name}|{networkObject.IP}|{networkObject.IpEnd}";
-            string userKey = networkLocation.User?.Id > 0
-                ? networkLocation.User.Id.ToString()
-                : networkLocation.User?.Name ?? "";
 
-            if (seenLocations.Add($"{userKey}|{objectKey}"))
+            if (seenLocations.Add(objectKey))
             {
                 yield return networkLocation;
             }

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/RuleController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/RuleController.cs
@@ -340,14 +340,35 @@ public class RuleController(ApiConnection apiConnection) : ControllerBase
             result.AppendLine(userConfig.GetText("negated"));
         }
 
-        var networkLocations = isSource ? rule.Froms : rule.Tos;
+        IEnumerable<NetworkLocation> networkLocations = DeduplicateNetworkLocations(isSource ? rule.Froms : rule.Tos);
 
         string joined = string.Join(Environment.NewLine,
-            Array.ConvertAll(networkLocations, NetworkLocationToPlainText));
+            networkLocations.Select(NetworkLocationToPlainText));
 
         result.Append(joined);
 
         return result.ToString();
+    }
+
+    private static IEnumerable<NetworkLocation> DeduplicateNetworkLocations(IEnumerable<NetworkLocation> networkLocations)
+    {
+        HashSet<string> seenLocations = [];
+
+        foreach (NetworkLocation networkLocation in networkLocations)
+        {
+            NetworkObject networkObject = networkLocation.Object;
+            string objectKey = networkObject.Id > 0
+                ? networkObject.Id.ToString()
+                : $"{networkObject.Type?.Name}|{networkObject.Name}|{networkObject.IP}|{networkObject.IpEnd}";
+            string userKey = networkLocation.User?.Id > 0
+                ? networkLocation.User.Id.ToString()
+                : networkLocation.User?.Name ?? "";
+
+            if (seenLocations.Add($"{userKey}|{objectKey}"))
+            {
+                yield return networkLocation;
+            }
+        }
     }
 
     private static string NetworkLocationToPlainText(NetworkLocation networkLocation)

--- a/roles/tests-unit/files/FWO.Test/RuleControllerBranchingTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleControllerBranchingTest.cs
@@ -172,6 +172,16 @@ namespace FWO.Test
             StringAssert.Contains("removed: { _is_null: true }", RuleQueries.getRuleIdsByRuleOwner);
         }
 
+        [Test]
+        public void GetRulesByFilter_RuleDetailsQuery_ShouldFilterRemovedRuleRelations()
+        {
+            StringAssert.Contains("rule_froms(", RuleQueries.getRuleDetailsById);
+            StringAssert.Contains("rule_tos(", RuleQueries.getRuleDetailsById);
+            StringAssert.Contains("rule_services(", RuleQueries.getRuleDetailsById);
+            StringAssert.Contains("active: { _eq: true }", RuleQueries.getRuleDetailsById);
+            StringAssert.Contains("removed: { _is_null: true }", RuleQueries.getRuleDetailsById);
+        }
+
         private static RuleController CreateController(ApiConnection apiConnection, string requestId)
         {
             RuleController controller = new(apiConnection);

--- a/roles/tests-unit/files/FWO.Test/RuleControllerBranchingTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleControllerBranchingTest.cs
@@ -175,11 +175,17 @@ namespace FWO.Test
         [Test]
         public void GetRulesByFilter_RuleDetailsQuery_ShouldFilterRemovedRuleRelations()
         {
-            StringAssert.Contains("rule_froms(", RuleQueries.getRuleDetailsById);
-            StringAssert.Contains("rule_tos(", RuleQueries.getRuleDetailsById);
-            StringAssert.Contains("rule_services(", RuleQueries.getRuleDetailsById);
-            StringAssert.Contains("active: { _eq: true }", RuleQueries.getRuleDetailsById);
-            StringAssert.Contains("removed: { _is_null: true }", RuleQueries.getRuleDetailsById);
+            AssertRelationFiltersActiveAndRemoved(RuleQueries.getRuleDetailsById, "rule_froms");
+            AssertRelationFiltersActiveAndRemoved(RuleQueries.getRuleDetailsById, "rule_tos");
+            AssertRelationFiltersActiveAndRemoved(RuleQueries.getRuleDetailsById, "rule_services");
+        }
+
+        [Test]
+        public void ActiveRulesByOwnerQuery_ShouldFilterRemovedRuleRelations()
+        {
+            AssertRelationFiltersActiveAndRemoved(RuleQueries.getActiveRulesByOwner, "rule_froms");
+            AssertRelationFiltersActiveAndRemoved(RuleQueries.getActiveRulesByOwner, "rule_tos");
+            AssertRelationFiltersActiveAndRemoved(RuleQueries.getActiveRulesByOwner, "rule_services");
         }
 
         private static RuleController CreateController(ApiConnection apiConnection, string requestId)
@@ -199,6 +205,46 @@ namespace FWO.Test
                 ?? throw new AssertionException("Expected OK response.");
             return okResult.Value as RulesByFilterResponse
                 ?? throw new AssertionException("Expected rules-by-filter payload.");
+        }
+
+        private static void AssertRelationFiltersActiveAndRemoved(string query, string relationName)
+        {
+            string arguments = ExtractRelationArguments(query, relationName);
+
+            StringAssert.Contains("where:", arguments);
+            StringAssert.Contains("active: { _eq: true }", arguments);
+            StringAssert.Contains("removed: { _is_null: true }", arguments);
+        }
+
+        private static string ExtractRelationArguments(string query, string relationName)
+        {
+            string marker = relationName + "(";
+            int startIndex = query.IndexOf(marker, StringComparison.Ordinal);
+            if (startIndex < 0)
+            {
+                Assert.Fail($"Could not find '{marker}' in the query.");
+            }
+
+            int argumentStart = startIndex + marker.Length;
+            int depth = 1;
+            for (int index = argumentStart; index < query.Length; ++index)
+            {
+                if (query[index] == '(')
+                {
+                    ++depth;
+                }
+                else if (query[index] == ')')
+                {
+                    --depth;
+                    if (depth == 0)
+                    {
+                        return query.Substring(argumentStart, index - argumentStart);
+                    }
+                }
+            }
+
+            Assert.Fail($"Could not find closing ')' for '{marker}' in the query.");
+            return string.Empty;
         }
 
         private sealed class BranchingApiConnection : ApiConnection

--- a/roles/tests-unit/files/FWO.Test/RuleControllerWiringTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleControllerWiringTest.cs
@@ -117,6 +117,26 @@ namespace FWO.Test
         }
 
         [Test]
+        public void ConvertRuleList_ShouldDeduplicateTransientUsersWithSameRenderedNetworkLocation()
+        {
+            NetworkObject sourceGroup = CreateNetworkObjectGroup(100, "Source Group");
+
+            List<RuleDetail> rules = InvokeConvertRuleList(
+                [
+                    new Rule
+                    {
+                        Froms =
+                        [
+                            CreateNetworkLocation("source-user-a", sourceGroup),
+                            CreateNetworkLocation("source-user-b", sourceGroup)
+                        ]
+                    }
+                ]);
+
+            ClassicAssert.AreEqual("Source Group", rules[0].SourceShort);
+        }
+
+        [Test]
         public void ConvertRuleList_ShouldFlattenNestedServiceGroups()
         {
             List<RuleDetail> rules = InvokeConvertRuleList(

--- a/roles/tests-unit/files/FWO.Test/RuleControllerWiringTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleControllerWiringTest.cs
@@ -90,6 +90,33 @@ namespace FWO.Test
         }
 
         [Test]
+        public void ConvertRuleList_ShouldDeduplicateSourceAndDestinationShortNetworkLocations()
+        {
+            NetworkObject sourceGroup = CreateNetworkObjectGroup(100, "Source Group");
+            NetworkObject destinationGroup = CreateNetworkObjectGroup(200, "Destination Group");
+
+            List<RuleDetail> rules = InvokeConvertRuleList(
+                [
+                    new Rule
+                    {
+                        Froms =
+                        [
+                            CreateNetworkLocation("", sourceGroup),
+                            CreateNetworkLocation("", sourceGroup)
+                        ],
+                        Tos =
+                        [
+                            CreateNetworkLocation("", destinationGroup),
+                            CreateNetworkLocation("", destinationGroup)
+                        ]
+                    }
+                ]);
+
+            ClassicAssert.AreEqual("Source Group", rules[0].SourceShort);
+            ClassicAssert.AreEqual("Destination Group", rules[0].DestinationShort);
+        }
+
+        [Test]
         public void ConvertRuleList_ShouldFlattenNestedServiceGroups()
         {
             List<RuleDetail> rules = InvokeConvertRuleList(
@@ -207,6 +234,16 @@ namespace FWO.Test
                 Name = name,
                 Type = new NetworkObjectType { Name = ObjectType.Group },
                 ObjectGroupFlats = [new GroupFlat<NetworkObject> { Id = member.Id, Object = member }]
+            };
+        }
+
+        private static NetworkObject CreateNetworkObjectGroup(long id, string name)
+        {
+            return new NetworkObject
+            {
+                Id = id,
+                Name = name,
+                Type = new NetworkObjectType { Name = ObjectType.Group }
             };
         }
 

--- a/roles/tests-unit/files/FWO.Test/RuleQueriesTest.cs
+++ b/roles/tests-unit/files/FWO.Test/RuleQueriesTest.cs
@@ -13,7 +13,7 @@ namespace FWO.Test
         {
             string fromBlock = ExtractObjectBlock(
                 RuleQueries.getRuleDetailsById,
-                "rule_froms(order_by:{ object: {obj_id: asc}}){",
+                "rule_froms(",
                 "objgrp_flats(");
 
             StringAssert.Contains("obj_id", fromBlock);
@@ -25,7 +25,7 @@ namespace FWO.Test
         {
             string toBlock = ExtractObjectBlock(
                 RuleQueries.getRuleDetailsById,
-                "rule_tos(order_by: { object: { obj_name: asc } }) {",
+                "rule_tos(",
                 "objgrp_flats(");
 
             StringAssert.Contains("obj_id", toBlock);


### PR DESCRIPTION
Only a partial fix as replicating other observed cases has been very hard
This change would eliminate the currently observed case by the customer (and the most egregious one)

Still missing however:
1. On Version 9.2.2: Observed the same bug happening without stale references being present, group object was seemingly nontype
2. On Version 9.2.2: Observed the same bug happening without stale references being present, object was not able to be located in the database but somehow present in the response?
3. On Version 9.1.13; Same bug as 2. different object