### PR TITLE
Feat(Metrics): Add Prometheus and change ressource usage gathering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ cov.xml
 **/.claude/
 FWO.local.runsettings
 **/*.lscache
+.codex_validate/obj/*

--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,4 @@ cov.xml
 **/.claude/
 FWO.local.runsettings
 **/*.lscache
-.codex_validate/obj/*
+.codex_validate/*

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -3577,6 +3577,34 @@ INSERT INTO txt VALUES ('scheduler_action', 	          'German',   'Aktion');
 INSERT INTO txt VALUES ('scheduler_action', 	          'English',  'Action');
 INSERT INTO txt VALUES ('scheduler_no_jobs', 	          'German',   'Keine Scheduler-Jobs verf&uuml;gbar.');
 INSERT INTO txt VALUES ('scheduler_no_jobs', 	          'English',  'No scheduler jobs available.');
+INSERT INTO txt VALUES ('monitoring_service_status',      'German',   'Dienststatus');
+INSERT INTO txt VALUES ('monitoring_service_status',      'English',  'Service status');
+INSERT INTO txt VALUES ('monitoring_ui_service',          'German',   'UI-Systemdaten');
+INSERT INTO txt VALUES ('monitoring_ui_service',          'English',  'UI system usage');
+INSERT INTO txt VALUES ('monitoring_middleware_usage',    'German',   'Middleware-Systemdaten');
+INSERT INTO txt VALUES ('monitoring_middleware_usage',    'English',  'Middleware system usage');
+INSERT INTO txt VALUES ('monitoring_scheduler_api',       'German',   'Scheduler-API');
+INSERT INTO txt VALUES ('monitoring_scheduler_api',       'English',  'Scheduler API');
+INSERT INTO txt VALUES ('monitoring_checked_at',          'German',   'Zuletzt gepr&uuml;ft');
+INSERT INTO txt VALUES ('monitoring_checked_at',          'English',  'Last checked');
+INSERT INTO txt VALUES ('monitoring_reachable',           'German',   'Erreichbar');
+INSERT INTO txt VALUES ('monitoring_reachable',           'English',  'Reachable');
+INSERT INTO txt VALUES ('monitoring_unreachable',         'German',   'Nicht erreichbar');
+INSERT INTO txt VALUES ('monitoring_unreachable',         'English',  'Unreachable');
+INSERT INTO txt VALUES ('scheduler_health',               'German',   'Scheduler-Gesundheit');
+INSERT INTO txt VALUES ('scheduler_health',               'English',  'Scheduler health');
+INSERT INTO txt VALUES ('scheduler_ok_count',             'German',   'Erfolgreich');
+INSERT INTO txt VALUES ('scheduler_ok_count',             'English',  'Successful');
+INSERT INTO txt VALUES ('scheduler_failed_count',         'German',   'Fehlgeschlagen');
+INSERT INTO txt VALUES ('scheduler_failed_count',         'English',  'Failed');
+INSERT INTO txt VALUES ('scheduler_overdue_count',        'German',   '&Uuml;berf&auml;llig');
+INSERT INTO txt VALUES ('scheduler_overdue_count',        'English',  'Overdue');
+INSERT INTO txt VALUES ('scheduler_never_run_count',      'German',   'Nie gelaufen');
+INSERT INTO txt VALUES ('scheduler_never_run_count',      'English',  'Never run');
+INSERT INTO txt VALUES ('scheduler_recent_runs',          'German',   'Letzte L&auml;ufe');
+INSERT INTO txt VALUES ('scheduler_recent_runs',          'English',  'Recent runs');
+INSERT INTO txt VALUES ('scheduler_last_error',           'German',   'Letzter Fehler');
+INSERT INTO txt VALUES ('scheduler_last_error',           'English',  'Last error');
 INSERT INTO txt VALUES ('scheduler_starting', 	          'German',   'Startet bald…');
 INSERT INTO txt VALUES ('scheduler_starting', 	          'English',  'Starting soon…');
 INSERT INTO txt VALUES ('scheduler_start_now', 	          'German',   'Jetzt starten');
@@ -7645,6 +7673,10 @@ INSERT INTO txt VALUES ('H7111', 'German', 'Der Abschnitt "Middleware" ruft dies
     Dadurch bleiben CPU-, Speicher- und Laufzeitwerte auch dann sichtbar, wenn UI und Middleware auf unterschiedlichen Hosts laufen.');
 INSERT INTO txt VALUES ('H7111', 'English', 'The "Middleware" section fetches the same metrics directly from the middleware server through its REST API.
     This keeps CPU, memory, and uptime values visible even when the UI and middleware run on different hosts.');
+INSERT INTO txt VALUES ('H7112', 'German', 'Zus&auml;tzlich zeigt die Seite einen kompakten Dienststatus f&uuml;r UI, Middleware-Systemdaten und Scheduler-API.
+    Die Scheduler-&Uuml;bersicht fasst erfolgreiche, fehlgeschlagene, &uuml;berf&auml;llige und noch nie gelaufene Jobs zusammen und zeigt die letzten Ausf&uuml;hrungen direkt auf derselben Seite.');
+INSERT INTO txt VALUES ('H7112', 'English', 'The page also shows a compact service status for UI, middleware system usage, and the scheduler API.
+    The scheduler overview summarizes successful, failed, overdue, and never-run jobs and shows the most recent executions on the same page.');
 INSERT INTO txt VALUES ('H7030', 'German', 'Die Workflow-Ticket-&Uuml;berwachung zeigt Tickets mit ihren Antrags- und Umsetzungsaufgaben.
     Die Filter f&uuml;r Aufgabentyp und Status greifen auf allen Ebenen: Ein Ticket wird angezeigt, wenn es mindestens eine Aufgabe eines gew&auml;hlten Typs enth&auml;lt und wenn das Ticket selbst, eine Antragsaufgabe, eine Umsetzungsaufgabe oder eine Genehmigung einen der gew&auml;hlten Status besitzt.
 ');

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -7657,18 +7657,12 @@ INSERT INTO txt VALUES ('H7109', 'German', 'Der Abschnitt "UI-Prozess" zeigt die
     Heaps, Anzahl der Threads und die Laufzeit seit dem letzten Start.');
 INSERT INTO txt VALUES ('H7109', 'English', 'The "UI Process" section shows the values of the UI server itself: used working set, size of the managed heap,
     number of threads and the uptime since its last start.');
-INSERT INTO txt VALUES ('H7110', 'German', 'Der Abschnitt "Weitere Dienste auf diesem Server" zeigt dieselben Werte f&uuml;r Middleware, Importer, Hasura API, Datenbank und LDAP-Server,
-    sofern diese auf demselben Server wie die UI laufen. Dienste auf anderen Servern der Installation werden nicht aufgef&uuml;hrt.
-    Besteht ein Dienst aus mehreren Prozessen (z. B. die Datenbank), sind deren Werte aufsummiert und die Spalte "Prozesse" zeigt ihre Anzahl;
-    der Arbeitsspeicher kann dabei h&ouml;her wirken als tats&auml;chlich belegt, da sich die Prozesse Speicher teilen.
-    Die Speicherauslastung gibt den Anteil am gesamten Arbeitsspeicher des Servers an.
-    Die CPU-Auslastung bezieht sich wie beim UI-Prozess auf alle Kerne zusammen: 100 % bedeutet, dass alle Kerne ausgelastet sind.');
-INSERT INTO txt VALUES ('H7110', 'English', 'The "Other Services on this Host" section shows the same values for middleware, importer, Hasura API, database and LDAP server,
-    as far as they run on the same host as the UI. Services on other hosts of the installation are not listed.
-    If a service consists of several processes (the database for example), their values are summed up and the "Processes" column shows their number;
-    the memory can then look higher than it really is, because the processes share memory.
-    The memory usage states the share of the total memory of the host.
-    Like for the UI process the CPU usage relates to all cores combined: 100 % means that all cores are busy.');
+INSERT INTO txt VALUES ('H7110', 'German', 'Die UI liest keine anderen FWO-Dienste mehr lokal &uuml;ber eine hostweite Prozesssuche aus.
+    Dadurch wird die Abh&auml;ngigkeit von Linux-/proc-Daten reduziert.
+    Zus&auml;tzliche Komponenten werden stattdessen &uuml;ber ihre eigenen Bereiche wie "Middleware" und die Scheduler-&Uuml;bersicht angezeigt.');
+INSERT INTO txt VALUES ('H7110', 'English', 'The UI no longer reads other FWO services locally through a host-wide process scan.
+    This reduces the dependency on Linux /proc data.
+    Additional components are instead shown through their own sections such as "Middleware" and the scheduler overview.');
 INSERT INTO txt VALUES ('H7111', 'German', 'Der Abschnitt "Middleware" ruft dieselben Kennzahlen direkt vom Middleware-Server &uuml;ber dessen REST-Schnittstelle ab.
     Dadurch bleiben CPU-, Speicher- und Laufzeitwerte auch dann sichtbar, wenn UI und Middleware auf unterschiedlichen Hosts laufen.');
 INSERT INTO txt VALUES ('H7111', 'English', 'The "Middleware" section fetches the same metrics directly from the middleware server through its REST API.

--- a/roles/database/files/sql/idempotent/fworch-texts.sql
+++ b/roles/database/files/sql/idempotent/fworch-texts.sql
@@ -7641,6 +7641,10 @@ INSERT INTO txt VALUES ('H7110', 'English', 'The "Other Services on this Host" s
     the memory can then look higher than it really is, because the processes share memory.
     The memory usage states the share of the total memory of the host.
     Like for the UI process the CPU usage relates to all cores combined: 100 % means that all cores are busy.');
+INSERT INTO txt VALUES ('H7111', 'German', 'Der Abschnitt "Middleware" ruft dieselben Kennzahlen direkt vom Middleware-Server &uuml;ber dessen REST-Schnittstelle ab.
+    Dadurch bleiben CPU-, Speicher- und Laufzeitwerte auch dann sichtbar, wenn UI und Middleware auf unterschiedlichen Hosts laufen.');
+INSERT INTO txt VALUES ('H7111', 'English', 'The "Middleware" section fetches the same metrics directly from the middleware server through its REST API.
+    This keeps CPU, memory, and uptime values visible even when the UI and middleware run on different hosts.');
 INSERT INTO txt VALUES ('H7030', 'German', 'Die Workflow-Ticket-&Uuml;berwachung zeigt Tickets mit ihren Antrags- und Umsetzungsaufgaben.
     Die Filter f&uuml;r Aufgabentyp und Status greifen auf allen Ebenen: Ein Ticket wird angezeigt, wenn es mindestens eine Aufgabe eines gew&auml;hlten Typs enth&auml;lt und wenn das Ticket selbst, eine Antragsaufgabe, eine Umsetzungsaufgabe oder eine Genehmigung einen der gew&auml;hlten Status besitzt.
 ');

--- a/roles/lib/files/FWO.Middleware.Client/MiddlewareClient.cs
+++ b/roles/lib/files/FWO.Middleware.Client/MiddlewareClient.cs
@@ -305,6 +305,12 @@ namespace FWO.Middleware.Client
             return await restClient.ExecuteAsync<ComplianceCheckJobStatus>(request);
         }
 
+        public async Task<RestResponse<string>> GetSystemUsage()
+        {
+            RestRequest request = new("Monitoring/SystemUsage", Method.Get);
+            return await restClient.ExecuteAsync<string>(request);
+        }
+
         /// <summary>
         /// Get a new token pair
         /// </summary>

--- a/roles/lib/files/FWO.Middleware.Client/MiddlewareClient.cs
+++ b/roles/lib/files/FWO.Middleware.Client/MiddlewareClient.cs
@@ -305,10 +305,10 @@ namespace FWO.Middleware.Client
             return await restClient.ExecuteAsync<ComplianceCheckJobStatus>(request);
         }
 
-        public async Task<RestResponse<string>> GetSystemUsage()
+        public async Task<RestResponse> GetSystemUsage()
         {
             RestRequest request = new("Monitoring/SystemUsage", Method.Get);
-            return await restClient.ExecuteAsync<string>(request);
+            return await restClient.ExecuteAsync(request);
         }
 
         /// <summary>

--- a/roles/lib/files/FWO.Services/SystemUsage/ISystemUsageSnapshotProvider.cs
+++ b/roles/lib/files/FWO.Services/SystemUsage/ISystemUsageSnapshotProvider.cs
@@ -1,0 +1,15 @@
+namespace FWO.Services.SystemUsage
+{
+    /// <summary>
+    /// Provides the current system and process resource usage of the own FWO service for UI consumption.
+    /// </summary>
+    public interface ISystemUsageSnapshotProvider
+    {
+        /// <summary>
+        /// Returns the current usage values. Samples taken within the caching interval of a previous
+        /// call return the already known snapshot, so that concurrent callers share one measurement.
+        /// </summary>
+        /// <returns>The current usage snapshot.</returns>
+        SystemUsageSnapshot Collect();
+    }
+}

--- a/roles/lib/files/FWO.Services/SystemUsage/ResourceMonitoringSystemUsageProvider.cs
+++ b/roles/lib/files/FWO.Services/SystemUsage/ResourceMonitoringSystemUsageProvider.cs
@@ -1,0 +1,383 @@
+using System.Diagnostics.Metrics;
+using System.Globalization;
+
+namespace FWO.Services.SystemUsage
+{
+    /// <summary>
+    /// Builds <see cref="SystemUsageSnapshot"/>s from <c>Microsoft.Extensions.Diagnostics.ResourceMonitoring</c>
+    /// metrics and supplements them with Linux host data that the package does not expose directly.
+    /// </summary>
+    /// <param name="source">Source of the operating system counters.</param>
+    public sealed class ResourceMonitoringSystemUsageProvider : ISystemUsageSnapshotProvider, IDisposable
+    {
+        private static readonly TimeSpan kMinSampleInterval = TimeSpan.FromSeconds(4);
+
+        private static readonly char[] kWhitespaceSeparators = [' ', '\t'];
+        private static readonly char[] kLineSeparators = ['\n', '\r'];
+        private static readonly HashSet<string> kObservedInstruments =
+        [
+            "process.cpu.utilization",
+            "container.memory.usage",
+            "dotnet.process.memory.virtual.utilization",
+            "container.memory.limit.utilization"
+        ];
+
+        private const string kResourceMonitoringMeterName = "Microsoft.Extensions.Diagnostics.ResourceMonitoring";
+        private const string kMemInfoFile = "meminfo";
+        private const string kStatFile = "stat";
+        private const string kLoadAvgFile = "loadavg";
+        private const string kCpuLineKey = "cpu";
+        private const string kMemTotalKey = "MemTotal";
+        private const string kMemFreeKey = "MemFree";
+        private const string kMemAvailableKey = "MemAvailable";
+        private const string kSwapTotalKey = "SwapTotal";
+        private const string kSwapFreeKey = "SwapFree";
+        private const long kBytesPerKibibyte = 1024;
+        private const int kLoadAverageFieldCount = 3;
+        private const int kMinCpuFieldCount = 5;
+        private const double kFullPercent = 100.0;
+
+        private readonly ISystemUsageSource source;
+        private readonly object sampleLock = new();
+        private readonly ServiceUsageScanner serviceScanner;
+        private readonly MeterListener meterListener = new();
+
+        private SystemUsageSnapshot? lastSnapshot;
+        private long lastCpuBusyTicks;
+        private long lastCpuTotalTicks;
+        private TimeSpan lastProcessCpuTime = TimeSpan.Zero;
+        private DateTime lastProcessSampleTime = DateTime.MinValue;
+        private double? latestProcessCpuUtilization;
+        private double? latestContainerMemoryUsageBytes;
+        private double? latestProcessMemoryUtilization;
+        private double? latestContainerMemoryLimitUtilization;
+        private bool disposed;
+
+        /// <summary>
+        /// Starts listening to the resource monitoring metrics published by .NET.
+        /// </summary>
+        public ResourceMonitoringSystemUsageProvider(ISystemUsageSource source)
+        {
+            this.source = source;
+            serviceScanner = new(source);
+            meterListener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == kResourceMonitoringMeterName
+                    && kObservedInstruments.Contains(instrument.Name))
+                {
+                    listener.EnableMeasurementEvents(instrument, null);
+                }
+            };
+            meterListener.SetMeasurementEventCallback<double>(OnDoubleMeasurement);
+            meterListener.SetMeasurementEventCallback<float>((instrument, value, _, __) =>
+                OnDoubleMeasurement(instrument, value, default, default));
+            meterListener.SetMeasurementEventCallback<long>((instrument, value, _, __) =>
+                OnDoubleMeasurement(instrument, value, default, default));
+            meterListener.SetMeasurementEventCallback<int>((instrument, value, _, __) =>
+                OnDoubleMeasurement(instrument, value, default, default));
+            meterListener.Start();
+        }
+
+        /// <inheritdoc />
+        public SystemUsageSnapshot Collect()
+        {
+            lock (sampleLock)
+            {
+                meterListener.RecordObservableInstruments();
+
+                DateTime now = source.UtcNow;
+                TimeSpan elapsedSinceLastSample = lastSnapshot == null
+                    ? TimeSpan.MaxValue
+                    : now - lastSnapshot.CollectedAt;
+                if (lastSnapshot != null
+                    && elapsedSinceLastSample >= TimeSpan.Zero
+                    && elapsedSinceLastSample < kMinSampleInterval)
+                {
+                    return lastSnapshot;
+                }
+
+                lastSnapshot = Sample(now);
+                return lastSnapshot;
+            }
+        }
+
+        /// <summary>
+        /// Releases the metric listener when the dependency injection container shuts down.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                disposed = true;
+                meterListener.Dispose();
+            }
+        }
+
+        private void OnDoubleMeasurement(Instrument instrument, double value, ReadOnlySpan<KeyValuePair<string, object?>> _, object? __)
+        {
+            if (instrument.Meter.Name != kResourceMonitoringMeterName)
+            {
+                return;
+            }
+
+            switch (instrument.Name)
+            {
+                case "process.cpu.utilization":
+                    latestProcessCpuUtilization = value;
+                    break;
+                case "container.memory.usage":
+                    latestContainerMemoryUsageBytes = value;
+                    break;
+                case "dotnet.process.memory.virtual.utilization":
+                    latestProcessMemoryUtilization = value;
+                    break;
+                case "container.memory.limit.utilization":
+                    latestContainerMemoryLimitUtilization = value;
+                    break;
+            }
+        }
+
+        private SystemUsageSnapshot Sample(DateTime now)
+        {
+            source.RefreshProcessInfo();
+            SystemUsageSnapshot snapshot = new()
+            {
+                CollectedAt = now,
+                ProcessorCount = Math.Max(1, source.ProcessorCount),
+                ProcessWorkingSetBytes = source.ProcessWorkingSetBytes,
+                ProcessPrivateMemoryBytes = source.ProcessPrivateMemoryBytes,
+                ProcessManagedHeapBytes = source.ProcessManagedHeapBytes,
+                ProcessThreadCount = source.ProcessThreadCount,
+                ProcessStartTime = source.ProcessStartTimeUtc
+            };
+
+            ApplyProcessMetrics(snapshot, now);
+            bool memoryRead = ApplyMemory(snapshot);
+            ApplyResourceMonitoringMemory(snapshot);
+            bool cpuRead = ApplyCpu(snapshot);
+            ApplyLoadAverage(snapshot);
+            snapshot.Services = serviceScanner.Scan(now, snapshot.ProcessorCount, snapshot.MemoryTotalBytes);
+            snapshot.ServicesVisible = serviceScanner.ForeignProcessesVisible();
+            snapshot.SourceAvailable = memoryRead && cpuRead;
+            return snapshot;
+        }
+
+        private void ApplyProcessMetrics(SystemUsageSnapshot snapshot, DateTime now)
+        {
+            snapshot.ProcessCpuPercent = latestProcessCpuUtilization.HasValue
+                ? Math.Clamp(latestProcessCpuUtilization.Value * kFullPercent, 0, kFullPercent)
+                : SampleProcessCpuPercent(now, snapshot.ProcessorCount, snapshot.ProcessStartTime);
+
+            if (latestContainerMemoryUsageBytes.HasValue)
+            {
+                long processMemoryBytes = Math.Max(0, (long)latestContainerMemoryUsageBytes.Value);
+                if (snapshot.ProcessWorkingSetBytes <= 0)
+                {
+                    snapshot.ProcessWorkingSetBytes = processMemoryBytes;
+                }
+
+                if (snapshot.ProcessPrivateMemoryBytes <= 0)
+                {
+                    snapshot.ProcessPrivateMemoryBytes = processMemoryBytes;
+                }
+            }
+        }
+
+        private bool ApplyMemory(SystemUsageSnapshot snapshot)
+        {
+            Dictionary<string, long> memInfo = ParseMemInfo(source.ReadProcFile(kMemInfoFile));
+            if (!memInfo.TryGetValue(kMemTotalKey, out long memTotal) || memTotal <= 0)
+            {
+                return false;
+            }
+
+            memInfo.TryGetValue(kMemFreeKey, out long memFree);
+            snapshot.MemoryTotalBytes = memTotal;
+            snapshot.MemoryFreeBytes = memFree;
+            snapshot.MemoryAvailableBytes = memInfo.TryGetValue(kMemAvailableKey, out long memAvailable) ? memAvailable : memFree;
+
+            memInfo.TryGetValue(kSwapTotalKey, out long swapTotal);
+            memInfo.TryGetValue(kSwapFreeKey, out long swapFree);
+            snapshot.SwapTotalBytes = swapTotal;
+            snapshot.SwapFreeBytes = swapFree;
+            return true;
+        }
+
+        private void ApplyResourceMonitoringMemory(SystemUsageSnapshot snapshot)
+        {
+            if (latestContainerMemoryUsageBytes.HasValue)
+            {
+                long usedBytes = Math.Max(0, (long)latestContainerMemoryUsageBytes.Value);
+                long totalBytes = snapshot.MemoryTotalBytes;
+
+                if (totalBytes <= 0 && latestContainerMemoryLimitUtilization is > 0)
+                {
+                    totalBytes = (long)Math.Round(usedBytes / latestContainerMemoryLimitUtilization.Value);
+                }
+
+                if (totalBytes > 0)
+                {
+                    snapshot.MemoryTotalBytes = totalBytes;
+                    snapshot.MemoryAvailableBytes = Math.Max(0, totalBytes - usedBytes);
+                    snapshot.MemoryFreeBytes = Math.Min(snapshot.MemoryFreeBytes, snapshot.MemoryAvailableBytes);
+                }
+            }
+            else if (latestProcessMemoryUtilization.HasValue && snapshot.MemoryTotalBytes > 0)
+            {
+                double utilization = Math.Clamp(latestProcessMemoryUtilization.Value, 0, 1);
+                long usedBytes = (long)Math.Round(snapshot.MemoryTotalBytes * utilization);
+                snapshot.MemoryAvailableBytes = Math.Max(0, snapshot.MemoryTotalBytes - usedBytes);
+                snapshot.MemoryFreeBytes = Math.Min(snapshot.MemoryFreeBytes, snapshot.MemoryAvailableBytes);
+            }
+        }
+
+        private bool ApplyCpu(SystemUsageSnapshot snapshot)
+        {
+            if (!TryParseCpuTicks(source.ReadProcFile(kStatFile), out long busyTicks, out long totalTicks))
+            {
+                return false;
+            }
+
+            if (lastCpuTotalTicks == 0 && totalTicks > 0)
+            {
+                // On the first sample there is no previous delta yet. Use the aggregate share seen so far
+                // so the UI shows a meaningful system value immediately instead of a guaranteed zero.
+                snapshot.CpuUsedPercent = Math.Clamp(kFullPercent * busyTicks / totalTicks, 0, kFullPercent);
+            }
+
+            long busyDelta = busyTicks - lastCpuBusyTicks;
+            long totalDelta = totalTicks - lastCpuTotalTicks;
+            if (totalDelta > 0 && busyDelta >= 0)
+            {
+                snapshot.CpuUsedPercent = Math.Clamp(kFullPercent * busyDelta / totalDelta, 0, kFullPercent);
+            }
+
+            lastCpuBusyTicks = busyTicks;
+            lastCpuTotalTicks = totalTicks;
+            return true;
+        }
+
+        private void ApplyLoadAverage(SystemUsageSnapshot snapshot)
+        {
+            string? content = source.ReadProcFile(kLoadAvgFile);
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return;
+            }
+
+            List<string> fields = [.. content.Split(kWhitespaceSeparators, StringSplitOptions.RemoveEmptyEntries)];
+            if (fields.Count < kLoadAverageFieldCount)
+            {
+                return;
+            }
+
+            snapshot.LoadAverage1 = ParseDouble(fields[0]);
+            snapshot.LoadAverage5 = ParseDouble(fields[1]);
+            snapshot.LoadAverage15 = ParseDouble(fields[2]);
+        }
+
+        private double SampleProcessCpuPercent(DateTime now, int processorCount, DateTime processStartTime)
+        {
+            TimeSpan processCpuTime = source.ProcessCpuTime;
+            DateTime referenceTime = lastProcessSampleTime == DateTime.MinValue ? processStartTime : lastProcessSampleTime;
+            TimeSpan referenceCpuTime = lastProcessSampleTime == DateTime.MinValue ? TimeSpan.Zero : lastProcessCpuTime;
+
+            double elapsedSeconds = (now - referenceTime).TotalSeconds;
+            double cpuSeconds = (processCpuTime - referenceCpuTime).TotalSeconds;
+
+            lastProcessCpuTime = processCpuTime;
+            lastProcessSampleTime = now;
+
+            if (elapsedSeconds <= 0 || cpuSeconds < 0)
+            {
+                return 0;
+            }
+
+            return Math.Clamp(kFullPercent * cpuSeconds / (elapsedSeconds * processorCount), 0, kFullPercent);
+        }
+
+        private static Dictionary<string, long> ParseMemInfo(string? content)
+        {
+            Dictionary<string, long> values = [];
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return values;
+            }
+
+            foreach (string line in content.Split(kLineSeparators, StringSplitOptions.RemoveEmptyEntries))
+            {
+                int colonIndex = line.IndexOf(':');
+                if (colonIndex <= 0)
+                {
+                    continue;
+                }
+
+                string key = line[..colonIndex].Trim();
+                List<string> valueFields = [.. line[(colonIndex + 1)..].Split(kWhitespaceSeparators, StringSplitOptions.RemoveEmptyEntries)];
+                if (valueFields.Count == 0 || !long.TryParse(valueFields[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out long rawValue))
+                {
+                    continue;
+                }
+
+                values[key] = valueFields.Count > 1 ? rawValue * kBytesPerKibibyte : rawValue;
+            }
+            return values;
+        }
+
+        private static bool TryParseCpuTicks(string? content, out long busyTicks, out long totalTicks)
+        {
+            busyTicks = 0;
+            totalTicks = 0;
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return false;
+            }
+
+            foreach (string line in content.Split(kLineSeparators, StringSplitOptions.RemoveEmptyEntries))
+            {
+                List<string> fields = [.. line.Split(kWhitespaceSeparators, StringSplitOptions.RemoveEmptyEntries)];
+                if (fields.Count < kMinCpuFieldCount || fields[0] != kCpuLineKey)
+                {
+                    continue;
+                }
+                return TryAccumulateCpuTicks(fields, out busyTicks, out totalTicks);
+            }
+            return false;
+        }
+
+        private static bool TryAccumulateCpuTicks(List<string> fields, out long busyTicks, out long totalTicks)
+        {
+            const int kIdleFieldIndex = 4;
+            const int kIoWaitFieldIndex = 5;
+            const int kGuestFieldIndex = 9;
+            const int kGuestNiceFieldIndex = 10;
+
+            busyTicks = 0;
+            totalTicks = 0;
+            for (int index = 1; index < fields.Count; index++)
+            {
+                if (!long.TryParse(fields[index], NumberStyles.Integer, CultureInfo.InvariantCulture, out long ticks))
+                {
+                    return false;
+                }
+
+                if (index == kGuestFieldIndex || index == kGuestNiceFieldIndex)
+                {
+                    continue;
+                }
+
+                totalTicks += ticks;
+                if (index != kIdleFieldIndex && index != kIoWaitFieldIndex)
+                {
+                    busyTicks += ticks;
+                }
+            }
+            return totalTicks > 0;
+        }
+
+        private static double ParseDouble(string value)
+        {
+            return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed) ? parsed : 0;
+        }
+    }
+}

--- a/roles/lib/files/FWO.Services/SystemUsage/ResourceMonitoringSystemUsageProvider.cs
+++ b/roles/lib/files/FWO.Services/SystemUsage/ResourceMonitoringSystemUsageProvider.cs
@@ -5,7 +5,7 @@ namespace FWO.Services.SystemUsage
 {
     /// <summary>
     /// Builds <see cref="SystemUsageSnapshot"/>s from <c>Microsoft.Extensions.Diagnostics.ResourceMonitoring</c>
-    /// metrics and supplements them with Linux host data that the package does not expose directly.
+    /// metrics and supplements them only with Linux host data that the package does not expose directly.
     /// </summary>
     /// <param name="source">Source of the operating system counters.</param>
     public sealed class ResourceMonitoringSystemUsageProvider : ISystemUsageSnapshotProvider, IDisposable
@@ -39,7 +39,6 @@ namespace FWO.Services.SystemUsage
 
         private readonly ISystemUsageSource source;
         private readonly object sampleLock = new();
-        private readonly ServiceUsageScanner serviceScanner;
         private readonly MeterListener meterListener = new();
 
         private SystemUsageSnapshot? lastSnapshot;
@@ -59,7 +58,6 @@ namespace FWO.Services.SystemUsage
         public ResourceMonitoringSystemUsageProvider(ISystemUsageSource source)
         {
             this.source = source;
-            serviceScanner = new(source);
             meterListener.InstrumentPublished = (instrument, listener) =>
             {
                 if (instrument.Meter.Name == kResourceMonitoringMeterName
@@ -156,8 +154,8 @@ namespace FWO.Services.SystemUsage
             ApplyResourceMonitoringMemory(snapshot);
             bool cpuRead = ApplyCpu(snapshot);
             ApplyLoadAverage(snapshot);
-            snapshot.Services = serviceScanner.Scan(now, snapshot.ProcessorCount, snapshot.MemoryTotalBytes);
-            snapshot.ServicesVisible = serviceScanner.ForeignProcessesVisible();
+            snapshot.Services = [];
+            snapshot.ServicesVisible = true;
             snapshot.SourceAvailable = memoryRead && cpuRead;
             return snapshot;
         }

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/MonitoringController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/MonitoringController.cs
@@ -1,0 +1,27 @@
+using FWO.Basics;
+using FWO.Services.SystemUsage;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FWO.Middleware.Server.Controllers
+{
+    /// <summary>
+    /// Exposes resource-usage snapshots of the middleware server for the UI monitoring page.
+    /// </summary>
+    [Authorize]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class MonitoringController(ISystemUsageSnapshotProvider systemUsageProvider) : ControllerBase
+    {
+        /// <summary>
+        /// Returns the current system and middleware-process resource usage snapshot.
+        /// </summary>
+        /// <returns>The current resource usage snapshot.</returns>
+        [HttpGet("SystemUsage")]
+        [Authorize(Roles = $"{Roles.Admin}, {Roles.FwAdmin}, {Roles.Auditor}")]
+        public ActionResult<SystemUsageSnapshot> GetSystemUsage()
+        {
+            return Ok(systemUsageProvider.Collect());
+        }
+    }
+}

--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="10.8.0" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
     <PackageReference Include="PuppeteerSharp" Version="25.3.4" />
     <PackageReference Include="Quartz" Version="3.18.2" />

--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="10.8.0" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
     <PackageReference Include="PuppeteerSharp" Version="25.3.4" />

--- a/roles/middleware/files/FWO.Middleware.Server/Program.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Program.cs
@@ -14,7 +14,9 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
+using Prometheus;
 using Quartz;
+using Quartz.Impl.Matchers;
 using Scalar.AspNetCore;
 
 object changesLock = new(); // LOCK
@@ -200,16 +202,19 @@ app.UseSwaggerRedirect(kApiDocsPageRoute);
 //app.UseHttpsRedirection();
 
 app.UseRouting();
+app.UseHttpMetrics(options => options.ReduceStatusCodeCardinality());
 
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.MapMetrics();
 app.MapControllers();
 
 //Register JobExecutionTracker with scheduler
 ISchedulerFactory schedulerFactory = app.Services.GetRequiredService<ISchedulerFactory>();
 JobExecutionTracker executionTracker = app.Services.GetRequiredService<JobExecutionTracker>();
 IScheduler scheduler = await schedulerFactory.GetScheduler();
+MiddlewarePrometheusMetrics.UpdateKnownJobCount((await scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup())).Count);
 scheduler.ListenerManager.AddJobListener(executionTracker);
 
 // Activate config listeners so they attach subscriptions after startup

--- a/roles/middleware/files/FWO.Middleware.Server/Program.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Program.cs
@@ -8,8 +8,10 @@ using FWO.Middleware.Server;
 using FWO.Middleware.Server.OpenApi;
 using FWO.Middleware.Server.Services;
 using FWO.Services;
+using FWO.Services.SystemUsage;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 using Quartz;
@@ -71,6 +73,9 @@ builder.Services.AddSingleton<ComplianceCheckStatusTracker>();
 builder.Services.AddSingleton(tokenLifetimeProvider);
 builder.Services.AddSingleton(internalApiTokenService);
 builder.Services.AddHostedService<InternalApiTokenRefreshService>();
+builder.Services.AddResourceMonitoring();
+builder.Services.AddSingleton<ISystemUsageSource, ProcSystemUsageSource>();
+builder.Services.AddSingleton<ISystemUsageSnapshotProvider, ResourceMonitoringSystemUsageProvider>();
 
 // Register config listeners as singletons (activated at startup)
 builder.Services.AddSingleton<ExternalRequestSchedulerService>();

--- a/roles/middleware/files/FWO.Middleware.Server/Services/JobExecutionTracker.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/JobExecutionTracker.cs
@@ -50,13 +50,15 @@ namespace FWO.Middleware.Server.Services
             string jobKey = context.JobDetail.Key.Name;
             bool success = jobException == null;
             string? errorMessage = jobException?.Message;
+            DateTimeOffset executedAt = DateTimeOffset.Now;
 
             executionResults[jobKey] = new JobExecutionResult
             {
                 Success = success,
                 ErrorMessage = errorMessage ?? "",
-                ExecutedAt = DateTimeOffset.Now
+                ExecutedAt = executedAt
             };
+            MiddlewarePrometheusMetrics.RecordExecution(jobKey, success, executedAt);
 
             if (!success)
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Services/MiddlewarePrometheusMetrics.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/MiddlewarePrometheusMetrics.cs
@@ -1,0 +1,48 @@
+using Prometheus;
+
+namespace FWO.Middleware.Server.Services
+{
+    /// <summary>
+    /// Central Prometheus metrics for the middleware server.
+    /// </summary>
+    public static class MiddlewarePrometheusMetrics
+    {
+        private static readonly Gauge kKnownJobCountGauge = Metrics.CreateGauge("fwo_middleware_scheduler_job_count",
+            "Number of known Quartz jobs in the middleware server.");
+        private static readonly Gauge kLastSuccessGauge = Metrics.CreateGauge("fwo_middleware_scheduler_job_last_success",
+            "Whether the last execution of a scheduler job succeeded (1) or not (0).",
+            new GaugeConfiguration { LabelNames = ["job"] });
+        private static readonly Gauge kLastFailureGauge = Metrics.CreateGauge("fwo_middleware_scheduler_job_last_failure",
+            "Whether the last execution of a scheduler job failed (1) or not (0).",
+            new GaugeConfiguration { LabelNames = ["job"] });
+        private static readonly Gauge kLastExecutionUnixTimeGauge = Metrics.CreateGauge("fwo_middleware_scheduler_job_last_execution_unixtime",
+            "Unix timestamp of the last execution of a scheduler job.",
+            new GaugeConfiguration { LabelNames = ["job"] });
+        private static readonly Counter kExecutionsCounter = Metrics.CreateCounter("fwo_middleware_scheduler_job_executions_total",
+            "Total number of scheduler job executions observed by the middleware server.",
+            new CounterConfiguration { LabelNames = ["job", "result"] });
+
+        /// <summary>
+        /// Updates the known number of scheduler jobs.
+        /// </summary>
+        /// <param name="jobCount">The number of known jobs.</param>
+        public static void UpdateKnownJobCount(int jobCount)
+        {
+            kKnownJobCountGauge.Set(Math.Max(0, jobCount));
+        }
+
+        /// <summary>
+        /// Records one scheduler job execution.
+        /// </summary>
+        /// <param name="jobName">The executed job name.</param>
+        /// <param name="success">True if the execution succeeded.</param>
+        /// <param name="executedAt">The execution timestamp.</param>
+        public static void RecordExecution(string jobName, bool success, DateTimeOffset executedAt)
+        {
+            kExecutionsCounter.WithLabels(jobName, success ? "success" : "failure").Inc();
+            kLastSuccessGauge.WithLabels(jobName).Set(success ? 1 : 0);
+            kLastFailureGauge.WithLabels(jobName).Set(success ? 0 : 1);
+            kLastExecutionUnixTimeGauge.WithLabels(jobName).Set(executedAt.ToUnixTimeSeconds());
+        }
+    }
+}

--- a/roles/ui/files/FWO.UI/FWO.Ui.csproj
+++ b/roles/ui/files/FWO.UI/FWO.Ui.csproj
@@ -18,6 +18,7 @@
 		<PackageReference Include="IPAddressRange" Version="6.3.0" />
 		<PackageReference Include="BlazorTable" Version="1.17.0" />
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="10.8.0" />
+		<PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
 		<PackageReference Include="PuppeteerSharp" Version="25.3.4" />
 	</ItemGroup>
 

--- a/roles/ui/files/FWO.UI/FWO.Ui.csproj
+++ b/roles/ui/files/FWO.UI/FWO.Ui.csproj
@@ -17,6 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="IPAddressRange" Version="6.3.0" />
 		<PackageReference Include="BlazorTable" Version="1.17.0" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="10.8.0" />
 		<PackageReference Include="PuppeteerSharp" Version="25.3.4" />
 	</ItemGroup>
 

--- a/roles/ui/files/FWO.UI/Pages/Help/HelpMonitoringSystemUsage.cshtml
+++ b/roles/ui/files/FWO.UI/Pages/Help/HelpMonitoringSystemUsage.cshtml
@@ -21,5 +21,6 @@
         <li>@(Html.Raw(userConfig.GetText("H7109")))</li>
         <li>@(Html.Raw(userConfig.GetText("H7110")))</li>
         <li>@(Html.Raw(userConfig.GetText("H7111")))</li>
+        <li>@(Html.Raw(userConfig.GetText("H7112")))</li>
     </ul>
 </div>

--- a/roles/ui/files/FWO.UI/Pages/Help/HelpMonitoringSystemUsage.cshtml
+++ b/roles/ui/files/FWO.UI/Pages/Help/HelpMonitoringSystemUsage.cshtml
@@ -20,5 +20,6 @@
         <li>@(Html.Raw(userConfig.GetText("H7108")))</li>
         <li>@(Html.Raw(userConfig.GetText("H7109")))</li>
         <li>@(Html.Raw(userConfig.GetText("H7110")))</li>
+        <li>@(Html.Raw(userConfig.GetText("H7111")))</li>
     </ul>
 </div>

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
@@ -506,15 +506,16 @@ MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
     {
         try
         {
-            RestSharp.RestResponse<string> response = await middlewareClient.GetSystemUsage();
-            if (!response.IsSuccessful)
+            RestSharp.RestResponse response = await middlewareClient.GetSystemUsage();
+            bool httpSuccess = (int)response.StatusCode >= 200 && (int)response.StatusCode < 300;
+            if (!httpSuccess)
             {
-                throw new InvalidOperationException($"Middleware system usage request failed with status {(int)response.StatusCode}.");
+                throw new InvalidOperationException($"Middleware system usage request failed with status {(int)response.StatusCode}: {response.ErrorMessage ?? response.Content ?? response.StatusDescription}.");
             }
 
             SystemUsageSnapshot? snapshot = !string.IsNullOrWhiteSpace(response.Content)
                 ? System.Text.Json.JsonSerializer.Deserialize<SystemUsageSnapshot>(response.Content)
-                    : new();
+                : new();
 
             if (snapshot is null)
             {

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
@@ -277,6 +277,148 @@
             <div class="col-12 mb-3">
                 <div class="card">
                     <div class="card-body">
+                        <h6>@(userConfig.GetText("monitoring_service_status"))</h6>
+                        <div class="table-responsive">
+                            <table class="table table-sm align-middle mb-0">
+                                <tbody>
+                                    <tr>
+                                        <td class="fw-bold">@(userConfig.GetText("monitoring_ui_service"))</td>
+                                        <td class="text-center">
+                                            <span class="@(LocalUsageHealthy ? $"text-success {Icons.Check}" : $"text-danger {Icons.Close}")"></span>
+                                        </td>
+                                        <td>@GetReachabilityText(LocalUsageHealthy)</td>
+                                        <td class="text-muted">@(userConfig.GetText("monitoring_checked_at")): @LastUpdatedDisplay</td>
+                                    </tr>
+                                    <tr>
+                                        <td class="fw-bold">@(userConfig.GetText("monitoring_middleware_usage"))</td>
+                                        <td class="text-center">
+                                            <span class="@(MiddlewareSystemHealthy ? $"text-success {Icons.Check}" : $"text-danger {Icons.Close}")"></span>
+                                        </td>
+                                        <td>@GetReachabilityText(MiddlewareSystemHealthy)</td>
+                                        <td class="text-muted">
+                                            @(userConfig.GetText("monitoring_checked_at")): @MiddlewareUsageCheckedAtDisplay
+                                            @if (!MiddlewareSystemHealthy && !string.IsNullOrWhiteSpace(MiddlewareUsageError))
+                                            {
+                                                <span> | @MiddlewareUsageError</span>
+                                            }
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td class="fw-bold">@(userConfig.GetText("monitoring_scheduler_api"))</td>
+                                        <td class="text-center">
+                                            <span class="@(SchedulerReachable ? $"text-success {Icons.Check}" : $"text-danger {Icons.Close}")"></span>
+                                        </td>
+                                        <td>@GetReachabilityText(SchedulerReachable)</td>
+                                        <td class="text-muted">
+                                            @(userConfig.GetText("monitoring_checked_at")): @SchedulerCheckedAtDisplay
+                                            @if (!SchedulerReachable && !string.IsNullOrWhiteSpace(SchedulerError))
+                                            {
+                                                <span> | @SchedulerError</span>
+                                            }
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12 mb-3">
+                <div class="card">
+                    <div class="card-body">
+                        <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+                            <h6 class="mb-0">@(userConfig.GetText("scheduler_health"))</h6>
+                            <span class="text-muted">@(userConfig.GetText("monitoring_checked_at")): @SchedulerCheckedAtDisplay</span>
+                        </div>
+                        <div class="row">
+                            <div class="col-sm-6 col-lg-3 mb-3">
+                                <div class="card h-100">
+                                    <div class="card-body">
+                                        <div class="usage-tile-value text-success">@SchedulerSuccessfulCount</div>
+                                        <div>@(userConfig.GetText("scheduler_ok_count"))</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6 col-lg-3 mb-3">
+                                <div class="card h-100">
+                                    <div class="card-body">
+                                        <div class="usage-tile-value text-danger">@SchedulerFailedCount</div>
+                                        <div>@(userConfig.GetText("scheduler_failed_count"))</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6 col-lg-3 mb-3">
+                                <div class="card h-100">
+                                    <div class="card-body">
+                                        <div class="usage-tile-value text-warning">@SchedulerOverdueCount</div>
+                                        <div>@(userConfig.GetText("scheduler_overdue_count"))</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6 col-lg-3 mb-3">
+                                <div class="card h-100">
+                                    <div class="card-body">
+                                        <div class="usage-tile-value text-muted">@SchedulerNeverRunCount</div>
+                                        <div>@(userConfig.GetText("scheduler_never_run_count"))</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        @if (!string.IsNullOrWhiteSpace(LastSchedulerError))
+                        {
+                            <div class="alert alert-warning mb-0">
+                                <span class="@Icons.Warning pe-2"></span>
+                                <strong>@(userConfig.GetText("scheduler_last_error")):</strong>
+                                @System.Net.WebUtility.HtmlEncode(LastSchedulerError)
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12 mb-3">
+                <div class="card">
+                    <div class="card-body">
+                        <h6>@(userConfig.GetText("scheduler_recent_runs"))</h6>
+                        @if (RecentSchedulerJobs.Count == 0)
+                        {
+                            <div class="text-muted">@(userConfig.GetText("scheduler_no_jobs"))</div>
+                        }
+                        else
+                        {
+                            <div class="table-responsive">
+                                <table class="table table-sm align-middle mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">@(userConfig.GetText("scheduler_job"))</th>
+                                            <th scope="col">@(userConfig.GetText("scheduler_last_run"))</th>
+                                            <th scope="col">@(userConfig.GetText("scheduler_next_run"))</th>
+                                            <th scope="col" class="text-center">@(userConfig.GetText("scheduler_status"))</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (SchedulerJobInfo job in RecentSchedulerJobs)
+                                        {
+                                            <tr>
+                                                <td>@job.JobName</td>
+                                                <td>@FormatSchedulerRunTime(job.LastFireTimeUtc, false)</td>
+                                                <td>@FormatSchedulerRunTime(job.NextFireTimeUtc, true)</td>
+                                                <td class="text-center">@FormatSchedulerExecutionStatus(job)</td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12 mb-3">
+                <div class="card">
+                    <div class="card-body">
                         <h6>@(userConfig.GetText("scheduler_jobs_title"))</h6>
                         @if (SchedulerJobs.Count == 0)
                         {
@@ -381,6 +523,7 @@
 
     private const int kRefreshIntervalSeconds = 5;
     private const int kMaxHistoryPoints = 60;
+    private static readonly TimeSpan kSchedulerOverdueGracePeriod = TimeSpan.FromMinutes(1);
 
     private SystemUsageSnapshot Usage { get; set; } = new();
     private SystemUsageSnapshot MiddlewareUsage { get; set; } = new();
@@ -399,6 +542,11 @@
     private bool interactiveRenderCompleted;
     private bool monitoringActive;
     private bool MiddlewareUsageReachable { get; set; } = true;
+    private bool SchedulerReachable { get; set; } = true;
+    private DateTime? MiddlewareUsageCheckedAtUtc { get; set; }
+    private DateTime? SchedulerCheckedAtUtc { get; set; }
+    private string MiddlewareUsageError { get; set; } = "";
+    private string SchedulerError { get; set; } = "";
     private bool disposed;
 
     private string LastUpdatedDisplay => Usage.CollectedAt == DateTime.MinValue
@@ -406,6 +554,10 @@
 
     private string MiddlewareLastUpdatedDisplay => MiddlewareUsage.CollectedAt == DateTime.MinValue
         ? "-" : MiddlewareUsage.CollectedAt.ToLocalTime().ToString("G");
+
+    private string MiddlewareUsageCheckedAtDisplay => FormatCheckedAt(MiddlewareUsageCheckedAtUtc);
+
+    private string SchedulerCheckedAtDisplay => FormatCheckedAt(SchedulerCheckedAtUtc);
 
     private string LoadAverageDisplay => SystemUsageDisplay.FormatLoadAverage(Usage);
 
@@ -422,6 +574,29 @@ MiddlewareHistoryTimes[0].ToLocalTime().ToString("T") : "";
 MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
 
     private bool CanViewUsage => userConfig.CanUseAnyRole(Roles.Admin, Roles.FwAdmin, Roles.Auditor);
+
+    private bool LocalUsageHealthy => Usage.CollectedAt != DateTime.MinValue && Usage.SourceAvailable;
+
+    private bool MiddlewareSystemHealthy => MiddlewareUsageReachable && MiddlewareUsage.SourceAvailable;
+
+    private int SchedulerSuccessfulCount => SchedulerJobs.Count(job => job.LastExecutionStatus == SchedulerJobExecutionStatus.Success);
+
+    private int SchedulerFailedCount => SchedulerJobs.Count(job => job.LastExecutionStatus == SchedulerJobExecutionStatus.Failed);
+
+    private int SchedulerNeverRunCount => SchedulerJobs.Count(job => job.LastFireTimeUtc is null);
+
+    private int SchedulerOverdueCount => SchedulerJobs.Count(IsSchedulerOverdue);
+
+    private string LastSchedulerError => SchedulerJobs
+        .Where(job => job.LastExecutionStatus == SchedulerJobExecutionStatus.Failed && !string.IsNullOrWhiteSpace(job.LastExecutionError))
+        .OrderByDescending(job => job.LastFireTimeUtc ?? DateTimeOffset.MinValue)
+        .Select(job => job.LastExecutionError!)
+        .FirstOrDefault() ?? SchedulerError;
+
+    private List<SchedulerJobInfo> RecentSchedulerJobs => [.. SchedulerJobs
+        .Where(job => job.LastFireTimeUtc is not null)
+        .OrderByDescending(job => job.LastFireTimeUtc)
+        .Take(5)];
 
     protected override void OnInitialized()
     {
@@ -558,6 +733,7 @@ MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
     {
         try
         {
+            MiddlewareUsageCheckedAtUtc = DateTime.UtcNow;
             RestSharp.RestResponse response = await middlewareClient.GetSystemUsage();
             bool httpSuccess = (int)response.StatusCode >= 200 && (int)response.StatusCode < 300;
             if (!httpSuccess)
@@ -575,17 +751,19 @@ MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
             }
 
             MiddlewareUsage = snapshot;
-            await RefreshSchedulerJobsAsync();
             MiddlewareUsageReachable = true;
+            MiddlewareUsageError = "";
             AppendHistory(MiddlewareCpuHistory, MiddlewareUsage.CpuUsedPercent);
             AppendHistory(MiddlewareMemoryHistory, MiddlewareUsage.MemoryUsedPercent);
             AppendHistory(MiddlewareHistoryTimes, MiddlewareUsage.CollectedAt);
             middlewareRefreshFailureReported = false;
+            await RefreshSchedulerJobsAsync();
             await InvokeAsync(StateHasChanged);
         }
         catch (Exception exception)
         {
             MiddlewareUsageReachable = false;
+            MiddlewareUsageError = exception.Message;
             if (!middlewareRefreshFailureReported)
             {
                 middlewareRefreshFailureReported = true;
@@ -598,12 +776,18 @@ MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
 
     private async Task RefreshSchedulerJobsAsync()
     {
+        SchedulerCheckedAtUtc = DateTime.UtcNow;
         RestSharp.RestResponse<List<SchedulerJobInfo>> response = await middlewareClient.GetSchedulerJobs();
         if (!response.IsSuccessful || response.Data == null)
         {
-            throw new InvalidOperationException(response.ErrorMessage ?? response.StatusDescription ?? userConfig.GetText("scheduler_job_fetch_failed"));
+            SchedulerReachable = false;
+            SchedulerError = response.ErrorMessage ?? response.StatusDescription ?? userConfig.GetText("scheduler_job_fetch_failed");
+            SchedulerJobs = [];
+            return;
         }
 
+        SchedulerReachable = true;
+        SchedulerError = "";
         SchedulerJobs = [.. response.Data.OrderBy(job => job.JobName)];
     }
 
@@ -668,6 +852,22 @@ MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
             SchedulerJobExecutionStatus.Failed => (MarkupString)$"<span class=\"text-danger {Icons.Close}\"></span>",
             _ => (MarkupString)"<span class=\"text-muted\">—</span>"
         };
+    }
+
+    private static string FormatCheckedAt(DateTime? checkedAtUtc)
+    {
+        return checkedAtUtc.HasValue ? checkedAtUtc.Value.ToLocalTime().ToString("G") : "-";
+    }
+
+    private bool IsSchedulerOverdue(SchedulerJobInfo job)
+    {
+        return job.NextFireTimeUtc.HasValue
+            && DateTimeOffset.Now > job.NextFireTimeUtc.Value.Add(kSchedulerOverdueGracePeriod);
+    }
+
+    private string GetReachabilityText(bool reachable)
+    {
+        return userConfig.GetText(reachable ? "monitoring_reachable" : "monitoring_unreachable");
     }
 
     /// <summary>

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
@@ -1,5 +1,6 @@
 @using FWO.Services.SystemUsage
 @using FWO.Middleware.Client
+@using FWO.Data.Middleware
 
 @page "/monitoring"
 @page "/monitoring/system_usage"
@@ -112,9 +113,9 @@
                 </div>
             </div>
 
-            <div class="row">
-                <div class="col-12 mb-3">
-                    <div class="card">
+        <div class="row">
+            <div class="col-12 mb-3">
+                <div class="card">
                         <div class="card-body">
                             <h6>@(userConfig.GetText("ui_process"))</h6>
                             <div class="row">
@@ -268,10 +269,60 @@
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                    </div>
-                                                </div>
-                                            </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12 mb-3">
+                <div class="card">
+                    <div class="card-body">
+                        <h6>@(userConfig.GetText("scheduler_jobs_title"))</h6>
+                        @if (SchedulerJobs.Count == 0)
+                        {
+                            <div class="text-muted">@(userConfig.GetText("scheduler_no_jobs"))</div>
+                        }
+                        else
+                        {
+                            <div class="table-responsive">
+                                <table class="table table-sm table-bordered th-bg-secondary align-middle">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">@(userConfig.GetText("scheduler_job"))</th>
+                                            <th scope="col">@(userConfig.GetText("scheduler_interval"))</th>
+                                            <th scope="col">@(userConfig.GetText("scheduler_last_run"))</th>
+                                            <th scope="col">@(userConfig.GetText("scheduler_next_run"))</th>
+                                            <th scope="col" class="text-center">@(userConfig.GetText("scheduler_status"))</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (SchedulerJobInfo job in SchedulerJobs)
+                                        {
+                                            <tr>
+                                                <td>@job.JobName</td>
+                                                <td class="@(string.IsNullOrWhiteSpace(job.IntervalDescription) ? "text-center" : "")">@FormatSchedulerInterval(job.IntervalDescription)</td>
+                                                <td class="@(job.LastFireTimeUtc is null ? "text-center" : "")">@FormatSchedulerRunTime(job.LastFireTimeUtc, false)</td>
+                                                <td class="@(job.NextFireTimeUtc is null ? "text-center" : "")">@FormatSchedulerRunTime(job.NextFireTimeUtc, true)</td>
+                                                <td class="text-center">@FormatSchedulerExecutionStatus(job)</td>
+                                            </tr>
+                                            @if (job.LastExecutionStatus == SchedulerJobExecutionStatus.Failed && !string.IsNullOrWhiteSpace(job.LastExecutionError))
+                                            {
+                                                <tr>
+                                                    <td colspan="5" style="background-color: #ffd400d6">
+                                                        @((MarkupString)$"<p><span class=\"text-danger {Icons.Warning} px-1\"></span><b>{System.Net.WebUtility.HtmlEncode(job.LastExecutionError)}</b></p>")
+                                                    </td>
+                                                </tr>
+                                            }
                                         }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
 
                                         <div class="row">
                                             <div class="col-12 mb-3">
@@ -334,6 +385,7 @@
     private SystemUsageSnapshot Usage { get; set; } = new();
     private SystemUsageSnapshot MiddlewareUsage { get; set; } = new();
     private UiSessionOverview Sessions { get; set; } = new();
+    private List<SchedulerJobInfo> SchedulerJobs { get; set; } = [];
     private List<double> CpuHistory { get; set; } = [];
     private List<double> MemoryHistory { get; set; } = [];
     private List<DateTime> HistoryTimes { get; set; } = [];
@@ -523,6 +575,7 @@ MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
             }
 
             MiddlewareUsage = snapshot;
+            await RefreshSchedulerJobsAsync();
             MiddlewareUsageReachable = true;
             AppendHistory(MiddlewareCpuHistory, MiddlewareUsage.CpuUsedPercent);
             AppendHistory(MiddlewareMemoryHistory, MiddlewareUsage.MemoryUsedPercent);
@@ -541,6 +594,17 @@ MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
 
             await InvokeAsync(StateHasChanged);
         }
+    }
+
+    private async Task RefreshSchedulerJobsAsync()
+    {
+        RestSharp.RestResponse<List<SchedulerJobInfo>> response = await middlewareClient.GetSchedulerJobs();
+        if (!response.IsSuccessful || response.Data == null)
+        {
+            throw new InvalidOperationException(response.ErrorMessage ?? response.StatusDescription ?? userConfig.GetText("scheduler_job_fetch_failed"));
+        }
+
+        SchedulerJobs = [.. response.Data.OrderBy(job => job.JobName)];
     }
 
     private async Task RefreshAsync()
@@ -565,6 +629,45 @@ MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
         {
             history.RemoveAt(0);
         }
+    }
+
+    private MarkupString FormatSchedulerInterval(string intervalDescription)
+    {
+        return string.IsNullOrWhiteSpace(intervalDescription)
+            ? (MarkupString)"<span class=\"text-muted text-center\">—</span>"
+            : (MarkupString)$"{userConfig.GetText("scheduler_interval_description")} {intervalDescription}";
+    }
+
+    private MarkupString FormatSchedulerRunTime(DateTimeOffset? fireTimeUtc, bool isNextRun)
+    {
+        if (fireTimeUtc == null)
+        {
+            return (MarkupString)"<span class=\"text-muted\">—</span>";
+        }
+
+        if (isNextRun)
+        {
+            TimeSpan timeUntil = fireTimeUtc.Value - DateTimeOffset.Now;
+            if (timeUntil.TotalSeconds <= 5 && timeUntil.TotalSeconds >= 0)
+            {
+                return (MarkupString)userConfig.GetText("scheduler_now");
+            }
+        }
+
+        DateTime localTime = fireTimeUtc.Value.LocalDateTime;
+        return localTime.Second != 0
+            ? (MarkupString)localTime.ToString("G")
+            : (MarkupString)localTime.ToString("g");
+    }
+
+    private MarkupString FormatSchedulerExecutionStatus(SchedulerJobInfo job)
+    {
+        return job.LastExecutionStatus switch
+        {
+            SchedulerJobExecutionStatus.Success => (MarkupString)$"<span class=\"text-success {Icons.Check}\"></span>",
+            SchedulerJobExecutionStatus.Failed => (MarkupString)$"<span class=\"text-danger {Icons.Close}\"></span>",
+            _ => (MarkupString)"<span class=\"text-muted\">—</span>"
+        };
     }
 
     /// <summary>

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
@@ -1,11 +1,13 @@
 @using FWO.Services.SystemUsage
+@using FWO.Middleware.Client
 
 @page "/monitoring"
 @page "/monitoring/system_usage"
 @attribute [Authorize(Roles = $"{Roles.Admin}, {Roles.Reporter}, {Roles.ReporterViewAll}, {Roles.Modeller}, {Roles.Recertifier}, {Roles.WorkflowRolesList}, {Roles.Auditor}, {Roles.FwAdmin}")]
 
 @inject UserConfig userConfig
-@inject ISystemUsageCollector systemUsageCollector
+@inject ISystemUsageSnapshotProvider systemUsageProvider
+@inject MiddlewareClient middlewareClient
 @inject UiSessionTracker sessionTracker
 @inject IPeriodicTaskRunnerFactory periodicTaskRunnerFactory
 
@@ -25,7 +27,8 @@
     </div>
     <p>@(userConfig.GetText("U7004"))</p>
     <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
-        <button type="button" class="btn btn-sm btn-primary" @onclick="Refresh">@(DisplayService.DisplayButton(userConfig, "refresh", Icons.Refresh))</button>
+        <button type="button" class="btn btn-sm btn-primary"
+                @onclick="Refresh">@(DisplayService.DisplayButton(userConfig, "refresh", Icons.Refresh))</button>
         <span class="text-muted">@(userConfig.GetText("last_updated")): @LastUpdatedDisplay</span>
     </div>
 
@@ -43,7 +46,8 @@
                 <div class="card-body">
                     <div class="usage-tile-value">@Sessions.OpenSessions</div>
                     <div>@(userConfig.GetText("open_sessions"))</div>
-                    <div class="text-muted">@(userConfig.GetText("connected_sessions")): @Sessions.ConnectedSessions</div>
+                    <div class="text-muted">@(userConfig.GetText("connected_sessions")): @Sessions.ConnectedSessions
+                    </div>
                 </div>
             </div>
         </div>
@@ -61,126 +65,263 @@
                 <div class="card-body">
                     <div class="usage-tile-value">@SystemUsageDisplay.FormatBytes(Usage.MemoryAvailableBytes)</div>
                     <div>@(userConfig.GetText("memory_available"))</div>
-                    <div class="text-muted">@(userConfig.GetText("memory_total")): @SystemUsageDisplay.FormatBytes(Usage.MemoryTotalBytes)</div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    @if (!Usage.SourceAvailable)
-    {
-        <div class="alert alert-warning">@(userConfig.GetText("usage_data_unavailable"))</div>
-    }
-
-    <div class="row">
-        <div class="col-lg-6 mb-3">
-            <div class="card h-100">
-                <div class="card-body">
-                    <h6>@(userConfig.GetText("memory_usage"))</h6>
-                    <UsageGauge Caption="@(userConfig.GetText("memory_used"))" Percent="@Usage.MemoryUsedPercent"
-                                Detail="@($"{SystemUsageDisplay.FormatBytes(Usage.MemoryUsedBytes)} / {SystemUsageDisplay.FormatBytes(Usage.MemoryTotalBytes)}")" />
-                    <UsageGauge Caption="@(userConfig.GetText("swap_usage"))" Percent="@Usage.SwapUsedPercent"
-                                Detail="@($"{SystemUsageDisplay.FormatBytes(Usage.SwapUsedBytes)} / {SystemUsageDisplay.FormatBytes(Usage.SwapTotalBytes)}")" />
-                    <UsageSparkline Values="@MemoryHistory" Caption="@(userConfig.GetText("memory_usage"))"
-                                    EmptyText="@(userConfig.GetText("collecting_data"))" StartTime="@HistoryStartTime" EndTime="@HistoryEndTime"
-                                    LineClass="usage-sparkline-secondary" AreaClass="usage-sparkline-secondary" />
-                    <div class="text-muted">@(userConfig.GetText("memory_available")): @SystemUsageDisplay.FormatBytes(Usage.MemoryAvailableBytes)</div>
-                </div>
-            </div>
-        </div>
-        <div class="col-lg-6 mb-3">
-            <div class="card h-100">
-                <div class="card-body">
-                    <h6>@(userConfig.GetText("cpu_usage"))</h6>
-                    <UsageGauge Caption="@(userConfig.GetText("system"))" Percent="@Usage.CpuUsedPercent"
-                                Detail="@SystemUsageDisplay.FormatPercent(Usage.CpuUsedPercent)" />
-                    <UsageGauge Caption="@(userConfig.GetText("ui_process"))" Percent="@Usage.ProcessCpuPercent"
-                                Detail="@SystemUsageDisplay.FormatPercent(Usage.ProcessCpuPercent)" />
-                    <UsageSparkline Values="@CpuHistory" Caption="@(userConfig.GetText("cpu_usage"))"
-                                    EmptyText="@(userConfig.GetText("collecting_data"))" StartTime="@HistoryStartTime" EndTime="@HistoryEndTime" />
-                    <div class="text-muted">@(userConfig.GetText("load_average")): @LoadAverageDisplay</div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-12 mb-3">
-            <div class="card">
-                <div class="card-body">
-                    <h6>@(userConfig.GetText("ui_process"))</h6>
-                    <div class="row">
-                        <div class="col-sm-6 col-lg-3">
-                            <div>@(userConfig.GetText("working_set"))</div>
-                            <div class="usage-tile-value">@SystemUsageDisplay.FormatBytes(Usage.ProcessWorkingSetBytes)</div>
-                        </div>
-                        <div class="col-sm-6 col-lg-3">
-                            <div>@(userConfig.GetText("managed_heap"))</div>
-                            <div class="usage-tile-value">@SystemUsageDisplay.FormatBytes(Usage.ProcessManagedHeapBytes)</div>
-                        </div>
-                        <div class="col-sm-6 col-lg-3">
-                            <div>@(userConfig.GetText("threads"))</div>
-                            <div class="usage-tile-value">@Usage.ProcessThreadCount</div>
-                        </div>
-                        <div class="col-sm-6 col-lg-3">
-                            <div>@(userConfig.GetText("uptime"))</div>
-                            <div class="usage-tile-value">@SystemUsageDisplay.FormatDuration(Usage.ProcessUpTime)</div>
-                        </div>
+                    <div class="text-muted">@(userConfig.GetText("memory_total")):
+                        @SystemUsageDisplay.FormatBytes(Usage.MemoryTotalBytes)</div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <div class="row">
-        <div class="col-12 mb-3">
-            <div class="card">
-                <div class="card-body">
-                    <h6>@(userConfig.GetText("system_services"))</h6>
-                    <p>@(userConfig.GetText("U7005"))</p>
-                    @if (!Usage.ServicesVisible)
-                    {
-                        <div class="alert alert-warning">@(userConfig.GetText("services_not_visible"))</div>
-                    }
-                    else if (Usage.Services.Count == 0)
-                    {
-                        <div class="text-muted">@(userConfig.GetText("no_services_found"))</div>
-                    }
-                    @if (Usage.Services.Count > 0)
-                    {
-                        <table class="table table-sm table-bordered th-bg-secondary table-responsive overflow-auto">
-                            <thead>
-                                <tr>
-                                    <th scope="col">@(userConfig.GetText("service"))</th>
-                                    <th scope="col">@(userConfig.GetText("cpu_usage"))</th>
-                                    <th scope="col">@(userConfig.GetText("working_set"))</th>
-                                    <th scope="col">@(userConfig.GetText("memory_usage"))</th>
-                                    <th scope="col">@(userConfig.GetText("threads"))</th>
-                                    <th scope="col">@(userConfig.GetText("processes"))</th>
-                                    <th scope="col">@(userConfig.GetText("uptime"))</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach (ServiceUsage service in Usage.Services)
-                                {
-                                    <tr>
-                                        <td>@(userConfig.GetText(service.NameKey))</td>
-                                        <td>@SystemUsageDisplay.FormatPercent(service.CpuPercent)</td>
-                                        <td>@SystemUsageDisplay.FormatBytes(service.MemoryBytes)</td>
-                                        <td>@SystemUsageDisplay.FormatPercent(service.MemoryPercent)</td>
-                                        <td>@service.ThreadCount</td>
-                                        <td>@service.ProcessCount</td>
-                                        <td>@SystemUsageDisplay.FormatDuration(service.UpTime)</td>
-                                    </tr>
-                                }
-                            </tbody>
-                        </table>
-                    }
+        @if (!Usage.SourceAvailable)
+        {
+            <div class="alert alert-warning">@(userConfig.GetText("usage_data_unavailable"))</div>
+        }
+
+        <div class="row">
+            <div class="col-lg-6 mb-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h6>@(userConfig.GetText("memory_usage"))</h6>
+                        <UsageGauge Caption="@(userConfig.GetText("memory_used"))" Percent="@Usage.MemoryUsedPercent"
+                                    Detail="@($"{SystemUsageDisplay.FormatBytes(Usage.MemoryUsedBytes)} / {SystemUsageDisplay.FormatBytes(Usage.MemoryTotalBytes)}")" />
+                        <UsageGauge Caption="@(userConfig.GetText("swap_usage"))" Percent="@Usage.SwapUsedPercent"
+                                    Detail="@($"{SystemUsageDisplay.FormatBytes(Usage.SwapUsedBytes)} / {SystemUsageDisplay.FormatBytes(Usage.SwapTotalBytes)}")" />
+                        <UsageSparkline Values="@MemoryHistory" Caption="@(userConfig.GetText("memory_usage"))"
+                                        EmptyText="@(userConfig.GetText("collecting_data"))" StartTime="@HistoryStartTime"
+                                        EndTime="@HistoryEndTime" LineClass="usage-sparkline-secondary"
+                                        AreaClass="usage-sparkline-secondary" />
+                        <div class="text-muted">@(userConfig.GetText("memory_available")):
+                            @SystemUsageDisplay.FormatBytes(Usage.MemoryAvailableBytes)</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-lg-6 mb-3">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h6>@(userConfig.GetText("cpu_usage"))</h6>
+                            <UsageGauge Caption="@(userConfig.GetText("system"))" Percent="@Usage.CpuUsedPercent"
+                                        Detail="@SystemUsageDisplay.FormatPercent(Usage.CpuUsedPercent)" />
+                            <UsageGauge Caption="@(userConfig.GetText("ui_process"))" Percent="@Usage.ProcessCpuPercent"
+                                        Detail="@SystemUsageDisplay.FormatPercent(Usage.ProcessCpuPercent)" />
+                            <UsageSparkline Values="@CpuHistory" Caption="@(userConfig.GetText("cpu_usage"))"
+                                            EmptyText="@(userConfig.GetText("collecting_data"))" StartTime="@HistoryStartTime"
+                                            EndTime="@HistoryEndTime" />
+                            <div class="text-muted">@(userConfig.GetText("load_average")): @LoadAverageDisplay</div>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</ExecutionModeAuthorizeView>
+
+            <div class="row">
+                <div class="col-12 mb-3">
+                    <div class="card">
+                        <div class="card-body">
+                            <h6>@(userConfig.GetText("ui_process"))</h6>
+                            <div class="row">
+                                <div class="col-sm-6 col-lg-3">
+                                    <div>@(userConfig.GetText("working_set"))</div>
+                                    <div class="usage-tile-value">@SystemUsageDisplay.FormatBytes(Usage.ProcessWorkingSetBytes)
+                                    </div>
+                                </div>
+                                <div class="col-sm-6 col-lg-3">
+                                    <div>@(userConfig.GetText("managed_heap"))</div>
+                                    <div class="usage-tile-value">@SystemUsageDisplay.FormatBytes(Usage.ProcessManagedHeapBytes)
+                                    </div>
+                                </div>
+                                <div class="col-sm-6 col-lg-3">
+                                    <div>@(userConfig.GetText("threads"))</div>
+                                    <div class="usage-tile-value">@Usage.ProcessThreadCount</div>
+                                </div>
+                                <div class="col-sm-6 col-lg-3">
+                                    <div>@(userConfig.GetText("uptime"))</div>
+                                    <div class="usage-tile-value">@SystemUsageDisplay.FormatDuration(Usage.ProcessUpTime)</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-12 mb-3">
+                    <div class="card">
+                        <div class="card-body">
+                            <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+                                <h6 class="mb-0">@(userConfig.GetText("middleware"))</h6>
+                                <span class="text-muted">@(userConfig.GetText("last_updated")):
+                                    @MiddlewareLastUpdatedDisplay</span>
+                                </div>
+
+                                @if (!MiddlewareUsageReachable || (MiddlewareUsage.CollectedAt != DateTime.MinValue &&
+                                !MiddlewareUsage.SourceAvailable))
+                                {
+                                    <div class="alert alert-warning mt-3 mb-0">@(userConfig.GetText("usage_data_unavailable"))</div>
+                                }
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                @if (MiddlewareUsage.CollectedAt != DateTime.MinValue)
+                {
+                    <div class="row">
+                        <div class="col-sm-6 col-lg-3 mb-3">
+                            <div class="card h-100">
+                                <div class="card-body">
+                                    <div class="usage-tile-value">@MiddlewareUsage.ProcessorCount</div>
+                                    <div>@(userConfig.GetText("cpu_cores"))</div>
+                                    <div class="text-muted">@(userConfig.GetText("load_average")): @MiddlewareLoadAverageDisplay</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-lg-3 mb-3">
+                            <div class="card h-100">
+                                <div class="card-body">
+                                    <div class="usage-tile-value">@SystemUsageDisplay.FormatBytes(MiddlewareUsage.MemoryAvailableBytes)
+                                    </div>
+                                    <div>@(userConfig.GetText("memory_available"))</div>
+                                    <div class="text-muted">@(userConfig.GetText("memory_total")):
+                                        @SystemUsageDisplay.FormatBytes(MiddlewareUsage.MemoryTotalBytes)</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6 col-lg-3 mb-3">
+                                <div class="card h-100">
+                                    <div class="card-body">
+                                        <div class="usage-tile-value">
+                                            @SystemUsageDisplay.FormatBytes(MiddlewareUsage.ProcessWorkingSetBytes)</div>
+                                            <div>@(userConfig.GetText("working_set"))</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-6 col-lg-3 mb-3">
+                                    <div class="card h-100">
+                                        <div class="card-body">
+                                            <div class="usage-tile-value">@MiddlewareUsage.ProcessThreadCount</div>
+                                            <div>@(userConfig.GetText("threads"))</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="row">
+                                <div class="col-lg-6 mb-3">
+                                    <div class="card h-100">
+                                        <div class="card-body">
+                                            <h6>@(userConfig.GetText("memory_usage"))</h6>
+                                            <UsageGauge Caption="@(userConfig.GetText("memory_used"))"
+                                                        Percent="@MiddlewareUsage.MemoryUsedPercent"
+                                                        Detail="@($"{SystemUsageDisplay.FormatBytes(MiddlewareUsage.MemoryUsedBytes)} / {SystemUsageDisplay.FormatBytes(MiddlewareUsage.MemoryTotalBytes)}")" />
+                                            <UsageGauge Caption="@(userConfig.GetText("swap_usage"))" Percent="@MiddlewareUsage.SwapUsedPercent"
+                                                        Detail="@($"{SystemUsageDisplay.FormatBytes(MiddlewareUsage.SwapUsedBytes)} / {SystemUsageDisplay.FormatBytes(MiddlewareUsage.SwapTotalBytes)}")" />
+                                            <UsageSparkline Values="@MiddlewareMemoryHistory" Caption="@(userConfig.GetText("memory_usage"))"
+                                                            EmptyText="@(userConfig.GetText("collecting_data"))" StartTime="@MiddlewareHistoryStartTime"
+                                                            EndTime="@MiddlewareHistoryEndTime" LineClass="usage-sparkline-secondary"
+                                                            AreaClass="usage-sparkline-secondary" />
+                                            <div class="text-muted">@(userConfig.GetText("memory_available")):
+                                                @SystemUsageDisplay.FormatBytes(MiddlewareUsage.MemoryAvailableBytes)</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6 mb-3">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <h6>@(userConfig.GetText("cpu_usage"))</h6>
+                                                <UsageGauge Caption="@(userConfig.GetText("system"))" Percent="@MiddlewareUsage.CpuUsedPercent"
+                                                            Detail="@SystemUsageDisplay.FormatPercent(MiddlewareUsage.CpuUsedPercent)" />
+                                                <UsageGauge Caption="@(userConfig.GetText("middleware"))"
+                                                            Percent="@MiddlewareUsage.ProcessCpuPercent"
+                                                            Detail="@SystemUsageDisplay.FormatPercent(MiddlewareUsage.ProcessCpuPercent)" />
+                                                <UsageSparkline Values="@MiddlewareCpuHistory" Caption="@(userConfig.GetText("cpu_usage"))"
+                                                                EmptyText="@(userConfig.GetText("collecting_data"))" StartTime="@MiddlewareHistoryStartTime"
+                                                                EndTime="@MiddlewareHistoryEndTime" />
+                                                <div class="text-muted">@(userConfig.GetText("load_average")): @MiddlewareLoadAverageDisplay</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-12 mb-3">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <h6>@(userConfig.GetText("middleware"))</h6>
+                                                <div class="row">
+                                                    <div class="col-sm-6 col-lg-3">
+                                                        <div>@(userConfig.GetText("working_set"))</div>
+                                                        <div class="usage-tile-value">
+                                                            @SystemUsageDisplay.FormatBytes(MiddlewareUsage.ProcessWorkingSetBytes)</div>
+                                                        </div>
+                                                        <div class="col-sm-6 col-lg-3">
+                                                            <div>@(userConfig.GetText("managed_heap"))</div>
+                                                            <div class="usage-tile-value">
+                                                                @SystemUsageDisplay.FormatBytes(MiddlewareUsage.ProcessManagedHeapBytes)</div>
+                                                            </div>
+                                                            <div class="col-sm-6 col-lg-3">
+                                                                <div>@(userConfig.GetText("threads"))</div>
+                                                                <div class="usage-tile-value">@MiddlewareUsage.ProcessThreadCount</div>
+                                                            </div>
+                                                            <div class="col-sm-6 col-lg-3">
+                                                                <div>@(userConfig.GetText("uptime"))</div>
+                                                                <div class="usage-tile-value">
+                                                                    @SystemUsageDisplay.FormatDuration(MiddlewareUsage.ProcessUpTime)</div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        }
+
+                                        <div class="row">
+                                            <div class="col-12 mb-3">
+                                                <div class="card">
+                                                    <div class="card-body">
+                                                        <h6>@(userConfig.GetText("system_services"))</h6>
+                                                        <p>@(userConfig.GetText("U7005"))</p>
+                                                        @if (!Usage.ServicesVisible)
+                                                        {
+                                                            <div class="alert alert-warning">@(userConfig.GetText("services_not_visible"))</div>
+                                                        }
+                                                        else if (Usage.Services.Count == 0)
+                                                        {
+                                                            <div class="text-muted">@(userConfig.GetText("no_services_found"))</div>
+                                                        }
+                                                        @if (Usage.Services.Count > 0)
+                                                        {
+                                                            <table class="table table-sm table-bordered th-bg-secondary table-responsive overflow-auto">
+                                                                <thead>
+                                                                    <tr>
+                                                                        <th scope="col">@(userConfig.GetText("service"))</th>
+                                                                        <th scope="col">@(userConfig.GetText("cpu_usage"))</th>
+                                                                        <th scope="col">@(userConfig.GetText("working_set"))</th>
+                                                                        <th scope="col">@(userConfig.GetText("memory_usage"))</th>
+                                                                        <th scope="col">@(userConfig.GetText("threads"))</th>
+                                                                        <th scope="col">@(userConfig.GetText("processes"))</th>
+                                                                        <th scope="col">@(userConfig.GetText("uptime"))</th>
+                                                                    </tr>
+                                                                </thead>
+                                                                <tbody>
+                                                                    @foreach (ServiceUsage service in Usage.Services)
+                                                                    {
+                                                                        <tr>
+                                                                            <td>@(userConfig.GetText(service.NameKey))</td>
+                                                                            <td>@SystemUsageDisplay.FormatPercent(service.CpuPercent)</td>
+                                                                            <td>@SystemUsageDisplay.FormatBytes(service.MemoryBytes)</td>
+                                                                            <td>@SystemUsageDisplay.FormatPercent(service.MemoryPercent)</td>
+                                                                            <td>@service.ThreadCount</td>
+                                                                            <td>@service.ProcessCount</td>
+                                                                            <td>@SystemUsageDisplay.FormatDuration(service.UpTime)</td>
+                                                                        </tr>
+                                                                    }
+                                                                </tbody>
+                                                            </table>
+                                                        }
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </ExecutionModeAuthorizeView>
 
 @code
 {
@@ -191,25 +332,42 @@
     private const int kMaxHistoryPoints = 60;
 
     private SystemUsageSnapshot Usage { get; set; } = new();
+    private SystemUsageSnapshot MiddlewareUsage { get; set; } = new();
     private UiSessionOverview Sessions { get; set; } = new();
     private List<double> CpuHistory { get; set; } = [];
     private List<double> MemoryHistory { get; set; } = [];
     private List<DateTime> HistoryTimes { get; set; } = [];
+    private List<double> MiddlewareCpuHistory { get; set; } = [];
+    private List<double> MiddlewareMemoryHistory { get; set; } = [];
+    private List<DateTime> MiddlewareHistoryTimes { get; set; } = [];
     private readonly SemaphoreSlim monitoringStateSemaphore = new(1, 1);
     private IPeriodicTaskRunner? refreshRunner;
     private bool refreshFailureReported;
+    private bool middlewareRefreshFailureReported;
     private bool interactiveRenderCompleted;
     private bool monitoringActive;
+    private bool MiddlewareUsageReachable { get; set; } = true;
     private bool disposed;
 
     private string LastUpdatedDisplay => Usage.CollectedAt == DateTime.MinValue
         ? "-" : Usage.CollectedAt.ToLocalTime().ToString("G");
 
+    private string MiddlewareLastUpdatedDisplay => MiddlewareUsage.CollectedAt == DateTime.MinValue
+        ? "-" : MiddlewareUsage.CollectedAt.ToLocalTime().ToString("G");
+
     private string LoadAverageDisplay => SystemUsageDisplay.FormatLoadAverage(Usage);
+
+    private string MiddlewareLoadAverageDisplay => SystemUsageDisplay.FormatLoadAverage(MiddlewareUsage);
 
     private string HistoryStartTime => HistoryTimes.Count > 0 ? HistoryTimes[0].ToLocalTime().ToString("T") : "";
 
     private string HistoryEndTime => HistoryTimes.Count > 0 ? HistoryTimes[^1].ToLocalTime().ToString("T") : "";
+
+    private string MiddlewareHistoryStartTime => MiddlewareHistoryTimes.Count > 0 ?
+MiddlewareHistoryTimes[0].ToLocalTime().ToString("T") : "";
+
+    private string MiddlewareHistoryEndTime => MiddlewareHistoryTimes.Count > 0 ?
+MiddlewareHistoryTimes[^1].ToLocalTime().ToString("T") : "";
 
     private bool CanViewUsage => userConfig.CanUseAnyRole(Roles.Admin, Roles.FwAdmin, Roles.Auditor);
 
@@ -219,7 +377,7 @@
         monitoringActive = CanViewUsage;
         if (monitoringActive)
         {
-            Refresh();
+            RefreshLocalUsage();
         }
     }
 
@@ -234,6 +392,10 @@
         if (firstRender)
         {
             interactiveRenderCompleted = true;
+            if (monitoringActive)
+            {
+                _ = RefreshMiddlewareUsageAsync();
+            }
             StartRefreshRunner();
         }
     }
@@ -315,9 +477,15 @@
     /// </summary>
     private void Refresh()
     {
+        RefreshLocalUsage();
+        _ = RefreshMiddlewareUsageAsync();
+    }
+
+    private void RefreshLocalUsage()
+    {
         try
         {
-            Usage = systemUsageCollector.Collect();
+            Usage = systemUsageProvider.Collect();
             Sessions = sessionTracker.GetOverview();
             AppendHistory(CpuHistory, Usage.CpuUsedPercent);
             AppendHistory(MemoryHistory, Usage.MemoryUsedPercent);
@@ -331,6 +499,46 @@
                 refreshFailureReported = true;
                 DisplayMessageInUi(exception, userConfig.GetText("system_usage"), "", true);
             }
+        }
+    }
+
+    private async Task RefreshMiddlewareUsageAsync()
+    {
+        try
+        {
+            RestSharp.RestResponse<string> response = await middlewareClient.GetSystemUsage();
+            if (!response.IsSuccessful)
+            {
+                throw new InvalidOperationException($"Middleware system usage request failed with status {(int)response.StatusCode}.");
+            }
+
+            SystemUsageSnapshot? snapshot = !string.IsNullOrWhiteSpace(response.Content)
+                ? System.Text.Json.JsonSerializer.Deserialize<SystemUsageSnapshot>(response.Content)
+                    : new();
+
+            if (snapshot is null)
+            {
+                return;
+            }
+
+            MiddlewareUsage = snapshot;
+            MiddlewareUsageReachable = true;
+            AppendHistory(MiddlewareCpuHistory, MiddlewareUsage.CpuUsedPercent);
+            AppendHistory(MiddlewareMemoryHistory, MiddlewareUsage.MemoryUsedPercent);
+            AppendHistory(MiddlewareHistoryTimes, MiddlewareUsage.CollectedAt);
+            middlewareRefreshFailureReported = false;
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (Exception exception)
+        {
+            MiddlewareUsageReachable = false;
+            if (!middlewareRefreshFailureReported)
+            {
+                middlewareRefreshFailureReported = true;
+                DisplayMessageInUi(exception, userConfig.GetText("middleware"), "", true);
+            }
+
+            await InvokeAsync(StateHasChanged);
         }
     }
 

--- a/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
+++ b/roles/ui/files/FWO.UI/Pages/Monitoring/MonitorSystemUsage.razor
@@ -465,56 +465,7 @@
             </div>
         </div>
     }
-
-                                        <div class="row">
-                                            <div class="col-12 mb-3">
-                                                <div class="card">
-                                                    <div class="card-body">
-                                                        <h6>@(userConfig.GetText("system_services"))</h6>
-                                                        <p>@(userConfig.GetText("U7005"))</p>
-                                                        @if (!Usage.ServicesVisible)
-                                                        {
-                                                            <div class="alert alert-warning">@(userConfig.GetText("services_not_visible"))</div>
-                                                        }
-                                                        else if (Usage.Services.Count == 0)
-                                                        {
-                                                            <div class="text-muted">@(userConfig.GetText("no_services_found"))</div>
-                                                        }
-                                                        @if (Usage.Services.Count > 0)
-                                                        {
-                                                            <table class="table table-sm table-bordered th-bg-secondary table-responsive overflow-auto">
-                                                                <thead>
-                                                                    <tr>
-                                                                        <th scope="col">@(userConfig.GetText("service"))</th>
-                                                                        <th scope="col">@(userConfig.GetText("cpu_usage"))</th>
-                                                                        <th scope="col">@(userConfig.GetText("working_set"))</th>
-                                                                        <th scope="col">@(userConfig.GetText("memory_usage"))</th>
-                                                                        <th scope="col">@(userConfig.GetText("threads"))</th>
-                                                                        <th scope="col">@(userConfig.GetText("processes"))</th>
-                                                                        <th scope="col">@(userConfig.GetText("uptime"))</th>
-                                                                    </tr>
-                                                                </thead>
-                                                                <tbody>
-                                                                    @foreach (ServiceUsage service in Usage.Services)
-                                                                    {
-                                                                        <tr>
-                                                                            <td>@(userConfig.GetText(service.NameKey))</td>
-                                                                            <td>@SystemUsageDisplay.FormatPercent(service.CpuPercent)</td>
-                                                                            <td>@SystemUsageDisplay.FormatBytes(service.MemoryBytes)</td>
-                                                                            <td>@SystemUsageDisplay.FormatPercent(service.MemoryPercent)</td>
-                                                                            <td>@service.ThreadCount</td>
-                                                                            <td>@service.ProcessCount</td>
-                                                                            <td>@SystemUsageDisplay.FormatDuration(service.UpTime)</td>
-                                                                        </tr>
-                                                                    }
-                                                                </tbody>
-                                                            </table>
-                                                        }
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </ExecutionModeAuthorizeView>
+</ExecutionModeAuthorizeView>
 
 @code
 {

--- a/roles/ui/files/FWO.UI/Program.cs
+++ b/roles/ui/files/FWO.UI/Program.cs
@@ -15,6 +15,7 @@ using FWO.Ui.Services;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.Extensions.Diagnostics.ResourceMonitoring;
 using RestSharp;
 
 
@@ -67,8 +68,9 @@ builder.Services.AddScoped<ExecutionModeStorage>();
 // system usage monitoring: track the open circuits and sample the resource usage of this UI server
 builder.Services.AddSingleton<UiSessionTracker>();
 builder.Services.AddScoped<CircuitHandler, UiSessionCircuitHandler>();
+builder.Services.AddResourceMonitoring();
 builder.Services.AddSingleton<ISystemUsageSource, ProcSystemUsageSource>();
-builder.Services.AddSingleton<ISystemUsageCollector, SystemUsageCollector>();
+builder.Services.AddSingleton<ISystemUsageSnapshotProvider, ResourceMonitoringSystemUsageProvider>();
 
 // Create "anonymous" (empty) jwt
 MiddlewareClient middlewareClient = new(MiddlewareUri);

--- a/roles/ui/files/FWO.UI/Program.cs
+++ b/roles/ui/files/FWO.UI/Program.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.Extensions.Diagnostics.ResourceMonitoring;
+using Prometheus;
 using RestSharp;
 
 
@@ -149,6 +150,7 @@ else
 app.UseStaticFiles();
 
 app.UseRouting();
+app.UseHttpMetrics(options => options.ReduceStatusCodeCardinality());
 
 app.UseWhen(
     ctx => !ctx.Request.Path.StartsWithSegments("/_blazor") &&
@@ -164,6 +166,7 @@ app.UseWhen(
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.MapMetrics();
 app.MapBlazorHub();
 app.MapFallbackToPage("/_Host");
 

--- a/roles/ui/files/FWO.UI/Services/UiSessionTracker.cs
+++ b/roles/ui/files/FWO.UI/Services/UiSessionTracker.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Prometheus;
 
 namespace FWO.Ui.Services
 {
@@ -8,6 +9,13 @@ namespace FWO.Ui.Services
     /// </summary>
     public class UiSessionTracker
     {
+        private static readonly Gauge kLoggedInUsersGauge = Metrics.CreateGauge("fwo_ui_logged_in_users",
+            "Number of distinct logged-in users currently tracked by the UI server.");
+        private static readonly Gauge kOpenSessionsGauge = Metrics.CreateGauge("fwo_ui_open_sessions",
+            "Number of open Blazor sessions currently tracked by the UI server.");
+        private static readonly Gauge kConnectedSessionsGauge = Metrics.CreateGauge("fwo_ui_connected_sessions",
+            "Number of currently connected Blazor sessions tracked by the UI server.");
+
         private readonly ConcurrentDictionary<string, UiSession> sessions = new();
         private readonly Func<DateTime> utcNow;
 
@@ -38,6 +46,7 @@ namespace FWO.Ui.Services
                 OpenedAt = now,
                 LastActivity = now
             };
+            UpdateMetrics();
         }
 
         /// <summary>
@@ -47,6 +56,7 @@ namespace FWO.Ui.Services
         public void Unregister(string sessionId)
         {
             sessions.TryRemove(sessionId, out _);
+            UpdateMetrics();
         }
 
         /// <summary>
@@ -102,6 +112,15 @@ namespace FWO.Ui.Services
 
             change(session);
             session.LastActivity = utcNow();
+            UpdateMetrics();
+        }
+
+        private void UpdateMetrics()
+        {
+            UiSessionOverview overview = GetOverview();
+            kOpenSessionsGauge.Set(overview.OpenSessions);
+            kConnectedSessionsGauge.Set(overview.ConnectedSessions);
+            kLoggedInUsersGauge.Set(overview.LoggedInUsers);
         }
     }
 }


### PR DESCRIPTION
### ❗❗ THIS PR is just for showcase purposes and shouldn't be merged like this (check follow up text)

✔ Custom metrics can easily be added

Linked Issue: #4536

---

### ❗❗ I have only added a few metrics to this, there is much more data available:
✔ [Ambient Metadata](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/ambient-metadata/application-metadata?tabs=dotnet-cli)
✔ [Data Enrichment](https://learn.microsoft.com/en-us/dotnet/core/enrichment/overview)
✔ [ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/log-mon/metrics/built-in?view=aspnetcore-10.0)
✔ [System.Net](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-system-net)
✔ [.NET extensions](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-diagnostics)
✔ [.NET Runtime](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-runtime)
✔ [EF Core](https://learn.microsoft.com/en-us/ef/core/logging-events-diagnostics/metrics?tabs=windows)

---

**Background**  
This PR refactors the system monitoring implementation to rely less on host-local Linux `/proc` inspection and more on service-owned telemetry and .NET-native monitoring.

The previous approach worked, but it was tightly coupled to local process visibility on a specific host. That becomes increasingly fragile in distributed setups where UI, Middleware, and background components may run on different machines or be exposed independently.

This change moves the monitoring model in a more maintainable direction:
- application/process metrics come from `Microsoft.Extensions.Diagnostics.ResourceMonitoring`
- service-specific operational data comes from the owning service
- Prometheus metrics provide a reusable observability layer beyond the built-in UI page

**What changed**
- Replaced the old UI monitoring collector path with a snapshot provider based on `Microsoft.Extensions.Diagnostics.ResourceMonitoring`
- Added shared monitoring registration and snapshot collection for both UI and Middleware
- Added a new Middleware API endpoint at `/api/Monitoring/SystemUsage` that exposes Middleware system usage directly
- Updated the monitoring page so Middleware usage is read remotely from Middleware instead of being inferred from local host processes
- Added scheduler information directly to the monitoring page
- Added compact status sections for service reachability, scheduler health, and recent scheduler runs
- Added Prometheus metrics endpoints to UI and Middleware
- Exported UI session metrics and Middleware scheduler metrics for Prometheus consumers
- Removed local scanning/aggregation of other FWO services from the UI monitoring path
- Removed the “other services on this host” section from the monitoring page
- Updated localized help/documentation texts to reflect the new monitoring model

**Endpoints**
- UI Prometheus metrics are available at `/metrics` on the UI service
- Middleware Prometheus metrics are available at `/metrics` on the Middleware service
- The new Middleware system usage API endpoint is available at `/api/Monitoring/SystemUsage`

**Why this is useful**
- Reduces direct dependency on Linux-specific `/proc` parsing
- Removes reliance on local visibility of foreign processes
- Improves correctness when UI and Middleware are deployed on separate hosts
- Shifts service-level monitoring responsibility to the service that actually owns the data
- Introduces Prometheus as a stable integration point for future observability work

Prometheus is especially helpful here because it gives us a path to grow beyond what is rendered directly in the Razor UI:
- additional runtime or business metrics can be added incrementally without redesigning the monitoring page
- Grafana dashboards can be built on top of the exported metrics
- alerting and long-term trend analysis become much easier
- future monitoring extensions can be consumed both by FWO itself and by external operations tooling

In other words, this PR not only improves the current monitoring page, it also lays the groundwork for broader observability in the platform.

**Follow-up**
- Add/update unit tests for the new monitoring provider and UI behavior
- Decide whether the remaining Linux-only host values such as load average and swap should stay visible or be removed in a later cleanup
- Consider expanding Prometheus coverage with additional service and workflow metrics as future needs become clearer

## Middleware /metrics
<img width="1709" height="929" alt="brave_u7flcdtsRR" src="https://github.com/user-attachments/assets/56d6fb67-c0f6-469c-b9d8-6242336833a5" />

## UI /metrics
<img width="1709" height="929" alt="brave_WB9zYXLArF" src="https://github.com/user-attachments/assets/72150180-75ce-4a90-b1e6-2309d30cb224" />

## Prometheus + Grafana
<img width="1917" height="1447" alt="image" src="https://github.com/user-attachments/assets/bf7417e1-8fa0-45b6-aaa0-e789b7f951ea" />

---

## API Endpoint
<img width="1567" height="1150" alt="brave_EGK1B2oVnQ" src="https://github.com/user-attachments/assets/786da714-626c-4a86-af2a-1a7e70024664" />

---

https://github.com/user-attachments/assets/fb5bbb12-b194-4865-b53d-6790b2b064b9

