### PR TITLE
Fix/modal autoscale

### DIFF
--- a/roles/tests-unit/files/FWO.Test/UiPopUpComponentTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiPopUpComponentTest.cs
@@ -66,6 +66,32 @@ namespace FWO.Test
         }
 
         /// <summary>
+        /// Every size marks its content box with its own class. The auto size needs it as well: without
+        /// that class its content grows past the viewport and pushes the footer out of reach.
+        /// </summary>
+        [Test]
+        public async Task SizeClassContent_KeepsSizeSpecificContentClass()
+        {
+            await using BunitContext context = new();
+            Dictionary<PopupSize, string> expectedClasses = new()
+            {
+                { PopupSize.Auto, "custom-modal-content-auto" },
+                { PopupSize.FullScreen, "custom-modal-content-fs" },
+                { PopupSize.XLarge, "custom-modal-content-xl" },
+                { PopupSize.Large, "custom-modal-content-lg" },
+                { PopupSize.Medium, "custom-modal-content-md" },
+                { PopupSize.Small, "custom-modal-content-sm" },
+                { PopupSize.XSmall, "custom-modal-content-xs" }
+            };
+
+            foreach (KeyValuePair<PopupSize, string> expectedClass in expectedClasses)
+            {
+                Assert.That(RenderContentClass(context, expectedClass.Key).Split(' '), Contains.Item(expectedClass.Value),
+                    $"The content box of popup size {expectedClass.Key} lost its size specific class.");
+            }
+        }
+
+        /// <summary>
         /// The footer is rendered as a sibling of the scrollable content for all sizes but the smallest one.
         /// </summary>
         [Test]
@@ -84,6 +110,11 @@ namespace FWO.Test
         private static string RenderDialogClass(BunitContext context, PopupSize size)
         {
             return RenderPopUp(context, size).Find(".modal-open > div").GetAttribute("class") ?? "";
+        }
+
+        private static string RenderContentClass(BunitContext context, PopupSize size)
+        {
+            return RenderPopUp(context, size).Find(".modal-content").GetAttribute("class") ?? "";
         }
 
         private static IRenderedComponent<PopUp> RenderPopUp(BunitContext context, PopupSize size)

--- a/roles/tests-unit/files/FWO.Test/UiPopUpStyleTest.cs
+++ b/roles/tests-unit/files/FWO.Test/UiPopUpStyleTest.cs
@@ -51,6 +51,70 @@ namespace FWO.Test
         }
 
         /// <summary>
+        /// An auto sized popup has to leave room for its footer. Reserving that room with a pixel constant
+        /// fails as soon as the footer wraps, so the height is distributed by a column flex box instead:
+        /// the footer keeps its intrinsic height and the content box takes whatever is left of the viewport.
+        /// </summary>
+        [Test]
+        public void PopUpCss_DistributesTheAutoSizedPopupWithAFlexBox()
+        {
+            string popUpCss = ReadStyleSheetWithoutComments(kPopUpCssResource);
+
+            Match modalRule = AutoModalRuleRegex().Match(popUpCss);
+            Match contentRule = AutoContentRuleRegex().Match(popUpCss);
+            Assert.Multiple(() =>
+            {
+                Assert.That(modalRule.Success, Is.True, "The class of the auto sized modal is missing.");
+                Assert.That(contentRule.Success, Is.True, "The content class of the auto sized modal is missing.");
+            });
+
+            string modalDeclarations = NormalizeWhitespace(modalRule.Groups["body"].Value);
+            string contentDeclarations = NormalizeWhitespace(contentRule.Groups["body"].Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(modalDeclarations, Does.Contain("display: flex"));
+                Assert.That(modalDeclarations, Does.Contain("flex-direction: column"));
+                Assert.That(contentDeclarations, Does.Contain("flex: 1 1 auto"));
+                Assert.That(contentDeclarations, Does.Contain("min-height: 0"),
+                    "Without min-height: 0 the content box keeps its automatic minimum size and overflows the modal.");
+                Assert.That(contentDeclarations, Does.Contain("scrollbar-gutter: stable"),
+                    "The modal is only as wide as its content, so the scrollbar needs a reserved gutter.");
+                Assert.That(PixelConstantRegex().IsMatch(contentDeclarations), Is.False,
+                    "The room for the footer must not be reserved with a pixel constant.");
+            });
+        }
+
+        /// <summary>
+        /// The content box of an auto sized popup scrolls, so its header has to be pinned to keep the title
+        /// and the close button reachable. It shares the scroll container with the sticky headers of the
+        /// tables inside the popup and therefore has to be stacked above them.
+        /// </summary>
+        [Test]
+        public void PopUpCss_PinsTheHeaderOfTheAutoSizedPopupAboveTheStickyTableHeaders()
+        {
+            string popUpCss = ReadStyleSheetWithoutComments(kPopUpCssResource);
+            string siteCss = ReadStyleSheetWithoutComments(kSiteCssResource);
+
+            Match headerRule = AutoModalHeaderRuleRegex().Match(popUpCss);
+            Match tableHeaderRule = StickyTableHeaderRuleRegex().Match(siteCss);
+            Assert.Multiple(() =>
+            {
+                Assert.That(headerRule.Success, Is.True, "The header of the auto sized modal is not pinned.");
+                Assert.That(tableHeaderRule.Success, Is.True, "The sticky table header rule is missing.");
+            });
+
+            string headerDeclarations = NormalizeWhitespace(headerRule.Groups["body"].Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(headerDeclarations, Does.Contain("position: sticky"));
+                Assert.That(headerDeclarations, Does.Contain("background-color"),
+                    "The scrolling content would shine through a transparent header.");
+                Assert.That(ReadZIndex(headerDeclarations), Is.GreaterThan(ReadZIndex(NormalizeWhitespace(tableHeaderRule.Groups["body"].Value))),
+                    "The pinned modal header has to stay above the sticky table headers inside the popup.");
+            });
+        }
+
+        /// <summary>
         /// A custom property that is referenced but never defined makes the whole declaration invalid,
         /// which silently disabled the sticky table headers inside the popups before.
         /// </summary>
@@ -81,6 +145,13 @@ namespace FWO.Test
             return WhitespaceRegex().Replace(declarations, " ");
         }
 
+        private static int ReadZIndex(string declarations)
+        {
+            Match zIndex = ZIndexRegex().Match(declarations);
+            Assert.That(zIndex.Success, Is.True, $"No z-index found in '{declarations}'.");
+            return int.Parse(zIndex.Groups["value"].Value);
+        }
+
         [GeneratedRegex(@"/\*.*?\*/", RegexOptions.Singleline, knMilliseconds)]
         private static partial Regex CommentRegex();
 
@@ -89,6 +160,24 @@ namespace FWO.Test
 
         [GeneratedRegex(@"\.custom-modal-center\s*\{(?<body>[^}]*)\}", RegexOptions.None, knMilliseconds)]
         private static partial Regex CenterRuleRegex();
+
+        [GeneratedRegex(@"\.custom-modal-auto\s*\{(?<body>[^}]*)\}", RegexOptions.None, knMilliseconds)]
+        private static partial Regex AutoModalRuleRegex();
+
+        [GeneratedRegex(@"\.custom-modal-content-auto\s*\{(?<body>[^}]*)\}", RegexOptions.None, knMilliseconds)]
+        private static partial Regex AutoContentRuleRegex();
+
+        [GeneratedRegex(@"\.custom-modal-content-auto\s+\.modal-header\s*\{(?<body>[^}]*)\}", RegexOptions.None, knMilliseconds)]
+        private static partial Regex AutoModalHeaderRuleRegex();
+
+        [GeneratedRegex(@"\.sticky-header\s+thead\s*\{(?<body>[^}]*)\}", RegexOptions.None, knMilliseconds)]
+        private static partial Regex StickyTableHeaderRuleRegex();
+
+        [GeneratedRegex(@"z-index\s*:\s*(?<value>-?\d+)", RegexOptions.None, knMilliseconds)]
+        private static partial Regex ZIndexRegex();
+
+        [GeneratedRegex(@"\d+\s*px", RegexOptions.None, knMilliseconds)]
+        private static partial Regex PixelConstantRegex();
 
         [GeneratedRegex(@"\s+", RegexOptions.None, knMilliseconds)]
         private static partial Regex WhitespaceRegex();

--- a/roles/ui/files/FWO.UI/Shared/PopUp.razor
+++ b/roles/ui/files/FWO.UI/Shared/PopUp.razor
@@ -82,7 +82,7 @@
     {
         switch (Size)
         {
-            case PopupSize.Auto: return ""; // Auto size doesn't have a specific class for content and should just take the size of its content
+            case PopupSize.Auto: return "custom-modal-content-auto"; //custom-modal-content-auto sets a max-height so content can't escape view
             case PopupSize.FullScreen: return "custom-modal-content-fs";
             case PopupSize.XLarge: return "custom-modal-content-xl";
             case PopupSize.Large: return "custom-modal-content-lg ";

--- a/roles/ui/files/FWO.UI/Shared/PopUp.razor
+++ b/roles/ui/files/FWO.UI/Shared/PopUp.razor
@@ -82,7 +82,7 @@
     {
         switch (Size)
         {
-            case PopupSize.Auto: return "custom-modal-content-auto"; //custom-modal-content-auto sets a max-height so content can't escape view
+            case PopupSize.Auto: return "custom-modal-content-auto"; // Auto sized content grows with its content, but has to stop at the viewport so the footer stays reachable
             case PopupSize.FullScreen: return "custom-modal-content-fs";
             case PopupSize.XLarge: return "custom-modal-content-xl";
             case PopupSize.Large: return "custom-modal-content-lg ";

--- a/roles/ui/files/FWO.UI/Shared/PopUp.razor.css
+++ b/roles/ui/files/FWO.UI/Shared/PopUp.razor.css
@@ -42,6 +42,10 @@
     height: 40dvh;
 }
 
+.custom-modal-content-auto {
+    max-height: calc(100dvh - 95px);
+}
+
 .custom-modal-auto {
     /* fit-content keeps the modal as wide as its content while staying centerable */
     width: fit-content;

--- a/roles/ui/files/FWO.UI/Shared/PopUp.razor.css
+++ b/roles/ui/files/FWO.UI/Shared/PopUp.razor.css
@@ -42,15 +42,41 @@
     height: 40dvh;
 }
 
-.custom-modal-content-auto {
-    max-height: calc(100dvh - 95px);
-}
-
 .custom-modal-auto {
     /* fit-content keeps the modal as wide as its content while staying centerable */
     width: fit-content;
     min-width: 60vw;
     max-width: 100vw;
+    /* A column flex box distributes the height capped by .custom-modal-center: the footer keeps
+        its intrinsic height and the content box gets whatever is left. Never reserve the footer
+        height with a constant here, it does not survive a wrapping footer. */
+    display: flex;
+    flex-direction: column;
+}
+
+.custom-modal-content-auto {
+    /* Takes the height left over by the footer. min-height: 0 overrides the automatic minimum
+        size of a flex item, without it the content box would refuse to shrink and overflow. */
+    flex: 1 1 auto;
+    min-height: 0;
+    /* The modal is only as wide as its content, so a scrollbar appearing on the content box
+        would cover its right edge instead of widening the modal. */
+    scrollbar-gutter: stable;
+}
+
+.custom-modal-auto > .custom-modal-footer {
+    /* The footer is the fixed part of the layout, only the content box above it may shrink. */
+    flex: 0 0 auto;
+}
+
+/* Keeps the title and the close button reachable while the content below them scrolls.
+    The z-index has to stay above the sticky table headers (.sticky-header thead in site.css),
+    the background is needed because the content scrolls underneath the header. */
+.custom-modal-content-auto .modal-header {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background-color: rgba(255, 255, 255, 1);
 }
 
 /* Centers the modal in the viewport without a transform (see attention note above):


### PR DESCRIPTION
## Fixes contained here
### F1 (medium) — magic 95px reserve → flex layout. [PopUp.razor.css:45-68](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/roles/ui/files/FWO.UI/Shared/PopUp.razor.css#L45-L68). 
.custom-modal-auto is now display: flex; flex-direction: column, so the height cap that .custom-modal-center already imposes (max-height: 100dvh) is distributed instead of guessed: .custom-modal-content-auto gets flex: 1 1 auto; min-height: 0 (the min-height overrides the automatic minimum size that would otherwise stop it shrinking), and .custom-modal-auto > .custom-modal-footer gets flex: 0 0 auto. A wrapping footer now takes its height off the content box rather than off the viewport.

### F2 (low) — constant duplication. Resolved by F1
calc(100dvh - 95px) is gone from the Auto path. I deliberately left .custom-modal-content-fs alone — it's pre-existing and not touched by this PR — so the constant still exists once, in the full-screen rule.

### F3 (low) — scrollbar covers the right edge. scrollbar-gutter: stable on .custom-modal-content-auto.

### F4 (low) — no test guard. Three new tests, each verified to fail when I mutated the code back:

SizeClassContent_KeepsSizeSpecificContentClass in [UiPopUpComponentTest.cs:68](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/roles/tests-unit/files/FWO.Test/UiPopUpComponentTest.cs#L68) — asserts the content class for every size, so restoring return "" regresses loudly.
PopUpCss_DistributesTheAutoSizedPopupWithAFlexBox in [UiPopUpStyleTest.cs:53](vscode-webview://0korbe7s2s21d76c7nbrd1e9t20gi1b0guvm30ia8c54v6dra6rq/roles/tests-unit/files/FWO.Test/UiPopUpStyleTest.cs#L53) — asserts the flex wiring and the gutter, and asserts no pixel constant appears in the rule.
PopUpCss_PinsTheHeaderOfTheAutoSizedPopupAboveTheStickyTableHeaders — parses the z-index out of both stylesheets and asserts the modal header outranks .sticky-header thead.

### F5 (low) — header scrolls out of view. I did not move the cap to .modal-body: 
site.css line 544 documents that .modal-content has to stay the scroll container for the tables' sticky headers. Instead .custom-modal-content-auto .modal-header is position: sticky; top: 0; z-index: 2 with an opaque background (needed because content scrolls underneath it, and the z-index because it shares the scrollport with the z-index: 1 table headers).
