### PR TITLE
fix(ui): role selection during rsb fetch for app rule report

### DIFF
--- a/roles/lib/files/FWO.Api.Client/ApiConnectionRoleScopeExtensions.cs
+++ b/roles/lib/files/FWO.Api.Client/ApiConnectionRoleScopeExtensions.cs
@@ -107,6 +107,15 @@ namespace FWO.Api.Client
             apiConnection.SetBestRole(user, GetReportRoles(reportType));
         }
 
+        /// <summary>
+        /// Runs an API operation with the best available role for the given report type.
+        /// </summary>
+        public static Task<TResult> RunWithBestRoleForReport<TResult>(this ApiConnection apiConnection,
+            ClaimsPrincipal user, ReportType reportType, Func<Task<TResult>> action)
+        {
+            return apiConnection.RunWithBestRole(user, GetReportRoles(reportType), action);
+        }
+
         private static List<string> GetReportRoles(ReportType reportType)
         {
             if (reportType == ReportType.Owners || reportType.IsComplianceReport())

--- a/roles/tests-unit/files/FWO.Test/ApiConnectionRoleScopeExtensionsTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ApiConnectionRoleScopeExtensionsTest.cs
@@ -9,6 +9,8 @@ namespace FWO.Test
     [TestFixture]
     internal class ApiConnectionRoleScopeExtensionsTest
     {
+        private static readonly List<string> AppRulesRoles = [Roles.Admin, Roles.Modeller, Roles.Recertifier, Roles.Auditor];
+
         [Test]
         public async Task RunWithNamedRoleScopeUsesExpectedRoles()
         {
@@ -64,6 +66,24 @@ namespace FWO.Test
                 Roles.Recertifier, Roles.Auditor]);
             AssertReportRoles(ReportType.Undefined, [Roles.ReporterViewAll, Roles.Reporter, Roles.Modeller,
                 Roles.Recertifier, Roles.Admin, Roles.Auditor, Roles.FwAdmin]);
+        }
+
+        [Test]
+        public async Task RunWithBestRoleForReportUsesAppRulesRoleAndSwitchesBack()
+        {
+            TrackingApiConnection connection = new();
+            ClaimsPrincipal user = CreateUser(Roles.Modeller);
+
+            await connection.RunWithBestRoleForReport(user, ReportType.AppRules, async () =>
+            {
+                Assert.That(connection.ActiveRole, Is.EqualTo(Roles.Modeller));
+                await Task.CompletedTask;
+                return true;
+            });
+
+            Assert.That(connection.LastTargetRoles, Is.EqualTo(AppRulesRoles));
+            Assert.That(connection.ActiveRole, Is.Empty);
+            Assert.That(connection.SwitchBackCount, Is.EqualTo(1));
         }
 
         private static async Task AssertRoleScope(ClaimsPrincipal user,

--- a/roles/tests-unit/files/FWO.Test/UiReportExportTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiReportExportTest.cs
@@ -7,8 +7,11 @@ using FWO.Report;
 using FWO.Report.Filter;
 using FWO.Ui.Pages.Reporting;
 using FWO.Ui.Services;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
+using System.Reflection;
+using System.Security.Claims;
 using System.Text;
 
 namespace FWO.Test
@@ -41,6 +44,42 @@ namespace FWO.Test
             public override string ExportToHtml()
             {
                 return GenerateHtmlFrameBase("Title", "", DateTime.Parse("2026-01-01T00:00:00Z"), new StringBuilder("<p>body</p>"));
+            }
+
+            public override string SetDescription()
+            {
+                return "";
+            }
+        }
+
+        private sealed class AppRulesExportTestReport() : ReportBase(new DynGraphqlQuery(""), new SimulatedUserConfig(), ReportType.AppRules)
+        {
+            public string RoleUsedForObjectFetch { get; private set; } = "";
+
+            public override Task Generate(int elementsPerFetch, ApiConnection apiConnection, Func<ReportData, Task> callback, CancellationToken ct)
+            {
+                return Task.CompletedTask;
+            }
+
+            public override async Task<bool> GetObjectsInReport(int objectsPerFetch, ApiConnection apiConnection, Func<ReportData, Task> callback)
+            {
+                RoleUsedForObjectFetch = ((ReportExportTrackingApiConnection)apiConnection).ActiveRole;
+                return await base.GetObjectsInReport(objectsPerFetch, apiConnection, callback);
+            }
+
+            public override string ExportToCsv()
+            {
+                return "";
+            }
+
+            public override string ExportToJson()
+            {
+                return "";
+            }
+
+            public override string ExportToHtml()
+            {
+                return "";
             }
 
             public override string SetDescription()
@@ -96,6 +135,65 @@ namespace FWO.Test
 
             Assert.DoesNotThrow(() =>
                 exportComponent.InvokeAsync(() => downloadPopUp.Instance.OnClose()).GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public async Task GettingObjectsForAppRulesExportUsesModellingRole()
+        {
+            await using BunitContext context = CreateContext();
+            ReportExportTrackingApiConnection apiConnection = new();
+            context.Services.AddSingleton<ApiConnection>(apiConnection);
+            context.Services.AddAuthorizationCore();
+            context.Services.AddSingleton<AuthenticationStateProvider>(new ReportExportAuthStateProvider(Roles.Modeller));
+            AppRulesExportTestReport report = new();
+            IRenderedComponent<ReportExport> exportComponent = context.Render<CascadingAuthenticationState>(parameters => parameters
+                .AddChildContent<ReportExport>(child => child.Add(p => p.ReportToExport, report)))
+                .FindComponent<ReportExport>();
+
+            MethodInfo getReportObjectsForExport = typeof(ReportExport).GetMethod("GetReportObjectsForExport", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            await exportComponent.InvokeAsync(async () => await (Task)getReportObjectsForExport.Invoke(exportComponent.Instance, null)!);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(report.RoleUsedForObjectFetch, Is.EqualTo(Roles.Modeller));
+                Assert.That(apiConnection.ActiveRole, Is.Empty);
+                Assert.That(apiConnection.SwitchBackCount, Is.EqualTo(1));
+            });
+        }
+
+        private sealed class ReportExportAuthStateProvider(string role) : AuthenticationStateProvider
+        {
+            private readonly ClaimsPrincipal principal = new(new ClaimsIdentity(new List<Claim> { new(ClaimTypes.Role, role) }, "test", ClaimTypes.Name, ClaimTypes.Role));
+
+            public override Task<AuthenticationState> GetAuthenticationStateAsync()
+            {
+                return Task.FromResult(new AuthenticationState(principal));
+            }
+        }
+
+        private sealed class ReportExportTrackingApiConnection : SimulatedApiConnection
+        {
+            private readonly Stack<string> previousRoles = new();
+
+            public string ActiveRole { get; private set; } = "";
+            public int SwitchBackCount { get; private set; }
+
+            public override void SetBestRole(ClaimsPrincipal user, List<string> targetRoleList)
+            {
+                SetRole(targetRoleList.First(user.IsInRole));
+            }
+
+            public override void SetRole(string role)
+            {
+                previousRoles.Push(ActiveRole);
+                ActiveRole = role;
+            }
+
+            public override void SwitchBack()
+            {
+                SwitchBackCount++;
+                ActiveRole = previousRoles.TryPop(out string? previousRole) ? previousRole : "";
+            }
         }
     }
 }

--- a/roles/ui/files/FWO.UI/Pages/Reporting/ReportExport.razor
+++ b/roles/ui/files/FWO.UI/Pages/Reporting/ReportExport.razor
@@ -132,6 +132,9 @@
 @code
 {
     [CascadingParameter]
+    private Task<AuthenticationState>? authenticationStateTask { get; set; }
+
+    [CascadingParameter]
     Action<Exception?, string, string, bool> DisplayMessageInUi { get; set; } = DefaultInit.DoNothing;
 
     [Parameter]
@@ -210,7 +213,7 @@
                 {
                     if (!ReportToExport.GotObjectsInReport)
                     {
-                        await ReportToExport.GetObjectsInReport(int.MaxValue, apiConnection, _ => Task.CompletedTask);
+                        await GetReportObjectsForExport();
                     }
 
                     ConvertToHtml();
@@ -251,6 +254,40 @@
         {
             DisplayMessageInUi(null, userConfig.GetText("export_report"), userConfig.GetText("E1002"), true);
         }
+    }
+
+    /// <summary>
+    /// Gets all report objects using the role required by App Rules reports when an authentication
+    /// state is available.
+    /// </summary>
+    private async Task GetReportObjectsForExport()
+    {
+        if (ReportToExport == null)
+        {
+            return;
+        }
+
+        if (authenticationStateTask == null || ReportToExport.ReportType != ReportType.AppRules)
+        {
+            await FetchReportObjects();
+            return;
+        }
+
+        AuthenticationState authenticationState = await authenticationStateTask;
+        await apiConnection.RunWithBestRoleForReport(authenticationState.User, ReportToExport.ReportType,
+            async () =>
+            {
+                await FetchReportObjects();
+                return true;
+            });
+    }
+
+    /// <summary>
+    /// Gets all objects needed by the report export.
+    /// </summary>
+    private Task FetchReportObjects()
+    {
+        return ReportToExport!.GetObjectsInReport(int.MaxValue, apiConnection, _ => Task.CompletedTask);
     }
 
     private async Task ConvertToPdf()

--- a/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
+++ b/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
@@ -490,12 +490,13 @@
         }
 
         bool gotAllObjects;
-        if (authenticationStateTask == null)
+        if (authenticationStateTask == null || CurrentReport is not ReportAppRules)
         {
             gotAllObjects = await FetchReportObjects();
         }
         else
         {
+            // for ReportAppRules we need to make sure we use the correct role (esp. modeller instead of reporter)
             AuthenticationState authenticationState = await authenticationStateTask;
             gotAllObjects = await apiConnection.RunWithBestRoleForReport(authenticationState.User,
                 CurrentReport!.ReportType, FetchReportObjects);

--- a/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
+++ b/roles/ui/files/FWO.UI/Shared/RightSidebar.razor
@@ -109,6 +109,9 @@
 @code
 {
     [CascadingParameter]
+    private Task<AuthenticationState>? authenticationStateTask { get; set; }
+
+    [CascadingParameter]
     Action<Exception?, string, string, bool> DisplayMessageInUi { get; set; } = DefaultInit.DoNothing;
 
     [Parameter]
@@ -462,27 +465,41 @@
             queryVars[QueryVar.ImportIdEnd] = importEnd;
         }
 
-        bool gotAllObjects = await CurrentReport!.GetObjectsForManagementInReport(
-            queryVars, objType,
-            userConfig.AutoFillRightSidebar ? int.MaxValue : userConfig.MaxInitialFetchesRightSidebar,
-            apiConnection,
-            async managementsUpdate =>
-            {
-                var mgtUpdated = managementsUpdate.ManagementData.FirstOrDefault(m => m.Id == id);
-                if (mgtUpdated != null)
+        async Task<bool> FetchReportObjects()
+        {
+            return await CurrentReport!.GetObjectsForManagementInReport(
+                queryVars, objType,
+                userConfig.AutoFillRightSidebar ? int.MaxValue : userConfig.MaxInitialFetchesRightSidebar,
+                apiConnection,
+                async managementsUpdate =>
                 {
-                    if (objType == ObjCategory.all || objType == ObjCategory.nobj)
-                        mgtReport.ReportObjects = mgtUpdated.ReportObjects;
+                    var mgtUpdated = managementsUpdate.ManagementData.FirstOrDefault(m => m.Id == id);
+                    if (mgtUpdated != null)
+                    {
+                        if (objType == ObjCategory.all || objType == ObjCategory.nobj)
+                            mgtReport.ReportObjects = mgtUpdated.ReportObjects;
 
-                    if (objType == ObjCategory.all || objType == ObjCategory.nsrv)
-                        mgtReport.ReportServices = mgtUpdated.ReportServices;
+                        if (objType == ObjCategory.all || objType == ObjCategory.nsrv)
+                            mgtReport.ReportServices = mgtUpdated.ReportServices;
 
-                    if (objType == ObjCategory.all || objType == ObjCategory.user)
-                        mgtReport.ReportUsers = mgtUpdated.ReportUsers;
-                }
-                await hasChangedCallback();
-            }
-        );
+                        if (objType == ObjCategory.all || objType == ObjCategory.user)
+                            mgtReport.ReportUsers = mgtUpdated.ReportUsers;
+                    }
+                    await hasChangedCallback();
+                });
+        }
+
+        bool gotAllObjects;
+        if (authenticationStateTask == null)
+        {
+            gotAllObjects = await FetchReportObjects();
+        }
+        else
+        {
+            AuthenticationState authenticationState = await authenticationStateTask;
+            gotAllObjects = await apiConnection.RunWithBestRoleForReport(authenticationState.User,
+                CurrentReport!.ReportType, FetchReportObjects);
+        }
 
         if (!gotAllObjects)
         {


### PR DESCRIPTION
## Fix App Rules sidebar role scope

### Summary

Ensure the App Rules right-sidebar fetch uses the same explicit report role as initial report generation.

### Problem

`GraphQlApiConnection.roleStack` is stored in an `AsyncLocal`. The initial App Rules report generation and the later right-sidebar fetch run in different asynchronous UI execution contexts. Therefore, the `modeller` role selected during report generation is not present when the sidebar requests detailed management data.

This caused the second call to `ReportAppRules.GetAppServers` to run without the expected explicit `modeller` role.

### Change

- Added `RunWithBestRoleForReport`, a scoped helper that selects the best permitted role for a report type and restores the previous role afterwards.
- Updated `RightSidebar` to obtain the authenticated user and run detailed report-object fetching inside that role scope.
- Added a focused unit test confirming App Rules selects `modeller` and switches back after the scoped operation.

### Result

For an App Rules report opened by a modeller, both the initial report generation and the right-sidebar detail fetch execute with `roleStack = ["modeller"]` during their respective API calls.

fixes #5101 