### PR TITLE
ci: auto-sync ruff required-version on dependabot PRs

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -27,7 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_ruff_sync_pat: ${{ steps.ruff-sync-pat.outputs.present }}
     steps:
+      - name: Check for ruff sync PAT
+        id: ruff-sync-pat
+        run: echo "present=${{ secrets.RUFF_SYNC_PAT != '' }}" >> "$GITHUB_OUTPUT"
+
       - name: Select matrix based on event
         id: set-matrix
         env:
@@ -83,6 +88,49 @@ jobs:
           echo "::notice::full=$full, selected $combos matrix combo(s)"
 
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  sync-ruff-required-version:
+    name: Sync ruff required-version
+    needs: setup
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/pip/') && needs.setup.outputs.has_ruff_sync_pat == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      REQ_FILE: roles/importer/files/importer/requirements.txt
+      PYPROJECT: pyproject.toml
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.RUFF_SYNC_PAT }}
+
+      - name: Sync required-version to pinned ruff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ruff_version="$(sed -n 's/^ruff==\([^[:space:]]*\).*$/\1/p' "$REQ_FILE" | head -1)"
+          if [[ -z "$ruff_version" ]]; then
+            echo "No pinned 'ruff==' entry found in $REQ_FILE, nothing to sync."
+            exit 0
+          fi
+
+          current="$(sed -n 's/^required-version = "\(.*\)"/\1/p' "$PYPROJECT" | head -1)"
+          echo "requirements.txt pins ruff==$ruff_version, pyproject.toml requires \"$current\""
+
+          if [[ "$current" == "$ruff_version" ]]; then
+            echo "required-version already matches, nothing to do."
+            exit 0
+          fi
+
+          sed -i "s/^required-version = \".*\"/required-version = \"$ruff_version\"/" "$PYPROJECT"
+
+          git config user.name "dependabot[bot]"
+          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git add "$PYPROJECT"
+          git commit -m "chore: sync ruff required-version to $ruff_version"
+          git push
 
   test-install:
     needs: setup

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Check for ruff sync app credentials
         id: ruff-sync-app
-        run: echo "present=${{ secrets.FWO_RUFF_SYNC_APP_KEY != '' }}" >> "$GITHUB_OUTPUT"
+        run: echo "present=${{ secrets.FWO_RUFF_SYNC_APP_KEY != '' && vars.FWO_RUFF_SYNC_APP_ID != '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Select matrix based on event
         id: set-matrix

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      has_ruff_sync_pat: ${{ steps.ruff-sync-pat.outputs.present }}
+      has_ruff_sync_app: ${{ steps.ruff-sync-app.outputs.present }}
     steps:
-      - name: Check for ruff sync PAT
-        id: ruff-sync-pat
-        run: echo "present=${{ secrets.RUFF_SYNC_PAT != '' }}" >> "$GITHUB_OUTPUT"
+      - name: Check for ruff sync app credentials
+        id: ruff-sync-app
+        run: echo "present=${{ secrets.FWO_RUFF_SYNC_APP_KEY != '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Select matrix based on event
         id: set-matrix
@@ -92,7 +92,7 @@ jobs:
   sync-ruff-required-version:
     name: Sync ruff required-version
     needs: setup
-    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/pip/') && needs.setup.outputs.has_ruff_sync_pat == 'true'
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/pip/') && needs.setup.outputs.has_ruff_sync_app == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -100,10 +100,17 @@ jobs:
       REQ_FILE: roles/importer/files/importer/requirements.txt
       PYPROJECT: pyproject.toml
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: app-token
+        with:
+          app-id: ${{ vars.FWO_RUFF_SYNC_APP_ID }}
+          private-key: ${{ secrets.FWO_RUFF_SYNC_APP_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.RUFF_SYNC_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Sync required-version to pinned ruff
         shell: bash

--- a/documentation/developer-docs/github/test-install-workflow.md
+++ b/documentation/developer-docs/github/test-install-workflow.md
@@ -66,6 +66,31 @@ with that exact name to exist on every run, including full-matrix
 runs. Other full matrix jobs are labeled with their OS and Python
 version, e.g. `Test install on ubuntu-26.04 with Python 3.10`.
 
+## Ruff required-version sync (Dependabot pip PRs)
+
+Ruff's version is pinned twice: as `ruff==<version>` in
+`roles/importer/files/importer/requirements.txt` and as
+`tool.ruff.required-version` in `pyproject.toml`. If the two drift apart,
+ruff refuses to run and the `python-code-check` job's `ruff check` step
+fails. When Dependabot opens a pip PR that bumps ruff, only the
+`requirements.txt` pin changes.
+
+The `sync-ruff-required-version` job closes that gap automatically. It
+runs only on `pull_request` events from `dependabot[bot]` on a
+`dependabot/pip/*` branch. It reads the pinned ruff version from
+`requirements.txt`, and if `required-version` in `pyproject.toml` differs,
+rewrites it, commits, and pushes the fix back onto the Dependabot branch.
+The job is idempotent — when the two already match, it does nothing.
+
+The push uses a Personal Access Token stored as a **Dependabot** secret
+named `RUFF_SYNC_PAT` (Settings -> Secrets and variables -> Dependabot;
+Dependabot-triggered runs cannot read regular Actions secrets). Scope:
+contents read/write on this repository. A PAT (rather than the default
+`GITHUB_TOKEN`) is required so the sync commit re-triggers this workflow.
+The re-triggered run supersedes the original via the workflow's
+`concurrency` group (keyed on the PR number), so the fresh run — now
+with matching versions — is the one that validates and reports status.
+
 ## Error handling in the matrix-selection script
 
 The script sets `set -euo pipefail` and validates the generated matrix

--- a/documentation/developer-docs/github/test-install-workflow.md
+++ b/documentation/developer-docs/github/test-install-workflow.md
@@ -82,14 +82,22 @@ runs only on `pull_request` events from `dependabot[bot]` on a
 rewrites it, commits, and pushes the fix back onto the Dependabot branch.
 The job is idempotent — when the two already match, it does nothing.
 
-The push uses a Personal Access Token stored as a **Dependabot** secret
-named `RUFF_SYNC_PAT` (Settings -> Secrets and variables -> Dependabot;
-Dependabot-triggered runs cannot read regular Actions secrets). Scope:
-contents read/write on this repository. A PAT (rather than the default
-`GITHUB_TOKEN`) is required so the sync commit re-triggers this workflow.
-The re-triggered run supersedes the original via the workflow's
-`concurrency` group (keyed on the PR number), so the fresh run — now
-with matching versions — is the one that validates and reports status.
+The push is authenticated with a short-lived GitHub App installation
+token minted by `actions/create-github-app-token`, scoped to
+`contents: write` on this repository. An App token (rather than the
+default `GITHUB_TOKEN`) is required so the sync commit re-triggers this
+workflow. The re-triggered run supersedes the original via the workflow's
+`concurrency` group (keyed on the PR number), so the fresh run — now with
+matching versions — is the one that validates and reports status.
+
+The App credentials are supplied as `vars.FWO_RUFF_SYNC_APP_ID` and the
+**Dependabot** secret `FWO_RUFF_SYNC_APP_KEY` (Settings -> Secrets and
+variables -> Dependabot; Dependabot-triggered runs cannot read regular
+Actions secrets, so the private key must live in the Dependabot store).
+The App must be installed on the repository with **Contents: Read and
+write**. When the credentials are absent the `setup` job's
+`has_ruff_sync_app` output is `false` and the job is skipped rather than
+failing.
 
 ## Error handling in the matrix-selection script
 


### PR DESCRIPTION
## Summary

Dependabot pip PRs that bump ruff only change the `ruff==` pin in `roles/importer/files/importer/requirements.txt`. The `tool.ruff.required-version` in `pyproject.toml` then has to be updated by hand to match, or ruff refuses to run and the `python-code-check` job fails.

This adds a `sync-ruff-required-version` job to the existing **FWO Test Install** workflow (rather than a separate workflow, to avoid firing an extra workflow on every PR) that does that sync automatically.

## Behavior

- Runs only on `pull_request` events from `dependabot[bot]` on a `dependabot/pip/*` branch.
- Reads the pinned ruff version from `requirements.txt`; if `required-version` in `pyproject.toml` differs, rewrites it, commits, and pushes the fix back onto the Dependabot branch. Idempotent — a no-op when they already match.
- Pushes with a short-lived **GitHub App installation token** (`actions/create-github-app-token`, scoped to `contents: write`) so the sync commit re-triggers the workflow; the `concurrency` group (keyed on PR number) then supersedes the original run, and the fresh run validates the synced code.
- The job is gated on the App key being present (`has_ruff_sync_app` output from the `setup` job), so it is skipped rather than failing when the credentials are not configured.

## Required setup

Create a GitHub App installed on this repository with **Contents: Read and write**, then provide its credentials to the workflow:

- `vars.FWO_RUFF_SYNC_APP_ID` — the App ID (repository/organization **variable**).
- `FWO_RUFF_SYNC_APP_KEY` — the App private key, stored as a **Dependabot** secret (Settings → Secrets and variables → **Dependabot**). It must live in the Dependabot store, since Dependabot-triggered runs cannot read regular Actions secrets.

A GitHub App (vs. the default `GITHUB_TOKEN`) is required because `GITHUB_TOKEN` pushes do not re-trigger the PR's other checks, and it allows tightly scoping the token to `contents: write` on just this repository.

## Notes

- Documented in `documentation/developer-docs/github/test-install-workflow.md`.
- Takes effect once merged into `develop`; it will not retroactively fix an already-open ruff PR.