### PR TITLE
Report App-Rule: Speed-up + Check if Recertification uses prefilter

### DIFF
--- a/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
+++ b/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
@@ -467,7 +467,7 @@ namespace FWO.Report.Filter
             }
 
             string ruleWherePrefix = RuleWhereStatement[..insertIndex].TrimEnd();
-            string separator = ruleWherePrefix.EndsWith("[") ? "" : ", ";
+            string separator = ruleWherePrefix.EndsWith('[') ? "" : ", ";
             RuleWhereStatement = RuleWhereStatement.Insert(insertIndex, separator + filter);
         }
 

--- a/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
+++ b/roles/lib/files/FWO.Report.Filter/DynGraphqlQuery.cs
@@ -454,6 +454,33 @@ namespace FWO.Report.Filter
             }
         }
 
+        /// <summary>
+        /// Appends an additional rule filter to the generated top-level _and block.
+        /// </summary>
+        public void AddRuleWhereAndFilter(string filter)
+        {
+            int insertIndex = RuleWhereStatement.LastIndexOf(']');
+            if (insertIndex < 0)
+            {
+                RuleWhereStatement += filter;
+                return;
+            }
+
+            string ruleWherePrefix = RuleWhereStatement[..insertIndex].TrimEnd();
+            string separator = ruleWherePrefix.EndsWith("[") ? "" : ", ";
+            RuleWhereStatement = RuleWhereStatement.Insert(insertIndex, separator + filter);
+        }
+
+        /// <summary>
+        /// Rebuilds the legacy rule report query after late-bound filters were added.
+        /// </summary>
+        public void RebuildLegacyRulesQuery(ReportTemplate filter)
+        {
+            string paramString = string.Join(" ", QueryParameters.ToArray());
+            FullQuery = Queries.Compact(RuleReportQueryBuilder.ConstructLegacyRulesQuery(this, paramString, filter));
+            FullQuery = RemoveUnnecessaryWhitespaces(FullQuery);
+        }
+
         private static string ConstructTicketQuery(DynGraphqlQuery query, ReportTemplate filter)
         {
             InitializeTicketQuery(query, filter);

--- a/roles/lib/files/FWO.Report/ReportAppRules.cs
+++ b/roles/lib/files/FWO.Report/ReportAppRules.cs
@@ -190,7 +190,7 @@ namespace FWO.Report
         /// <summary>
         /// Collects management and sub-management IDs that can be affected by pending rule_owner mapping imports.
         /// </summary>
-        private HashSet<int> BuildRelevantManagementIds(List<ManagementReport> managementsWithRelevantImportId)
+        private static HashSet<int> BuildRelevantManagementIds(List<ManagementReport> managementsWithRelevantImportId)
         {
             HashSet<int> managementIds = new();
             foreach (ManagementReport management in managementsWithRelevantImportId)

--- a/roles/lib/files/FWO.Report/ReportAppRules.cs
+++ b/roles/lib/files/FWO.Report/ReportAppRules.cs
@@ -5,6 +5,7 @@ using FWO.Data.Report;
 using FWO.Data.Modelling;
 using FWO.Report.Filter;
 using FWO.Config.Api;
+using FWO.Logging;
 using NetTools;
 using System.Net;
 using FWO.Basics;
@@ -13,11 +14,15 @@ namespace FWO.Report
 {
     public class ReportAppRules : ReportRules
     {
+        private const string kRuleOwnerPrefilterMarker = "appRulesRuleOwnerPrefilterMarker";
         private readonly ModellingFilter modellingFilter;
+        private readonly ReportTemplate? reportTemplate;
+        private bool ruleOwnerPrefilterApplied;
 
-        public ReportAppRules(DynGraphqlQuery query, UserConfig userConfig, ReportType reportType, ModellingFilter modellingFilter) : base(query, userConfig, reportType)
+        public ReportAppRules(DynGraphqlQuery query, UserConfig userConfig, ReportType reportType, ModellingFilter modellingFilter, ReportTemplate reportTemplate) : base(query, userConfig, reportType)
         {
             this.modellingFilter = modellingFilter;
+            this.reportTemplate = reportTemplate;
         }
 
         public ReportAppRules(ReportRules reportRules, ModellingFilter modellingFilter) : base(reportRules.Query, reportRules.userConfig, reportRules.ReportType)
@@ -29,6 +34,27 @@ namespace FWO.Report
         {
             await base.Generate(elementsPerFetch, apiConnection, callback, ct);
             ReportData.ManagementData = await PrepareAppRulesReport(ReportData.ManagementData, modellingFilter, apiConnection, Query.SelectedOwner?.Id);
+        }
+
+        /// <summary>
+        /// Adds the NameField rule_owner prefilter to App Rules reports when the mapping can safely replace an early marker scan.
+        /// </summary>
+        protected override async Task PrepareQueryBeforeFetch(List<ManagementReport> managementsWithRelevantImportId, ApiConnection apiConnection)
+        {
+            if (reportTemplate == null || ruleOwnerPrefilterApplied || !ShouldUseNameFieldRuleOwnerPreFilter())
+            {
+                return;
+            }
+
+            if (!await IsRuleOwnerMappingCurrent(managementsWithRelevantImportId, apiConnection)
+                || !await IsRuleOwnerPreFilterCompletenessVerified(managementsWithRelevantImportId, apiConnection))
+            {
+                return;
+            }
+
+            ApplyNameFieldRuleOwnerPreFilter();
+            Log.WriteDebug("App Rules Report",
+                $"Using NameField rule_owner prefilter for owner {Query.SelectedOwner?.Id}.");
         }
 
         public override async Task<bool> GetObjectsForManagementInReport(Dictionary<string, object> objQueryVariables, ObjCategory objects, int maxFetchCycles, ApiConnection apiConnection, Func<ReportData, Task> callback)
@@ -44,6 +70,163 @@ namespace FWO.Report
                 PrepareRsbOutput(managementReport);
             }
             return gotAllObjects;
+        }
+
+        /// <summary>
+        /// Checks the App Rules specific preconditions for using NameField rule_owner data as an early rule prefilter.
+        /// </summary>
+        private bool ShouldUseNameFieldRuleOwnerPreFilter()
+        {
+            return userConfig.OwnerSoruceMappingID == (int)OwnerMappingSourceStm.NameField
+                && userConfig.ModModelledMarkerLocation == MarkerLocation.Rulename
+                && Query.SelectedOwner?.Id > 0
+                && !string.IsNullOrWhiteSpace(userConfig.ModModelledMarker);
+        }
+
+        /// <summary>
+        /// Verifies that no pending rule_owner mapping imports can make the NameField mapping stale for this report.
+        /// </summary>
+        private async Task<bool> IsRuleOwnerMappingCurrent(List<ManagementReport> managementsWithRelevantImportId, ApiConnection apiConnection)
+        {
+            try
+            {
+                List<ImportControl> pendingRuleOwnerMappingImports =
+                    await apiConnection.SendQueryAsync<List<ImportControl>>(ImportQueries.getPendingRuleOwnerImports) ?? new List<ImportControl>();
+                HashSet<int> relevantManagementIds = BuildRelevantManagementIds(managementsWithRelevantImportId);
+                bool hasRelevantPendingImport = pendingRuleOwnerMappingImports.Any(import => !import.MgmId.HasValue || relevantManagementIds.Contains(import.MgmId.Value));
+
+                if (hasRelevantPendingImport)
+                {
+                    Log.WriteDebug("App Rules Report",
+                        $"Skipping NameField rule_owner prefilter because pending rule_owner mapping imports exist for managements {string.Join(", ", relevantManagementIds)}.");
+                }
+
+                return !hasRelevantPendingImport;
+            }
+            catch (Exception exception)
+            {
+                Log.WriteWarning("App Rules Report",
+                    $"Could not verify rule_owner mapping freshness. Falling back to App Rules query. {exception.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Ensures marker rules for the selected owner already have active NameField rule_owner mappings before the prefilter is used.
+        /// </summary>
+        private async Task<bool> IsRuleOwnerPreFilterCompletenessVerified(List<ManagementReport> managementsWithRelevantImportId, ApiConnection apiConnection)
+        {
+            try
+            {
+                HashSet<long> ownerConnectionIds = await GetNameFieldRuleOwnerConnectionIds(apiConnection);
+                int missingMappingCount = 0;
+                foreach (ManagementReport management in managementsWithRelevantImportId)
+                {
+                    Dictionary<string, object?> ruleVariables = BuildNameFieldRuleOwnerRuleVariables(management);
+                    List<Rule> markerRules = await apiConnection.SendQueryAsync<List<Rule>>(RuleQueries.getNameFieldRuleOwnerPreFilterCompletenessRules, ruleVariables) ?? new List<Rule>();
+                    missingMappingCount += markerRules.Count(rule => long.TryParse(ParseMarkerConnectionId(rule.Name), out long connectionId) && ownerConnectionIds.Contains(connectionId));
+                }
+
+                if (missingMappingCount > 0)
+                {
+                    Log.WriteDebug("App Rules Report",
+                        $"Skipping NameField rule_owner prefilter because {missingMappingCount} owner marker rules have no active rule_owner mapping " +
+                        $"for owner {Query.SelectedOwner?.Id}.");
+                }
+
+                return missingMappingCount == 0;
+            }
+            catch (Exception exception)
+            {
+                Log.WriteWarning("App Rules Report",
+                    $"Could not verify NameField rule_owner prefilter completeness for owner {Query.SelectedOwner?.Id}. Falling back to App Rules query. {exception.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Loads modelling connection IDs that should be represented by NameField rule_owner mappings for the selected app.
+        /// </summary>
+        private async Task<HashSet<long>> GetNameFieldRuleOwnerConnectionIds(ApiConnection apiConnection)
+        {
+            List<int> ownerIds = new() { Query.SelectedOwner!.Id };
+            List<ModellingConnection> ownerConnections =
+                await apiConnection.SendQueryAsync<List<ModellingConnection>>(ModellingQueries.getOwnersForRuleOwnerNameFieldFilteredByOwner, new { ownerIds }) ?? new List<ModellingConnection>();
+            return ownerConnections.Select(connection => (long)connection.Id).ToHashSet();
+        }
+
+        /// <summary>
+        /// Builds variables for the shared NameField marker completeness query for one management import snapshot.
+        /// </summary>
+        private Dictionary<string, object?> BuildNameFieldRuleOwnerRuleVariables(ManagementReport management)
+        {
+            return new()
+            {
+                ["mgmId"] = management.Id,
+                ["ownerId"] = Query.SelectedOwner!.Id,
+                ["ownerMappingSourceId"] = (short)(int)OwnerMappingSourceStm.NameField,
+                ["marker"] = $"%{userConfig.ModModelledMarker}%",
+                ["import_id_start"] = management.RelevantImportId,
+                ["import_id_end"] = management.RelevantImportId
+            };
+        }
+
+        /// <summary>
+        /// Adds the marker and rule_owner predicates to the App Rules query and rebuilds the legacy report query.
+        /// </summary>
+        private void ApplyNameFieldRuleOwnerPreFilter()
+        {
+            Query.QueryParameters.Add($"${kRuleOwnerPrefilterMarker}: String! ");
+            Query.QueryVariables[kRuleOwnerPrefilterMarker] = $"%{userConfig.ModModelledMarker}%";
+            Query.AddRuleWhereAndFilter($"{{ rule_name: {{ _ilike: ${kRuleOwnerPrefilterMarker} }} }}");
+            Query.AddRuleWhereAndFilter(
+                $"{{ rule_metadatum: {{ rule_owners: {{ owner_id: {{ _eq: {Query.SelectedOwner!.Id} }}, " +
+                $"owner_mapping_source_id: {{ _eq: {(short)(int)OwnerMappingSourceStm.NameField} }}, " +
+                "removed: { _is_null: true } } } }");
+            Query.RebuildLegacyRulesQuery(reportTemplate!);
+            ruleOwnerPrefilterApplied = true;
+        }
+
+        /// <summary>
+        /// Collects management and sub-management IDs that can be affected by pending rule_owner mapping imports.
+        /// </summary>
+        private HashSet<int> BuildRelevantManagementIds(List<ManagementReport> managementsWithRelevantImportId)
+        {
+            HashSet<int> managementIds = new();
+            foreach (ManagementReport management in managementsWithRelevantImportId)
+            {
+                managementIds.Add(management.Id);
+                foreach (Management subManagement in management.SubManagements)
+                {
+                    managementIds.Add(subManagement.Id);
+                }
+            }
+            return managementIds;
+        }
+
+        /// <summary>
+        /// Extracts the connection ID from the configured marker in a rule name.
+        /// </summary>
+        private string? ParseMarkerConnectionId(string? ruleName)
+        {
+            if (string.IsNullOrEmpty(ruleName))
+            {
+                return null;
+            }
+
+            int markerIndex = ruleName.IndexOf(userConfig.ModModelledMarker, StringComparison.Ordinal);
+            if (markerIndex < 0)
+            {
+                return null;
+            }
+
+            int start = markerIndex + userConfig.ModModelledMarker.Length;
+            int end = start;
+            while (end < ruleName.Length && char.IsDigit(ruleName[end]))
+            {
+                end++;
+            }
+            return end > start ? ruleName[start..end] : null;
         }
 
         public static async Task<List<ManagementReport>> PrepareAppRulesReport(List<ManagementReport> managementData, ModellingFilter modellingFilter, ApiConnection apiConnection, int? ownerId)

--- a/roles/lib/files/FWO.Report/ReportBase.cs
+++ b/roles/lib/files/FWO.Report/ReportBase.cs
@@ -198,7 +198,7 @@ namespace FWO.Report
                 ReportType.Recertification => new ReportRules(query, userConfig, repType, ruleTreeBuilder),
                 ReportType.UnusedRules => new ReportRules(query, userConfig, repType, ruleTreeBuilder),
                 ReportType.Connections => new ReportConnections(query, userConfig, repType),
-                ReportType.AppRules => new ReportAppRules(query, userConfig, repType, reportFilter.ReportParams.ModellingFilter),
+                ReportType.AppRules => new ReportAppRules(query, userConfig, repType, reportFilter.ReportParams.ModellingFilter, reportFilter),
                 ReportType.VarianceAnalysis => new ReportVariances(query, userConfig, repType),
                 ReportType.ComplianceReport => new ReportCompliance(query, userConfig, repType, reportFilter.ReportParams),
                 ReportType.ComplianceDiffReport => new ReportComplianceDiff(query, userConfig, repType, reportFilter.ReportParams),

--- a/roles/lib/files/FWO.Report/ReportRules.cs
+++ b/roles/lib/files/FWO.Report/ReportRules.cs
@@ -65,6 +65,7 @@ namespace FWO.Report
             bool keepFetching = true;
 
             List<ManagementReport> managementsWithRelevantImportId = await GetRelevantImportIds(apiConnection);
+            await PrepareQueryBeforeFetch(managementsWithRelevantImportId, apiConnection);
             ReportData.ManagementData = [];
             foreach (var management in managementsWithRelevantImportId)
             {
@@ -123,6 +124,7 @@ namespace FWO.Report
             Query.QueryVariables[QueryVar.Offset] = 0;
 
             List<ManagementReport> managementsWithRelevantImportId = await GetRelevantImportIds(apiConnection);
+            await PrepareQueryBeforeFetch(managementsWithRelevantImportId, apiConnection);
             ReportData.ManagementData = [];
             foreach (ManagementReport management in managementsWithRelevantImportId)
             {
@@ -220,6 +222,14 @@ namespace FWO.Report
         }
 
         internal readonly record struct RuleAttachCounts(int Attached, int Skipped);
+
+        /// <summary>
+        /// Allows specialized rule reports to adjust the query after relevant imports were resolved.
+        /// </summary>
+        protected virtual Task PrepareQueryBeforeFetch(List<ManagementReport> managementsWithRelevantImportId, ApiConnection apiConnection)
+        {
+            return Task.CompletedTask;
+        }
 
         /// <summary>
         /// Appends a flat page of rules to the matching rulebase shells already present in the management report.

--- a/roles/tests-unit/files/FWO.Test/FilterTest.cs
+++ b/roles/tests-unit/files/FWO.Test/FilterTest.cs
@@ -4,6 +4,7 @@ using FWO.Report.Filter.Exceptions;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using FWO.Basics;
+using FWO.Data;
 using FWO.Data.Report;
 using FWO.Data.Workflow;
 using System.Reflection;
@@ -390,6 +391,30 @@ namespace FWO.Test
             StringAssert.Contains("rulebase_links(where:", query.FullQuery);
             StringAssert.DoesNotContain("rulebase_links(where: { }) { rules (", query.FullQuery);
             StringAssert.Contains("rulebases { id uid name rules (", query.FullQuery);
+        }
+
+        [Test]
+        [Parallelizable]
+        public void AppRulesRebuildIncludesLateRuleOwnerPrefilter()
+        {
+            ReportTemplate template = new("", new()
+            {
+                ReportType = (int)ReportType.AppRules
+            });
+            template.ReportParams.ModellingFilter.SelectedOwner = new FwoOwner { Id = 17 };
+            DynGraphqlQuery query = Compiler.Compile(template);
+
+            query.QueryParameters.Add("$appRulesRuleOwnerPrefilterMarker: String! ");
+            query.QueryVariables["appRulesRuleOwnerPrefilterMarker"] = "%FWOC%";
+            short ownerMappingSourceId = (short)(int)OwnerMappingSourceStm.NameField;
+            query.AddRuleWhereAndFilter("{ rule_name: { _ilike: $appRulesRuleOwnerPrefilterMarker } }");
+            query.AddRuleWhereAndFilter($"{{ rule_metadatum: {{ rule_owners: {{ owner_id: {{ _eq: 17 }}, owner_mapping_source_id: {{ _eq: {ownerMappingSourceId} }}, removed: {{ _is_null: true }} }} }} }}");
+            query.RebuildLegacyRulesQuery(template);
+
+            StringAssert.Contains("get_rules_for_owner(args: {ownerid: 17 ", query.FullQuery);
+            StringAssert.Contains("$appRulesRuleOwnerPrefilterMarker: String!", query.FullQuery);
+            StringAssert.Contains("rule_name: { _ilike: $appRulesRuleOwnerPrefilterMarker }", query.FullQuery);
+            StringAssert.Contains($"rule_metadatum: {{ rule_owners: {{ owner_id: {{ _eq: 17 }}, owner_mapping_source_id: {{ _eq: {ownerMappingSourceId} }}, removed: {{ _is_null: true }} }} }}", query.FullQuery);
         }
 
         [Test]

--- a/roles/tests-unit/files/FWO.Test/ReportAppRulesTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ReportAppRulesTest.cs
@@ -1,0 +1,210 @@
+using FWO.Api.Client;
+using FWO.Api.Client.Queries;
+using FWO.Basics;
+using FWO.Config.Api;
+using FWO.Data;
+using FWO.Data.Modelling;
+using FWO.Data.Report;
+using FWO.Report;
+using FWO.Report.Filter;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace FWO.Test
+{
+    [TestFixture]
+    [Parallelizable]
+    public class ReportAppRulesTest
+    {
+        [Test]
+        [Parallelizable]
+        public async Task PrepareQueryBeforeFetchAppliesNameFieldRuleOwnerPrefilter()
+        {
+            (TestReportAppRules report, AppRulesPrefilterApiConnection apiConnection) = CreateReport();
+
+            await report.CallPrepareQueryBeforeFetch(CreateManagements(), apiConnection);
+
+            StringAssert.Contains("rule_name: { _ilike: $appRulesRuleOwnerPrefilterMarker }", report.Query.FullQuery);
+            StringAssert.Contains("rule_metadatum: { rule_owners: { owner_id: { _eq: 17 }, owner_mapping_source_id: { _eq: 3 }, removed: { _is_null: true } } }", report.Query.FullQuery);
+            Assert.That(apiConnection.Queries, Does.Contain(ImportQueries.getPendingRuleOwnerImports));
+            Assert.That(apiConnection.Queries, Does.Contain(ModellingQueries.getOwnersForRuleOwnerNameFieldFilteredByOwner));
+            Assert.That(apiConnection.Queries, Does.Contain(RuleQueries.getNameFieldRuleOwnerPreFilterCompletenessRules));
+        }
+
+        [Test]
+        [Parallelizable]
+        public async Task PrepareQueryBeforeFetchSkipsPrefilterWhenNameFieldMappingIsNotActive()
+        {
+            UserConfig userConfig = CreateUserConfig();
+            userConfig.OwnerSoruceMappingID = 0;
+            (TestReportAppRules report, AppRulesPrefilterApiConnection apiConnection) = CreateReport(userConfig);
+
+            await report.CallPrepareQueryBeforeFetch(CreateManagements(), apiConnection);
+
+            StringAssert.DoesNotContain("rule_metadatum: { rule_owners:", report.Query.FullQuery);
+            Assert.That(apiConnection.Queries, Is.Empty);
+        }
+
+        [Test]
+        [Parallelizable]
+        public async Task PrepareQueryBeforeFetchSkipsPrefilterWhenRuleOwnerMappingImportIsPending()
+        {
+            AppRulesPrefilterApiConnection apiConnection = new()
+            {
+                PendingImports = new List<ImportControl>
+                {
+                    new() { MgmId = 10 }
+                }
+            };
+            (TestReportAppRules report, _) = CreateReport(apiConnection: apiConnection);
+
+            await report.CallPrepareQueryBeforeFetch(CreateManagements(), apiConnection);
+
+            StringAssert.DoesNotContain("rule_metadatum: { rule_owners:", report.Query.FullQuery);
+            Assert.That(apiConnection.Queries, Does.Contain(ImportQueries.getPendingRuleOwnerImports));
+            Assert.That(apiConnection.Queries, Does.Not.Contain(RuleQueries.getNameFieldRuleOwnerPreFilterCompletenessRules));
+        }
+
+        [Test]
+        [Parallelizable]
+        public async Task PrepareQueryBeforeFetchSkipsPrefilterWhenCompletenessCheckFindsMissingMapping()
+        {
+            AppRulesPrefilterApiConnection apiConnection = new()
+            {
+                OwnerConnections = new List<ModellingConnection>
+                {
+                    new() { Id = 42 }
+                },
+                MarkerRulesMissingMappings = new List<Rule>
+                {
+                    new() { Name = "FWOC42" }
+                }
+            };
+            (TestReportAppRules report, _) = CreateReport(apiConnection: apiConnection);
+
+            await report.CallPrepareQueryBeforeFetch(CreateManagements(), apiConnection);
+
+            StringAssert.DoesNotContain("rule_metadatum: { rule_owners:", report.Query.FullQuery);
+            Assert.That(apiConnection.Queries, Does.Contain(ModellingQueries.getOwnersForRuleOwnerNameFieldFilteredByOwner));
+            Assert.That(apiConnection.Queries, Does.Contain(RuleQueries.getNameFieldRuleOwnerPreFilterCompletenessRules));
+        }
+
+        private static (TestReportAppRules report, AppRulesPrefilterApiConnection apiConnection) CreateReport(
+            UserConfig? userConfig = null, AppRulesPrefilterApiConnection? apiConnection = null)
+        {
+            ReportTemplate template = new("", new()
+            {
+                ReportType = (int)ReportType.AppRules
+            });
+            template.ReportParams.ModellingFilter.SelectedOwner = new FwoOwner { Id = 17 };
+            DynGraphqlQuery query = Compiler.Compile(template);
+            TestReportAppRules report = new(query, userConfig ?? CreateUserConfig(), ReportType.AppRules,
+                template.ReportParams.ModellingFilter, template);
+            return (report, apiConnection ?? new AppRulesPrefilterApiConnection());
+        }
+
+        private static UserConfig CreateUserConfig()
+        {
+            return new()
+            {
+                OwnerSoruceMappingID = (int)OwnerMappingSourceStm.NameField,
+                ModModelledMarker = "FWOC",
+                ModModelledMarkerLocation = MarkerLocation.Rulename
+            };
+        }
+
+        private static List<ManagementReport> CreateManagements()
+        {
+            return new List<ManagementReport>
+            {
+                new()
+                {
+                    Id = 10,
+                    RelevantImportId = 100
+                }
+            };
+        }
+
+        private sealed class TestReportAppRules : ReportAppRules
+        {
+            public TestReportAppRules(DynGraphqlQuery query, UserConfig userConfig, ReportType reportType,
+                ModellingFilter modellingFilter, ReportTemplate reportTemplate) : base(query, userConfig, reportType, modellingFilter, reportTemplate)
+            {
+            }
+
+            public Task CallPrepareQueryBeforeFetch(List<ManagementReport> managementsWithRelevantImportId, ApiConnection apiConnection)
+            {
+                return PrepareQueryBeforeFetch(managementsWithRelevantImportId, apiConnection);
+            }
+        }
+
+        private sealed class AppRulesPrefilterApiConnection : ApiConnection
+        {
+            public List<string> Queries { get; } = new();
+            public List<ImportControl> PendingImports { get; set; } = new();
+            public List<ModellingConnection> OwnerConnections { get; set; } = new();
+            public List<Rule> MarkerRulesMissingMappings { get; set; } = new();
+
+            public override Task<QueryResponseType> SendQueryAsync<QueryResponseType>(string query, object? variables = null,
+                string? operationName = null, QueryChunkingOptions? chunkingOptions = null)
+            {
+                Queries.Add(query);
+                if (query == ImportQueries.getPendingRuleOwnerImports)
+                {
+                    return Task.FromResult((QueryResponseType)(object)PendingImports);
+                }
+                if (query == ModellingQueries.getOwnersForRuleOwnerNameFieldFilteredByOwner)
+                {
+                    return Task.FromResult((QueryResponseType)(object)OwnerConnections);
+                }
+                if (query == RuleQueries.getNameFieldRuleOwnerPreFilterCompletenessRules)
+                {
+                    return Task.FromResult((QueryResponseType)(object)MarkerRulesMissingMappings);
+                }
+                throw new NotSupportedException(query);
+            }
+
+            public override void SetAuthHeader(string jwt)
+            {
+            }
+
+            public override Task ReconnectSubscriptionsAsync(string jwt, CancellationToken ct)
+            {
+                return Task.CompletedTask;
+            }
+
+            public override void SetRole(string role)
+            {
+            }
+
+            public override void SetBestRole(System.Security.Claims.ClaimsPrincipal user, List<string> targetRoleList)
+            {
+            }
+
+            public override void SwitchBack()
+            {
+            }
+
+            public override Task<ApiResponse<QueryResponseType>> SendQuerySafeAsync<QueryResponseType>(string query, object? variables = null,
+                string? operationName = null)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override GraphQlApiSubscription<SubscriptionResponseType> GetSubscription<SubscriptionResponseType>(Action<Exception> exceptionHandler,
+                GraphQlApiSubscription<SubscriptionResponseType>.SubscriptionUpdate subscriptionUpdateHandler, string subscription,
+                object? variables = null, string? operationName = null)
+            {
+                throw new NotSupportedException();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+            }
+
+            public override void DisposeSubscriptions<T>()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `rule_owner` prefilter to the App Rules report and documents the existing recertification behavior.

The App Rules report now applies an early rule filter when the NameField mapping is safe to use:
- `OwnerSoruceMappingID == NameField`
- modelled marker is configured for the rule name
- selected app/owner is available
- no relevant pending `rule_owner` mapping imports exist
- completeness check confirms no matching FWOC marker rules are missing active `rule_owner` mappings

When all checks pass, the report query is narrowed by:
- `rule_name _ilike <modelled marker>`
- `rule_api -> rule_metadatum -> rule_owners`

If any check fails, the report falls back to the previous App Rules query path.

## Recertification

The recertification button already uses the existing NameField/FWOC `rule_owner` prefilter via check 3:

`Modelling -> Recertification button -> Check 3`

That path runs through:

`RequestRecertPopup.CheckImplementation()` -> `AnalyseRulesVsModelledConnections()` -> `GetRules()`

The prefilter is used there when the normal NameField/FWOC conditions are met and `ModRecertExpectAllModelled == false`.

If `ModRecertExpectAllModelled == true`, the prefilter is intentionally not used because the check must also consider non-modelled rules.

closes: #5055, #5103