### PR TITLE
fix sticky header

### DIFF
--- a/roles/tests-unit/files/FWO.Test/UiPopUpStyleTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiPopUpStyleTest.cs
@@ -14,6 +14,7 @@ namespace FWO.Test
         private const string kPopUpCssResource = "FWO.Test.PopUp.css";
         private const string kSiteCssResource = "FWO.Test.site.css";
         private const string kModalMarginVariable = "--bs-custom-modal-margin-top";
+        private const string kModalPaddingVariable = "--fwo-modal-content-padding-top";
         private const int knMilliseconds = 1000;
 
         /// <summary>
@@ -67,6 +68,51 @@ namespace FWO.Test
                 $"'{kModalMarginVariable}' is used without being defined, so the declaration using it has no effect.");
         }
 
+        /// <summary>
+        /// The .modal-content box is the scroll container of a popup and its top padding belongs to the
+        /// scrollport. The sticky table headers have to compensate it, so the padding has to stay
+        /// readable for them through a custom property instead of being written as a literal length.
+        /// </summary>
+        [Test]
+        public void PopUpCss_PublishesTheTopPaddingOfTheScrollContainer()
+        {
+            string popUpCss = ReadStyleSheetWithoutComments(kPopUpCssResource);
+
+            Match scrollContainerRule = ModalContentRuleRegex().Match(popUpCss);
+            Assert.That(scrollContainerRule.Success, Is.True, "The rule of the popup scroll container is missing.");
+
+            string declarations = NormalizeWhitespace(scrollContainerRule.Groups["body"].Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(declarations, Does.Contain($"{kModalPaddingVariable}:"),
+                    $"'{kModalPaddingVariable}' has to define the top padding of the popup scroll container.");
+                Assert.That(declarations, Does.Contain($"padding: var({kModalPaddingVariable})"),
+                    "The top padding of the popup scroll container has to be taken from its custom property.");
+            });
+        }
+
+        /// <summary>
+        /// A sticky offset is resolved against the content box of the scroll container: without
+        /// compensating the top padding of the popup, the rows scroll through the gap above the header.
+        /// </summary>
+        [Test]
+        public void SiteCss_CompensatesThePopUpPaddingForStickyTableHeaders()
+        {
+            string siteCss = ReadStyleSheetWithoutComments(kSiteCssResource);
+
+            Match stickyHeaderRule = ModalStickyHeaderRuleRegex().Match(siteCss);
+            Assert.That(stickyHeaderRule.Success, Is.True, "The sticky header rule of the popups is missing.");
+
+            string declarations = NormalizeWhitespace(stickyHeaderRule.Groups["body"].Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(declarations, Does.Contain($"var({kModalPaddingVariable}, "),
+                    $"The sticky headers of the popups have to compensate '{kModalPaddingVariable}' with a fallback, "
+                    + "because a custom property without one makes the whole declaration invalid if it is removed.");
+                Assert.That(declarations, Does.Contain("-1px"), "The sticky headers lost their chrome offset.");
+            });
+        }
+
         private static string ReadStyleSheetWithoutComments(string resourceName)
         {
             Assembly assembly = typeof(UiPopUpStyleTest).Assembly;
@@ -89,6 +135,12 @@ namespace FWO.Test
 
         [GeneratedRegex(@"\.custom-modal-center\s*\{(?<body>[^}]*)\}", RegexOptions.None, knMilliseconds)]
         private static partial Regex CenterRuleRegex();
+
+        [GeneratedRegex(@"\.modal-content\s*\{(?<body>[^}]*)\}", RegexOptions.None, knMilliseconds)]
+        private static partial Regex ModalContentRuleRegex();
+
+        [GeneratedRegex(@"\.modal-content\s+\.sticky-header\s+thead\s*\{(?<body>[^}]*)\}", RegexOptions.None, knMilliseconds)]
+        private static partial Regex ModalStickyHeaderRuleRegex();
 
         [GeneratedRegex(@"\s+", RegexOptions.None, knMilliseconds)]
         private static partial Regex WhitespaceRegex();

--- a/roles/ui/files/FWO.UI/Shared/PopUp.razor.css
+++ b/roles/ui/files/FWO.UI/Shared/PopUp.razor.css
@@ -1,6 +1,8 @@
 /* !! ATTENTION: The .modal-content box is the scroll container of a popup. Do not add an
     offset to its content classes without checking the sticky headers of the tables inside
     the popups (see .sticky-header in site.css) !!
+    Its top padding is published as --fwo-modal-content-padding-top, because the sticky
+    headers have to compensate it. Change the padding only through that variable.
 */
 
 /* !! ATTENTION: Never center the modal with a CSS transform. A transformed element becomes
@@ -96,7 +98,8 @@
     padding-right: 1em;
 }
 .modal-content {
-    padding: 2em 2em 0 2em;
+    --fwo-modal-content-padding-top: 2em;
+    padding: var(--fwo-modal-content-padding-top) 2em 0 2em;
     background-color: rgba(255, 255, 255, 1);
     overflow-y: auto;
     /*overflow-x: hidden;*/    

--- a/roles/ui/files/FWO.UI/wwwroot/css/site.css
+++ b/roles/ui/files/FWO.UI/wwwroot/css/site.css
@@ -540,8 +540,14 @@ div.modal-body > * > div.table-responsive {
     overflow-x: inherit;
 }
 
-/* No modal specific sticky offset needed: the scroll container of a table in a popup is
-    the .modal-content box itself, so the offset of the generic .sticky-header rule applies. */
+/* The scroll container of a table in a popup is the .modal-content box itself. A sticky offset is
+    resolved against the content box of the scroll container, so a header pinned at the generic
+    top: -1px would come to rest below the top padding of the popup and the rows would scroll
+    through the gap above it. Compensating that padding pins the header to the top edge of the popup.
+    The fallback keeps the declaration valid (and the header sticky) if the variable ever goes away. */
+div.modal-content .sticky-header thead {
+    top: calc(-1px - var(--fwo-modal-content-padding-top, 0px));
+}
 
 .small-helptext {
     color: hsl(39, 100%, 50%);


### PR DESCRIPTION
## Root cause
Two separate things collided, and neither was quite what it looked like:

Luca's variable was already dead before PR #5074. --bs-custom-modal-margin-top was only still defined on .custom-modal-fs; commit d7fd99bd5 ("fix modal size and scrolling", 31.07.) had removed it from xl/lg/md/sm/xs together with their margin-top. A var() without fallback that is undefined makes the whole declaration invalid → top: auto → the sticky headers in all non-fullscreen popups silently didn't stick at all. So PR #5074 didn't break those; it made them sticky again.

But it made them stick in the wrong place. .modal-content is the scroll container and has padding: 2em 2em 0 2em. A sticky offset is resolved against the content box of the scroll container, so top: -1px pins the header 32px below the top edge of the popup — and the rows keep scrolling visibly through that 32px gap above it. That is the ugly picture Luca sent.

Reproduced with the real stylesheets in headless Chrome — before vs. after: [popup-250.png](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/tmp/claude-1000/-home-tim-dev-fwo-tim/089d3444-d0d0-43bc-b38a-b37359a88b3a/scratchpad/repro/popup-250.png) vs [fixed-250.png](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/tmp/claude-1000/-home-tim-dev-fwo-tim/089d3444-d0d0-43bc-b38a-b37359a88b3a/scratchpad/repro/fixed-250.png).

## Fix
Instead of resurrecting the hand-maintained margin variable, the padding of the scroll container is now published where it is defined, and the sticky header subtracts it:

[PopUp.razor.css:100-102](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/roles/ui/files/FWO.UI/Shared/PopUp.razor.css#L100-L102) — --fwo-modal-content-padding-top: 2em and padding: var(--fwo-modal-content-padding-top) 2em 0 2em
[site.css:543-550](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/roles/ui/files/FWO.UI/wwwroot/css/site.css#L543-L550) — div.modal-content .sticky-header thead { top: calc(-1px - var(--fwo-modal-content-padding-top, 0px)); }
The 0px fallback is deliberate: it is exactly the trap that killed the old rule — if the variable ever disappears the header stays sticky instead of silently dropping to top: auto.

No transform is reintroduced, so the dropdown fix stays intact. Verified in the same repro that a position: fixed dropdown menu still lands exactly on its input's getBoundingClientRect() coordinates (expected=344,-47 actual=344,-47) and paints above the sticky header: [combo-lg-0.png](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/tmp/claude-1000/-home-tim-dev-fwo-tim/089d3444-d0d0-43bc-b38a-b37359a88b3a/scratchpad/repro/combo-lg-0.png). Fullscreen popups also check out: [combo-fs-250.png](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/tmp/claude-1000/-home-tim-dev-fwo-tim/089d3444-d0d0-43bc-b38a-b37359a88b3a/scratchpad/repro/combo-fs-250.png).

## Tests
Two tests added to [UiPopUpStyleTest.cs](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/roles/tests-unit/files/FWO.Test/UiPopUpStyleTest.cs) (the stylesheets are already embedded into the test assembly, so nothing reads foreign repo files at runtime): one asserts the popup publishes its top padding as a custom property, one asserts the sticky rule compensates it with a fallback. All 8 popup tests pass; I mutation-checked the second one by putting top: -1px back — it fails as intended.

Two notes: the changes are unstaged on fix/dotnet-install-redhat-3, which is otherwise about the dotnet installer — you probably want them on their own branch. And non-modal tables were never affected: there the scrollport is the viewport, where the padding of .content plays no role.