### PR TITLE
fix: api select permissions and log data import

### DIFF
--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -2517,6 +2517,15 @@
                   "comment": ""
                 },
                 {
+                  "role": "middleware-server",
+                  "permission": {
+                    "columns": [
+                      "owner_id"
+                    ],
+                    "filter": {}
+                  },
+                  "comment": ""
+                },                {
                   "role": "modeller",
                   "permission": {
                     "columns": [

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -2520,12 +2520,14 @@
                   "role": "middleware-server",
                   "permission": {
                     "columns": [
+                      "log_time",
                       "owner_id"
                     ],
                     "filter": {}
                   },
                   "comment": ""
-                },                {
+                },
+                {
                   "role": "modeller",
                   "permission": {
                     "columns": [

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -2929,16 +2929,7 @@
                   "role": "implementer",
                   "permission": {
                     "columns": [
-                      "id",
-                      "app_id",
-                      "proposed_app_id",
-                      "name",
-                      "is_interface",
-                      "is_requested",
-                      "is_published",
-                      "removed",
-                      "ticket_id",
-                      "conn_prop"
+                      "id"
                     ],
                     "filter": {}
                   },
@@ -5009,19 +5000,7 @@
                   "permission": {
                     "columns": [
                       "alert_id",
-                      "ref_alert_id",
-                      "ref_log_id",
-                      "description",
-                      "source",
-                      "title",
-                      "ack_by",
-                      "alert_code",
-                      "alert_dev_id",
-                      "alert_mgm_id",
-                      "user_id",
-                      "json_data",
-                      "ack_timestamp",
-                      "alert_timestamp"
+                      "ack_by"
                     ],
                     "filter": {}
                   }

--- a/roles/api/files/replace_metadata.json
+++ b/roles/api/files/replace_metadata.json
@@ -2926,6 +2926,25 @@
                   "comment": ""
                 },
                 {
+                  "role": "implementer",
+                  "permission": {
+                    "columns": [
+                      "id",
+                      "app_id",
+                      "proposed_app_id",
+                      "name",
+                      "is_interface",
+                      "is_requested",
+                      "is_published",
+                      "removed",
+                      "ticket_id",
+                      "conn_prop"
+                    ],
+                    "filter": {}
+                  },
+                  "comment": ""
+                },
+                {
                   "role": "middleware-server",
                   "permission": {
                     "columns": [
@@ -3814,7 +3833,8 @@
                   "role": "middleware-server",
                   "permission": {
                     "columns": [
-                      "nwgroup_id"
+                      "nwgroup_id",
+                      "app_id"
                     ],
                     "filter": {}
                   },
@@ -4964,6 +4984,28 @@
                 },
                 {
                   "role": "reporter",
+                  "permission": {
+                    "columns": [
+                      "alert_id",
+                      "ref_alert_id",
+                      "ref_log_id",
+                      "description",
+                      "source",
+                      "title",
+                      "ack_by",
+                      "alert_code",
+                      "alert_dev_id",
+                      "alert_mgm_id",
+                      "user_id",
+                      "json_data",
+                      "ack_timestamp",
+                      "alert_timestamp"
+                    ],
+                    "filter": {}
+                  }
+                },
+                {
+                  "role": "reporter-viewall",
                   "permission": {
                     "columns": [
                       "alert_id",

--- a/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.Sources.cs
+++ b/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.Sources.cs
@@ -1,0 +1,570 @@
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using ApiQueries = FWO.Api.Client.Queries.Queries;
+
+namespace FWO.Test
+{
+    /// <summary>
+    /// Locating and reading the sources the permission alignment is checked against: the API call
+    /// definitions and the places the repository and an installed system keep them. The checks
+    /// themselves and the reading of the Hasura metadata live in the other part of this class.
+    /// </summary>
+    internal partial class ApiPermissionAlignmentTest
+    {
+        /// <summary>
+        /// Reads every root field of the embedded API calls together with what it filters on and returns.
+        /// </summary>
+        private static ApiCallSurvey ReadApiCalls()
+        {
+            DirectoryInfo apiCalls = kApiCallDirectory.Value
+                ?? throw new InvalidOperationException(kApiCallsOutOfReach);
+
+            ApiCallSurvey survey = new();
+            foreach (FileInfo apiCall in apiCalls.EnumerateFiles($"*{kApiCallSuffix}", SearchOption.AllDirectories)
+                .OrderBy(apiCall => apiCall.FullName, StringComparer.Ordinal))
+            {
+                ReadApiCall(survey, FormatSource(apiCalls, apiCall),
+                    ApiQueries.Compact(File.ReadAllText(apiCall.FullName)));
+            }
+            return survey;
+        }
+
+        /// <summary>
+        /// Reads the root fields of a single API call. The call is compacted the same way it is before it
+        /// is sent, so the comments of the file cannot be mistaken for part of it.
+        /// </summary>
+        private static void ReadApiCall(ApiCallSurvey survey, string source, string apiCall)
+        {
+            string operationType = ReadOperationType(apiCall);
+            string? selectionSet = ReadSelectionSet(apiCall);
+            if (selectionSet == null)
+            {
+                survey.Uncheckable.Add($"{source}: the operation carries no selection set.");
+                return;
+            }
+
+            foreach (ApiField field in EnumerateFields(selectionSet))
+            {
+                if (field.IsFragmentSpread)
+                {
+                    survey.Uncheckable.Add($"{source}: a fragment spread stands where a root field is expected.");
+                }
+                else
+                {
+                    ReadRootField(survey, source, operationType, field);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Turns one root field into the operation it performs on a table.
+        /// </summary>
+        private static void ReadRootField(ApiCallSurvey survey, string source, string operationType, ApiField field)
+        {
+            (string operation, string tableRoot, bool addressesOneRow) = ResolveRootField(field.Name, operationType);
+            if (operation.Length == 0)
+            {
+                return;
+            }
+
+            List<string> filterColumns = ReadFilterColumns(survey, source, field);
+            (List<string> returned, bool opaque) = ReadReturnedColumns(survey, source, field.SubSelection);
+            survey.Operations.Add(new ApiOperation(source, operation, tableRoot, filterColumns, returned,
+                ReadWrittenColumns(survey, source, field, operation),
+                addressesOneRow || opaque || returned.Count > 0));
+        }
+
+        /// <summary>
+        /// Reads the operation type of an API call, which is a query where the shorthand form omits it.
+        /// </summary>
+        private static string ReadOperationType(string apiCall)
+        {
+            Match keyword = OperationKeywordRegex().Match(apiCall);
+            return keyword.Success ? keyword.Groups[1].Value : kQueryOperationType;
+        }
+
+        /// <summary>
+        /// Reads the outermost selection set of an API call, skipping the name and the variable
+        /// definitions of the operation.
+        /// </summary>
+        /// <returns>The body of the selection set, or null when the call carries none.</returns>
+        private static string? ReadSelectionSet(string apiCall)
+        {
+            Match keyword = OperationKeywordRegex().Match(apiCall);
+            int position = keyword.Success
+                ? SkipOperationHeader(apiCall, keyword.Index + keyword.Length)
+                : 0;
+
+            int start = apiCall.IndexOf('{', position);
+            if (start < 0)
+            {
+                return null;
+            }
+            int end = IndexOfMatchingBracket(apiCall, start);
+            return end < 0 ? null : apiCall[(start + 1)..end];
+        }
+
+        /// <summary>
+        /// Skips the name and the variable definitions following the operation keyword.
+        /// </summary>
+        private static int SkipOperationHeader(string apiCall, int position)
+        {
+            position = SkipName(apiCall, SkipSpaces(apiCall, position));
+            position = SkipSpaces(apiCall, position);
+            if (position < apiCall.Length && apiCall[position] == '(')
+            {
+                int end = IndexOfMatchingBracket(apiCall, position);
+                position = end < 0 ? position : end + 1;
+            }
+            return position;
+        }
+
+        /// <summary>
+        /// Walks the fields of a selection set, resolving the alias of a field to the field it renames.
+        /// </summary>
+        private static IEnumerable<ApiField> EnumerateFields(string selectionSet)
+        {
+            int position = 0;
+            while (position < selectionSet.Length)
+            {
+                position = SkipSpaces(selectionSet, position);
+                if (position >= selectionSet.Length)
+                {
+                    yield break;
+                }
+                if (string.CompareOrdinal(selectionSet, position, kFragmentSpread, 0, kFragmentSpread.Length) == 0)
+                {
+                    position = SkipName(selectionSet, position + kFragmentSpread.Length);
+                    yield return ApiField.FragmentSpread;
+                    continue;
+                }
+
+                (string name, int afterName) = ReadFieldName(selectionSet, position);
+                if (name.Length == 0)
+                {
+                    position++;
+                    continue;
+                }
+                (string? arguments, int afterArguments) = ReadBracketed(selectionSet, afterName, '(');
+                (string? subSelection, int afterSubSelection) = ReadBracketed(selectionSet, afterArguments, '{');
+                position = afterSubSelection;
+                yield return new ApiField(name, arguments, subSelection, false);
+            }
+        }
+
+        /// <summary>
+        /// Reads the name of a field, which is the one behind the colon where the field carries an alias.
+        /// </summary>
+        /// <returns>The name and the position behind it.</returns>
+        private static (string Name, int Position) ReadFieldName(string selectionSet, int position)
+        {
+            int nameEnd = SkipName(selectionSet, position);
+            string name = selectionSet[position..nameEnd];
+            int afterName = SkipSpaces(selectionSet, nameEnd);
+            if (name.Length == 0 || afterName >= selectionSet.Length || selectionSet[afterName] != ':')
+            {
+                return (name, afterName);
+            }
+
+            int aliasedStart = SkipSpaces(selectionSet, afterName + 1);
+            int aliasedEnd = SkipName(selectionSet, aliasedStart);
+            return (selectionSet[aliasedStart..aliasedEnd], SkipSpaces(selectionSet, aliasedEnd));
+        }
+
+        /// <summary>
+        /// Reads the body enclosed in the given bracket where one opens at the given position.
+        /// </summary>
+        /// <returns>The body without the brackets, or null where none opens, and the position behind it.</returns>
+        private static (string? Body, int Position) ReadBracketed(string text, int position, char opening)
+        {
+            if (position >= text.Length || text[position] != opening)
+            {
+                return (null, position);
+            }
+            int end = IndexOfMatchingBracket(text, position);
+            return end < 0 ? (null, text.Length) : (text[(position + 1)..end], SkipSpaces(text, end + 1));
+        }
+
+        /// <summary>
+        /// Resolves a root field to the operation it performs and the table it addresses.
+        /// </summary>
+        /// <returns>An empty operation where the root field addresses no table.</returns>
+        private static (string Operation, string TableRoot, bool AddressesOneRow) ResolveRootField(
+            string rootField, string operationType)
+        {
+            string name = rootField;
+            bool addressesOneRow = name.EndsWith(kByPkRootSuffix);
+            if (addressesOneRow)
+            {
+                name = name[..^kByPkRootSuffix.Length];
+            }
+
+            if (operationType != kMutationOperationType)
+            {
+                return (kSelectOperation, TrimRootFieldSuffix(name), addressesOneRow);
+            }
+            Match mutation = MutationRootFieldRegex().Match(name);
+            return mutation.Success
+                ? (mutation.Groups[1].Value, TrimRootFieldSuffix(mutation.Groups[2].Value), addressesOneRow)
+                : ("", "", addressesOneRow);
+        }
+
+        /// <summary>
+        /// Cuts off the suffix Hasura appends to the name of a table for a root field addressing it in
+        /// another way, which leaves the name of the table itself.
+        /// </summary>
+        private static string TrimRootFieldSuffix(string rootField)
+        {
+            string suffix = kRootFieldSuffixes.Find(rootField.EndsWith) ?? "";
+            return rootField[..^suffix.Length];
+        }
+
+        /// <summary>
+        /// Reads the columns the where clause of a root field compares. A filter handed over as a variable
+        /// is only known at run time and is recorded as uncheckable instead.
+        /// </summary>
+        private static List<string> ReadFilterColumns(ApiCallSurvey survey, string source, ApiField field)
+        {
+            HashSet<string> columns = new();
+            if (field.Arguments == null)
+            {
+                return columns.ToList();
+            }
+
+            Match filter = FilterArgumentRegex().Match(field.Arguments);
+            if (!filter.Success)
+            {
+                ReportVariableArgument(survey, source, field, VariableFilterRegex(), "filter");
+                return columns.ToList();
+            }
+            int bodyStart = filter.Index + filter.Length - 1;
+            int bodyEnd = IndexOfMatchingBracket(field.Arguments, bodyStart);
+            if (bodyEnd >= 0)
+            {
+                CollectFilterColumns(field.Arguments[(bodyStart + 1)..bodyEnd], columns, 0);
+            }
+            return columns.ToList();
+        }
+
+        /// <summary>
+        /// Reads the columns a mutation writes, which decides whether a role can run it at all. An object
+        /// list handed over as a variable is only known at run time and is recorded as uncheckable.
+        /// </summary>
+        private static List<string> ReadWrittenColumns(ApiCallSurvey survey, string source, ApiField field,
+            string operation)
+        {
+            if (field.Arguments == null || operation == kDeleteOperation || operation == kSelectOperation)
+            {
+                return new();
+            }
+
+            Regex bodyRegex = operation == kUpdateOperation ? AssignmentRegex() : ObjectsRegex();
+            Match written = bodyRegex.Match(field.Arguments);
+            if (!written.Success)
+            {
+                ReportVariableArgument(survey, source, field, VariableWrittenRegex(), "written object");
+                return new();
+            }
+            int bodyStart = written.Index + written.Length - 1;
+            int bodyEnd = IndexOfMatchingBracket(field.Arguments, bodyStart);
+            return bodyEnd < 0
+                ? new()
+                : EnumerateMembers(field.Arguments[(bodyStart + 1)..bodyEnd]).Select(member => member.Name).ToList();
+        }
+
+        /// <summary>
+        /// Records an argument handed over as a variable, whose content no static check can read.
+        /// </summary>
+        private static void ReportVariableArgument(ApiCallSurvey survey, string source, ApiField field,
+            Regex variableRegex, string subject)
+        {
+            if (field.Arguments != null && variableRegex.IsMatch(field.Arguments))
+            {
+                survey.Uncheckable.Add($"{source}: {field.Name} takes its {subject} from a variable.");
+            }
+        }
+
+        /// <summary>
+        /// Reads the columns a mutation returns, which are the direct scalar fields of its response.
+        /// A nested object addresses another table and is left to the permissions of that table.
+        /// </summary>
+        /// <returns>The returned columns, and whether a fragment spread hides further ones.</returns>
+        private static (List<string> Columns, bool Opaque) ReadReturnedColumns(ApiCallSurvey survey, string source,
+            string? selectionSet)
+        {
+            HashSet<string> columns = new();
+            bool opaque = false;
+            if (selectionSet == null)
+            {
+                return (columns.ToList(), false);
+            }
+
+            foreach (ApiField field in EnumerateFields(selectionSet))
+            {
+                if (field.IsFragmentSpread)
+                {
+                    opaque = true;
+                    survey.Uncheckable.Add($"{source}: a fragment spread hides part of the returned columns.");
+                }
+                else if (field.Name == kReturningField)
+                {
+                    (List<string> nested, bool nestedOpaque) = ReadReturnedColumns(survey, source, field.SubSelection);
+                    columns.UnionWith(nested);
+                    opaque = opaque || nestedOpaque;
+                }
+                else if (field.SubSelection == null && !kResponseMetaFields.Contains(field.Name))
+                {
+                    columns.Add(field.Name);
+                }
+            }
+            return (columns.ToList(), opaque);
+        }
+
+        /// <summary>
+        /// Collects the columns a filter compares. A member comparing a column carries comparison operators
+        /// only; a member carrying a combining operator or a named condition walks a relationship into
+        /// another table and is left to the API call of it.
+        /// </summary>
+        private static void CollectFilterColumns(string filter, ISet<string> columns, int depth)
+        {
+            if (depth >= kMaxFilterDepth)
+            {
+                throw new InvalidOperationException($"Filter is nested deeper than {kMaxFilterDepth} levels.");
+            }
+
+            foreach ((string name, string? body) in EnumerateMembers(filter))
+            {
+                if (body == null)
+                {
+                    continue;
+                }
+                if (kLogicalOperators.Contains(name))
+                {
+                    CollectFilterColumns(body, columns, depth + 1);
+                }
+                else if (!name.StartsWith('_') && ComparesAColumn(body))
+                {
+                    columns.Add(name);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Decides whether the members of a filter member are comparison operators, which makes the member
+        /// itself a column and not a relationship. A combining operator is no comparison: it introduces a
+        /// condition over another table and appears in a boolean expression only.
+        /// </summary>
+        private static bool ComparesAColumn(string memberBody)
+        {
+            bool hasMember = false;
+            foreach ((string name, string? _) in EnumerateMembers(memberBody))
+            {
+                hasMember = true;
+                if (!name.StartsWith('_') || kLogicalOperators.Contains(name))
+                {
+                    return false;
+                }
+            }
+            return hasMember;
+        }
+
+        /// <summary>
+        /// Walks the members of a GraphQL object.
+        /// </summary>
+        /// <returns>The name of every member with its body, which is null for a member holding a value.</returns>
+        private static IEnumerable<(string Name, string? Body)> EnumerateMembers(string objectBody)
+        {
+            int position = 0;
+            while (position < objectBody.Length)
+            {
+                Match member = MemberRegex().Match(objectBody, position);
+                if (!member.Success)
+                {
+                    yield break;
+                }
+
+                int valueStart = member.Index + member.Length;
+                int valueEnd = IsBracket(objectBody, valueStart) ? IndexOfMatchingBracket(objectBody, valueStart) : -1;
+                if (valueEnd < 0)
+                {
+                    yield return (member.Groups[1].Value, null);
+                    position = valueStart;
+                    continue;
+                }
+
+                yield return (member.Groups[1].Value, objectBody[(valueStart + 1)..valueEnd]);
+                position = valueEnd + 1;
+            }
+        }
+
+        /// <summary>
+        /// Decides whether an object or a list starts at the given position.
+        /// </summary>
+        private static bool IsBracket(string text, int position)
+        {
+            return position < text.Length && (text[position] == '{' || text[position] == '[');
+        }
+
+        /// <summary>
+        /// Skips the spaces at the given position, of which a compacted call holds at most one in a row.
+        /// </summary>
+        private static int SkipSpaces(string text, int position)
+        {
+            while (position < text.Length && char.IsWhiteSpace(text[position]))
+            {
+                position++;
+            }
+            return position;
+        }
+
+        /// <summary>
+        /// Skips the name at the given position.
+        /// </summary>
+        private static int SkipName(string text, int position)
+        {
+            while (position < text.Length && (char.IsLetterOrDigit(text[position]) || text[position] == '_'))
+            {
+                position++;
+            }
+            return position;
+        }
+
+        /// <summary>
+        /// Finds the bracket closing the one at the given position. Brackets of another kind in between do
+        /// not change the nesting of the searched one and are therefore not counted.
+        /// </summary>
+        /// <returns>The position of the closing bracket, or -1 when it is missing.</returns>
+        private static int IndexOfMatchingBracket(string text, int openingPosition)
+        {
+            char opening = text[openingPosition];
+            char closing = ClosingBracketOf(opening);
+            int depth = 0;
+
+            for (int position = openingPosition; position < text.Length; position++)
+            {
+                if (text[position] == opening)
+                {
+                    depth++;
+                }
+                else if (text[position] == closing && --depth == 0)
+                {
+                    return position;
+                }
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Reads the bracket closing an opening one.
+        /// </summary>
+        private static char ClosingBracketOf(char opening)
+        {
+            return opening switch
+            {
+                '{' => '}',
+                '[' => ']',
+                '(' => ')',
+                _ => throw new ArgumentException($"{opening} is no opening bracket.", nameof(opening))
+            };
+        }
+
+        /// <summary>
+        /// Names an API call by its path below fwo-api-calls, so a failure points at the file to repair.
+        /// </summary>
+        private static string FormatSource(DirectoryInfo apiCalls, FileInfo apiCall)
+        {
+            return Path.GetRelativePath(apiCalls.FullName, apiCall.FullName)
+                .Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+
+        /// <summary>
+        /// Locates the Hasura metadata in the repository or in the directory the installer copies it to
+        /// next to the tests.
+        /// </summary>
+        /// <returns>The metadata file, or null when it is out of reach.</returns>
+        private static FileInfo? LocateMetadata()
+        {
+            return LocateBesideOrAbove(directory =>
+            {
+                FileInfo repository = new(Path.Combine(directory.FullName, "roles", "api", "files", kMetadataFile));
+                FileInfo installed = new(Path.Combine(directory.FullName, kMetadataFile));
+                return repository.Exists ? repository : installed.Exists ? installed : null;
+            });
+        }
+
+        /// <summary>
+        /// Locates the API call definitions in the repository or where the installer deploys them for the
+        /// UI, middleware and importer.
+        /// </summary>
+        /// <returns>The directory holding the API calls, or null when it is out of reach.</returns>
+        private static DirectoryInfo? LocateApiCalls()
+        {
+            return LocateBesideOrAbove(directory =>
+            {
+                DirectoryInfo repository = new(Path.Combine(directory.FullName, "roles", "common", "files", kApiCallDirectoryName));
+                DirectoryInfo installed = new(Path.Combine(directory.FullName, kApiCallDirectoryName));
+                return repository.Exists ? repository : installed.Exists ? installed : null;
+            });
+        }
+
+        /// <summary>
+        /// Walks from the directory of the test assembly up to the root and returns what the given lookup
+        /// finds first. The tests run from a repository checkout as well as from an installed system, where
+        /// the sources of the other components are not laid out the same way.
+        /// </summary>
+        private static TFound? LocateBesideOrAbove<TFound>(Func<DirectoryInfo, TFound?> lookup) where TFound : class
+        {
+            DirectoryInfo? directory = new(AppContext.BaseDirectory);
+            while (directory is not null)
+            {
+                TFound? found = lookup(directory);
+                if (found is not null)
+                {
+                    return found;
+                }
+                directory = directory.Parent;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Skips a test when the metadata or the API calls cannot be read, which happens wherever only
+        /// part of the sources is deployed. Reporting that plainly is better than passing on no input.
+        /// </summary>
+        private static void SkipWithoutSources()
+        {
+            if (kMetadataFileInfo.Value is null)
+            {
+                Assert.Ignore(kMetadataOutOfReach);
+            }
+            if (kApiCallDirectory.Value is null)
+            {
+                Assert.Ignore(kApiCallsOutOfReach);
+            }
+        }
+
+        [GeneratedRegex(@"^\s*(query|mutation|subscription)\b", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex OperationKeywordRegex();
+
+        [GeneratedRegex(@"^(insert|update|delete)_(.+)$", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex MutationRootFieldRegex();
+
+        [GeneratedRegex(@"\bwhere\s*:\s*\{", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex FilterArgumentRegex();
+
+        [GeneratedRegex(@"\bwhere\s*:\s*\$", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex VariableFilterRegex();
+
+        [GeneratedRegex(@"\b_set\s*:\s*\{", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex AssignmentRegex();
+
+        [GeneratedRegex(@"\bobjects?\s*:\s*[\{\[]", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex ObjectsRegex();
+
+        [GeneratedRegex(@"\b(_set|objects?|updates)\s*:\s*\$", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex VariableWrittenRegex();
+
+        [GeneratedRegex(@"([A-Za-z_][A-Za-z0-9_]*)\s*:\s*", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex MemberRegex();
+    }
+}

--- a/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
@@ -423,7 +423,7 @@ namespace FWO.Test
         /// Reads the names of the relationships of a table, which appear in a filter and in a selection set
         /// like a column but address another table.
         /// </summary>
-        private static void ReadRelationships(JsonElement table, ISet<string> relationships)
+        private static void ReadRelationships(JsonElement table, HashSet<string> relationships)
         {
             foreach (string kind in kRelationshipKinds)
             {

--- a/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
@@ -1,0 +1,475 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using ApiQueries = FWO.Api.Client.Queries.Queries;
+
+namespace FWO.Test
+{
+    /// <summary>
+    /// Guards the alignment between the API call definitions and the Hasura role permissions.
+    /// Hasura builds the columns of a role specific &lt;table&gt;_bool_exp from the select permission of
+    /// that role, so a role which may delete or update a table but cannot select the columns its where
+    /// clause filters on has the mutation rejected while it is validated. Nothing but a runtime error
+    /// inside a background job reports that mismatch, which is why it is checked here instead.
+    /// The metadata and the API calls are embedded into this assembly at build time
+    /// (see FWO.Test.csproj), so no file of another component is read at runtime.
+    /// </summary>
+    [TestFixture]
+    internal partial class ApiPermissionAlignmentTest
+    {
+        private const string kMetadataResource = "FWO.Test.replace_metadata.json";
+        private const string kApiCallPrefix = "FWO.Test.ApiCalls.";
+        private const string kApiCallSuffix = ".graphql";
+        private const string kPermissionSuffix = "_permissions";
+        private const string kSelectOperation = "select";
+        private const string kPublicSchema = "public";
+        private const string kManyRootSuffix = "_many";
+        private const int kMaxFilterDepth = 100;
+        private const int kRegexTimeoutMilliseconds = 1000;
+
+        /// <summary>
+        /// Operators combining several conditions. Their operands are conditions again and not columns.
+        /// </summary>
+        private static readonly List<string> kLogicalOperators = new() { "_and", "_or", "_not" };
+
+        /// <summary>
+        /// Mismatches which exist in the metadata already. Every entry breaks the API call named with it
+        /// for the role named with it, and closing one widens the read access of that role, which is a
+        /// decision for the owner of the respective workflow. They are listed here so the check passes on
+        /// the current metadata while still failing for every mismatch added from now on.
+        /// ApiCalls_KnownPermissionGapsStillExist removes the risk of the list outliving the mismatches.
+        /// </summary>
+        private static readonly List<string> kKnownPermissionGaps = new()
+        {
+            // monitor/updateAlert.graphql, reporter-viewall may acknowledge alerts but not read any
+            "alert|reporter-viewall|alert_id",
+            // monitor/acknowledgeAllOpenAlerts.graphql, same role and table as above
+            "alert|reporter-viewall|ack_by",
+            // modelling/removeSelectedNwGroupObject.graphql, middleware-server selects nwgroup_id only
+            "modelling_selected_objects|middleware-server|app_id",
+            // modelling/replaceUsedInterface.graphql, implementer may update conn_prop but not read
+            "modelling_connection|implementer|used_interface_id"
+        };
+
+        /// <summary>
+        /// Every column an API call filters a delete or update on has to be selectable by the roles which
+        /// are allowed to run that mutation, otherwise the column is no field of their boolean expression.
+        /// </summary>
+        [Test]
+        public void ApiCalls_FilterOnlyColumnsTheirRolesMaySelect()
+        {
+            Dictionary<string, TableMetadata> tables = ReadMetadata();
+            List<string> mismatches = new();
+
+            foreach (FilteredMutation mutation in ReadFilteredMutations())
+            {
+                if (tables.TryGetValue(mutation.TableRoot, out TableMetadata? table))
+                {
+                    mismatches.AddRange(FindMismatches(mutation, table)
+                        .Where(gap => !kKnownPermissionGaps.Contains(gap))
+                        .Select(gap => $"{mutation.Source}: {gap}"));
+                }
+            }
+
+            Assert.That(mismatches, Is.Empty,
+                "A role may run these mutations but cannot select the columns they filter on:"
+                + Environment.NewLine + string.Join(Environment.NewLine, mismatches));
+        }
+
+        /// <summary>
+        /// A mutation on a table which is not tracked in the metadata does not exist in the API schema at
+        /// all, so an unknown table name is a typo or a table someone forgot to track.
+        /// </summary>
+        [Test]
+        public void ApiCalls_AddressOnlyTrackedTables()
+        {
+            Dictionary<string, TableMetadata> tables = ReadMetadata();
+
+            List<string> unknownTables = ReadFilteredMutations()
+                .Where(mutation => !tables.ContainsKey(mutation.TableRoot))
+                .Select(mutation => $"{mutation.Source}: {mutation.TableRoot}")
+                .Distinct()
+                .ToList();
+
+            Assert.That(unknownTables, Is.Empty,
+                "These mutations address tables which are not tracked in the metadata:"
+                + Environment.NewLine + string.Join(Environment.NewLine, unknownTables));
+        }
+
+        /// <summary>
+        /// Keeps the accepted mismatches honest: once one of them is repaired in the metadata its entry has
+        /// to be removed here as well, otherwise the list would silently accept the mismatch again later.
+        /// </summary>
+        [Test]
+        public void ApiCalls_KnownPermissionGapsStillExist()
+        {
+            Dictionary<string, TableMetadata> tables = ReadMetadata();
+            List<string> existingGaps = new();
+
+            foreach (FilteredMutation mutation in ReadFilteredMutations())
+            {
+                if (tables.TryGetValue(mutation.TableRoot, out TableMetadata? table))
+                {
+                    existingGaps.AddRange(FindMismatches(mutation, table));
+                }
+            }
+
+            List<string> repairedGaps = kKnownPermissionGaps.Where(gap => !existingGaps.Contains(gap)).ToList();
+
+            Assert.That(repairedGaps, Is.Empty,
+                "These accepted mismatches no longer exist and have to be removed from kKnownPermissionGaps:"
+                + Environment.NewLine + string.Join(Environment.NewLine, repairedGaps));
+        }
+
+        /// <summary>
+        /// Collects the roles which may run the mutation but cannot select one of the filtered columns.
+        /// </summary>
+        /// <returns>One entry per missing permission, in the format of FormatGap.</returns>
+        private static List<string> FindMismatches(FilteredMutation mutation, TableMetadata table)
+        {
+            List<string> mismatches = new();
+            if (!table.RolesByOperation.TryGetValue(mutation.Operation, out List<string>? roles))
+            {
+                return mismatches;
+            }
+
+            foreach (string role in roles)
+            {
+                table.SelectableColumns.TryGetValue(role, out HashSet<string>? selectable);
+                mismatches.AddRange(mutation.Columns
+                    .Where(column => selectable == null || !selectable.Contains(column))
+                    .Select(column => FormatGap(mutation.TableRoot, role, column)));
+            }
+            return mismatches;
+        }
+
+        /// <summary>
+        /// Identifies one missing permission independently of the API call which uncovered it, so the same
+        /// gap reported by several calls is accepted by a single entry of kKnownPermissionGaps.
+        /// </summary>
+        private static string FormatGap(string tableRoot, string role, string column)
+        {
+            return $"{tableRoot}|{role}|{column}";
+        }
+
+        /// <summary>
+        /// Reads the tables of the metadata by the name their mutations carry in the GraphQL schema.
+        /// </summary>
+        private static Dictionary<string, TableMetadata> ReadMetadata()
+        {
+            using JsonDocument metadata = JsonDocument.Parse(ReadResource(kMetadataResource));
+            Dictionary<string, TableMetadata> tables = new();
+
+            foreach (JsonElement source in metadata.RootElement.GetProperty("args")
+                .GetProperty("metadata").GetProperty("sources").EnumerateArray())
+            {
+                foreach (JsonElement table in source.GetProperty("tables").EnumerateArray())
+                {
+                    tables.Add(ReadTableRoot(table.GetProperty("table")), ReadTablePermissions(table));
+                }
+            }
+            return tables;
+        }
+
+        /// <summary>
+        /// Builds the name the mutations of a table carry, which Hasura prefixes with the schema for every
+        /// schema but public.
+        /// </summary>
+        private static string ReadTableRoot(JsonElement table)
+        {
+            string schema = table.GetProperty("schema").GetString() ?? "";
+            string name = table.GetProperty("name").GetString() ?? "";
+            return schema == kPublicSchema ? name : $"{schema}_{name}";
+        }
+
+        /// <summary>
+        /// Reads which roles hold which permission on a table and which columns each role may select.
+        /// </summary>
+        private static TableMetadata ReadTablePermissions(JsonElement table)
+        {
+            TableMetadata metadata = new();
+            foreach (JsonProperty property in table.EnumerateObject()
+                .Where(property => property.Name.EndsWith(kPermissionSuffix)))
+            {
+                string operation = property.Name[..^kPermissionSuffix.Length];
+                foreach (JsonElement entry in property.Value.EnumerateArray())
+                {
+                    string role = entry.GetProperty("role").GetString() ?? "";
+                    AddRole(metadata.RolesByOperation, operation, role);
+                    if (operation == kSelectOperation)
+                    {
+                        metadata.SelectableColumns[role] = ReadPermittedColumns(entry);
+                    }
+                }
+            }
+            return metadata;
+        }
+
+        /// <summary>
+        /// Adds a role to the roles holding one permission on a table.
+        /// </summary>
+        private static void AddRole(Dictionary<string, List<string>> rolesByOperation, string operation, string role)
+        {
+            if (!rolesByOperation.TryGetValue(operation, out List<string>? roles))
+            {
+                roles = new();
+                rolesByOperation.Add(operation, roles);
+            }
+            roles.Add(role);
+        }
+
+        /// <summary>
+        /// Reads the columns of one permission entry. A delete permission carries no columns at all.
+        /// </summary>
+        private static HashSet<string> ReadPermittedColumns(JsonElement permissionEntry)
+        {
+            HashSet<string> columns = new();
+            if (permissionEntry.GetProperty("permission").TryGetProperty("columns", out JsonElement declared)
+                && declared.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement column in declared.EnumerateArray())
+                {
+                    columns.Add(column.GetString() ?? "");
+                }
+            }
+            return columns;
+        }
+
+        /// <summary>
+        /// Reads every delete and update mutation of the embedded API calls which carries a where clause.
+        /// </summary>
+        private static List<FilteredMutation> ReadFilteredMutations()
+        {
+            List<FilteredMutation> mutations = new();
+            foreach (string resource in Assembly.GetExecutingAssembly().GetManifestResourceNames()
+                .Where(name => name.StartsWith(kApiCallPrefix) && name.EndsWith(kApiCallSuffix)))
+            {
+                mutations.AddRange(ReadFilteredMutations(FormatSource(resource), ApiQueries.Compact(ReadResource(resource))));
+            }
+            return mutations;
+        }
+
+        /// <summary>
+        /// Reads the filtered mutations of a single API call. The call is compacted the same way it is
+        /// before it is sent, so the comments of the file cannot be mistaken for a mutation.
+        /// </summary>
+        private static List<FilteredMutation> ReadFilteredMutations(string source, string apiCall)
+        {
+            List<FilteredMutation> mutations = new();
+            foreach (Match mutation in MutationRegex().Matches(apiCall).Cast<Match>())
+            {
+                string? filter = ReadFilter(apiCall, mutation.Index + mutation.Length - 1);
+                if (filter == null)
+                {
+                    continue;
+                }
+
+                HashSet<string> columns = new();
+                CollectFilterColumns(filter, columns, 0);
+                mutations.Add(new FilteredMutation(source, mutation.Groups[1].Value,
+                    ReadMutationRoot(mutation.Groups[2].Value), columns.ToList()));
+            }
+            return mutations;
+        }
+
+        /// <summary>
+        /// Reads the table a mutation addresses. Hasura appends _many to the mutation updating several
+        /// filters at once and _by_pk to the one addressing a single row without a where clause.
+        /// </summary>
+        private static string ReadMutationRoot(string mutationName)
+        {
+            return mutationName.EndsWith(kManyRootSuffix) ? mutationName[..^kManyRootSuffix.Length] : mutationName;
+        }
+
+        /// <summary>
+        /// Reads the body of the where clause out of the argument list starting at the given bracket.
+        /// </summary>
+        /// <returns>The body of the where clause, or null when the mutation has none.</returns>
+        private static string? ReadFilter(string apiCall, int argumentStart)
+        {
+            int argumentEnd = IndexOfMatchingBracket(apiCall, argumentStart);
+            if (argumentEnd < 0)
+            {
+                return null;
+            }
+
+            string arguments = apiCall[(argumentStart + 1)..argumentEnd];
+            Match filter = FilterRegex().Match(arguments);
+            if (!filter.Success)
+            {
+                return null;
+            }
+
+            int filterStart = filter.Index + filter.Length - 1;
+            int filterEnd = IndexOfMatchingBracket(arguments, filterStart);
+            return filterEnd < 0 ? null : arguments[(filterStart + 1)..filterEnd];
+        }
+
+        /// <summary>
+        /// Collects the columns a filter compares. A member comparing a column carries operators only,
+        /// every other member walks a relationship into another table and is left to the API call of it.
+        /// </summary>
+        private static void CollectFilterColumns(string filter, ISet<string> columns, int depth)
+        {
+            if (depth >= kMaxFilterDepth)
+            {
+                throw new InvalidOperationException($"Filter is nested deeper than {kMaxFilterDepth} levels.");
+            }
+
+            foreach ((string name, string? body) in EnumerateMembers(filter))
+            {
+                if (body == null)
+                {
+                    continue;
+                }
+                if (kLogicalOperators.Contains(name))
+                {
+                    CollectFilterColumns(body, columns, depth + 1);
+                }
+                else if (!name.StartsWith('_') && ComparesAColumn(body))
+                {
+                    columns.Add(name);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Decides whether the members of a filter member are comparison operators, which makes the member
+        /// itself a column and not a relationship.
+        /// </summary>
+        private static bool ComparesAColumn(string memberBody)
+        {
+            bool hasMember = false;
+            foreach ((string name, string? _) in EnumerateMembers(memberBody))
+            {
+                hasMember = true;
+                if (!name.StartsWith('_'))
+                {
+                    return false;
+                }
+            }
+            return hasMember;
+        }
+
+        /// <summary>
+        /// Walks the members of a GraphQL object.
+        /// </summary>
+        /// <returns>The name of every member with its body, which is null for a member holding a value.</returns>
+        private static IEnumerable<(string Name, string? Body)> EnumerateMembers(string objectBody)
+        {
+            int position = 0;
+            while (position < objectBody.Length)
+            {
+                Match member = MemberRegex().Match(objectBody, position);
+                if (!member.Success)
+                {
+                    yield break;
+                }
+
+                int valueStart = member.Index + member.Length;
+                int valueEnd = IsBracket(objectBody, valueStart) ? IndexOfMatchingBracket(objectBody, valueStart) : -1;
+                if (valueEnd < 0)
+                {
+                    yield return (member.Groups[1].Value, null);
+                    position = valueStart;
+                    continue;
+                }
+
+                yield return (member.Groups[1].Value, objectBody[(valueStart + 1)..valueEnd]);
+                position = valueEnd + 1;
+            }
+        }
+
+        /// <summary>
+        /// Decides whether an object or a list starts at the given position.
+        /// </summary>
+        private static bool IsBracket(string text, int position)
+        {
+            return position < text.Length && (text[position] == '{' || text[position] == '[');
+        }
+
+        /// <summary>
+        /// Finds the bracket closing the one at the given position. Brackets of another kind in between do
+        /// not change the nesting of the searched one and are therefore not counted.
+        /// </summary>
+        /// <returns>The position of the closing bracket, or -1 when it is missing.</returns>
+        private static int IndexOfMatchingBracket(string text, int openingPosition)
+        {
+            char opening = text[openingPosition];
+            char closing = ClosingBracketOf(opening);
+            int depth = 0;
+
+            for (int position = openingPosition; position < text.Length; position++)
+            {
+                if (text[position] == opening)
+                {
+                    depth++;
+                }
+                else if (text[position] == closing && --depth == 0)
+                {
+                    return position;
+                }
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Reads the bracket closing an opening one.
+        /// </summary>
+        private static char ClosingBracketOf(char opening)
+        {
+            return opening switch
+            {
+                '{' => '}',
+                '[' => ']',
+                '(' => ')',
+                _ => throw new ArgumentException($"{opening} is no opening bracket.", nameof(opening))
+            };
+        }
+
+        /// <summary>
+        /// Names an API call by its path below fwo-api-calls, so a failure points at the file to repair.
+        /// The directories of the path are separators of the resource name and are restored here.
+        /// </summary>
+        private static string FormatSource(string resourceName)
+        {
+            string path = resourceName[kApiCallPrefix.Length..^kApiCallSuffix.Length];
+            return path.Replace('.', Path.AltDirectorySeparatorChar) + kApiCallSuffix;
+        }
+
+        /// <summary>
+        /// Reads an embedded resource of this assembly.
+        /// </summary>
+        private static string ReadResource(string resourceName)
+        {
+            using Stream? resource = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName)
+                ?? throw new InvalidOperationException($"Embedded resource {resourceName} is missing.");
+            using StreamReader reader = new(resource);
+            return reader.ReadToEnd();
+        }
+
+        [GeneratedRegex(@"\b(delete|update)_([A-Za-z0-9_]+)\s*\(", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex MutationRegex();
+
+        [GeneratedRegex(@"\bwhere\s*:\s*\{", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex FilterRegex();
+
+        [GeneratedRegex(@"([A-Za-z_][A-Za-z0-9_]*)\s*:\s*", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex MemberRegex();
+
+        /// <summary>
+        /// A delete or update mutation of an API call together with the columns its where clause filters on.
+        /// </summary>
+        private sealed record FilteredMutation(string Source, string Operation, string TableRoot, List<string> Columns);
+
+        /// <summary>
+        /// The permissions of one table: which roles hold which permission and which columns they may select.
+        /// </summary>
+        private sealed class TableMetadata
+        {
+            public Dictionary<string, List<string>> RolesByOperation { get; } = new();
+            public Dictionary<string, HashSet<string>> SelectableColumns { get; } = new();
+        }
+    }
+}

--- a/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
@@ -1,19 +1,31 @@
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using NUnit.Framework;
-using ApiQueries = FWO.Api.Client.Queries.Queries;
 
 namespace FWO.Test
 {
     /// <summary>
     /// Guards the alignment between the API call definitions and the Hasura role permissions.
-    /// Hasura builds the columns of a role specific &lt;table&gt;_bool_exp from the select permission of
-    /// that role, so a role which may delete or update a table but cannot select the columns its where
-    /// clause filters on has the mutation rejected while it is validated. Nothing but a runtime error
-    /// inside a background job reports that mismatch, which is why it is checked here instead.
+    /// Hasura derives what a role sees of a table from the select permission of that role, which makes
+    /// a missing select permission break calls that never read anything on purpose:
+    /// <list type="bullet">
+    /// <item>the columns of a role specific &lt;table&gt;_bool_exp are the selectable ones, so a role which
+    /// may delete or update a table but cannot select the columns its where clause filters on has the
+    /// mutation rejected while it is validated,</item>
+    /// <item>a mutation response passes through the select permission as well, so a role which cannot
+    /// select the columns behind a returning block cannot run the mutation either, and a _by_pk root
+    /// field is not even part of the schema of a role without select permission on the table.</item>
+    /// </list>
+    /// Nothing but a runtime error inside a background job or a page reports either mismatch, which is why
+    /// they are checked here instead.
     /// The metadata and the API calls are read from the repository, or from the places the installer
     /// deploys them to, because an installed system holds only the sources of the tests themselves.
     /// Where neither is reachable the checks are skipped instead of passing on no input at all.
+    /// What the checks cannot see is listed by ReportUncheckableCalls instead of passing silently:
+    /// filters and object lists handed over as a variable are only known at run time, and a selection set
+    /// behind a fragment spread lives in another file, so of it only the fact that something is returned
+    /// is used. Queries are covered by ApiCalls_QueriesAreRunnableByAtLeastOneRole alone, because the
+    /// metadata does not record which role issues which query and demanding the filter of a query from
+    /// every role holding select permission would report far more roles than ever run it.
     /// </summary>
     [TestFixture]
     internal partial class ApiPermissionAlignmentTest
@@ -27,16 +39,65 @@ namespace FWO.Test
             "The API call definitions are not reachable in this environment, so the permission alignment cannot be checked.";
         private const string kPermissionSuffix = "_permissions";
         private const string kSelectOperation = "select";
+        private const string kInsertOperation = "insert";
         private const string kUpdateOperation = "update";
+        private const string kDeleteOperation = "delete";
+        private const string kQueryOperationType = "query";
+        private const string kMutationOperationType = "mutation";
         private const string kPublicSchema = "public";
-        private const string kManyRootSuffix = "_many";
+        private const string kByPkRootSuffix = "_by_pk";
+        private const string kFragmentSpread = "...";
+        private const string kAffectedRowsField = "affected_rows";
+        private const string kReturningField = "returning";
+        private const string kTypeNameField = "__typename";
+        private const string kAllColumnsMarker = "*";
+
+        /// <summary>
+        /// Stands for "the role needs select permission on this table at all" in a gap, which is what a
+        /// _by_pk root field and a returning block behind a fragment spread require without naming a
+        /// single column.
+        /// </summary>
+        private const string kAnyColumn = "<any column>";
+
+        /// <summary>
+        /// Stands for "no role at all" in a gap reported for a query, whose issuing role is not recorded
+        /// anywhere in the metadata.
+        /// </summary>
+        private const string kAnyRole = "<any role>";
+
         private const int kMaxFilterDepth = 100;
         private const int kRegexTimeoutMilliseconds = 1000;
 
         /// <summary>
-        /// Operators combining several conditions. Their operands are conditions again and not columns.
+        /// Operators combining several conditions. Their operands are conditions again and not columns,
+        /// and they appear in a boolean expression only, never inside the comparison of a single column,
+        /// which is what tells a relationship apart from a column.
         /// </summary>
         private static readonly List<string> kLogicalOperators = new() { "_and", "_or", "_not" };
+
+        /// <summary>
+        /// Suffixes Hasura appends to the name of a table for a root field addressing it in another way.
+        /// They are cut off to arrive at the table the root field belongs to.
+        /// </summary>
+        private static readonly List<string> kRootFieldSuffixes =
+            new() { "_many", "_one", "_aggregate", "_stream" };
+
+        /// <summary>
+        /// The kinds of relationship a table declares, which are read the same way.
+        /// </summary>
+        private static readonly List<string> kRelationshipKinds =
+            new() { "object_relationships", "array_relationships" };
+
+        /// <summary>
+        /// Fields of a mutation response which are no columns of the table.
+        /// </summary>
+        private static readonly List<string> kResponseMetaFields = new() { kAffectedRowsField, kTypeNameField };
+
+        /// <summary>
+        /// Marks a role which may select every column of a table, which Hasura writes as "*" instead of
+        /// listing the columns. Compared by reference, so it cannot collide with a real column set.
+        /// </summary>
+        private static readonly HashSet<string> kAllColumns = new() { kAllColumnsMarker };
 
         /// <summary>
         /// The sources under test. They are looked up once and are read from wherever the environment
@@ -45,16 +106,39 @@ namespace FWO.Test
         /// </summary>
         private static readonly Lazy<FileInfo?> kMetadataFileInfo = new(LocateMetadata);
         private static readonly Lazy<DirectoryInfo?> kApiCallDirectory = new(LocateApiCalls);
+        private static readonly Lazy<ApiCallSurvey> kApiCallSurvey = new(ReadApiCalls);
 
         /// <summary>
         /// Mismatches which are accepted although they exist. Every entry breaks the API call named with
         /// it for the role named with it, and closing one widens the read access of that role, which is a
-        /// decision for the owner of the respective workflow. The list is empty because the metadata
-        /// currently holds no such mismatch; it stays here so an accepted one can be recorded with the
-        /// reason for accepting it instead of being silenced by weakening the check.
-        /// ApiCalls_KnownPermissionGapsStillExist removes the risk of the list outliving the mismatches.
+        /// decision for the owner of the respective workflow rather than one to take while repairing an
+        /// unrelated call. ApiCalls_KnownPermissionGapsStillExist removes the risk of an entry outliving
+        /// the mismatch it accepts.
         /// </summary>
-        private static readonly List<string> kKnownPermissionGaps = new();
+        private static readonly List<string> kKnownPermissionGaps = new()
+        {
+            // The importer role holds insert permission on recertification but none of the three calls is
+            // issued by the importer: FWO.Recert sends them under the role of the logged in user
+            // (RecertRefresh.cs, RecertHandler.cs). Granting the importer select on recertification would
+            // widen its read access for a call it never makes. Dropping its insert permission instead is
+            // the cleaner repair and belongs to the owner of the recertification workflow.
+            "recertification|importer|<any column>",
+
+            // The middleware-server role holds insert permission on report but report/addGeneratedReport
+            // is sent over the user context connection of the scheduling user (ReportJob.cs), never under
+            // the technical role. Granting it select on report would widen its read access to every
+            // generated report for a call it never makes; dropping the insert permission is the cleaner
+            // repair and belongs to the owner of the report scheduling workflow.
+            "report|middleware-server|<any column>",
+
+            // v_rule_with_rule_owner_1 is tracked with no permission at all, so owner/getRuleOwnerships
+            // exists in the schema of no role of this metadata. /settings/owners is open to admin and
+            // auditor: admin is the built in role of Hasura and passes every permission, auditor is not
+            // and its EditOwner.razor fails to load the rules of an owner. Which role should read the view
+            // is a decision for the owner of the ownership workflow; the gap is recorded here so it is not
+            // lost while it is open.
+            "v_rule_with_rule_owner_1|<any role>|owner_id"
+        };
 
         /// <summary>
         /// Every column an API call filters a delete or update on has to be selectable by the roles which
@@ -63,24 +147,31 @@ namespace FWO.Test
         [Test]
         public void ApiCalls_FilterOnlyColumnsTheirRolesMaySelect()
         {
-            SkipWithoutSources();
+            AssertNoGaps(CollectGaps(FindFilterGaps),
+                "A role may run these mutations but cannot select the columns they filter on:");
+        }
 
-            Dictionary<string, TableMetadata> tables = ReadMetadata();
-            List<string> mismatches = new();
+        /// <summary>
+        /// Every column a mutation returns has to be selectable by the roles which are allowed to run it,
+        /// because a mutation response is read through the select permission of the role.
+        /// </summary>
+        [Test]
+        public void ApiCalls_ReturnOnlyColumnsTheirRolesMaySelect()
+        {
+            AssertNoGaps(CollectGaps(FindReturnGaps),
+                "A role may run these mutations but cannot select the columns they return:");
+        }
 
-            foreach (FilteredMutation mutation in ReadFilteredMutations())
-            {
-                if (tables.TryGetValue(mutation.TableRoot, out TableMetadata? table))
-                {
-                    mismatches.AddRange(FindMismatches(mutation, table)
-                        .Where(gap => !kKnownPermissionGaps.Contains(gap))
-                        .Select(gap => $"{mutation.Source}: {gap}"));
-                }
-            }
-
-            Assert.That(mismatches, Is.Empty,
-                "A role may run these mutations but cannot select the columns they filter on:"
-                + Environment.NewLine + string.Join(Environment.NewLine, mismatches));
+        /// <summary>
+        /// A query filtering on columns no role at all may select cannot be issued by anybody, so it is
+        /// broken however it is called. Which role issues a query is recorded nowhere, which is why only
+        /// this direction of the check is decidable.
+        /// </summary>
+        [Test]
+        public void ApiCalls_QueriesAreRunnableByAtLeastOneRole()
+        {
+            AssertNoGaps(CollectGaps(FindUnrunnableQueryGaps),
+                "No role can select all the columns these queries filter on:");
         }
 
         /// <summary>
@@ -93,10 +184,10 @@ namespace FWO.Test
             SkipWithoutSources();
 
             Dictionary<string, TableMetadata> tables = ReadMetadata();
-
-            List<string> unknownTables = ReadFilteredMutations()
-                .Where(mutation => !tables.ContainsKey(mutation.TableRoot))
-                .Select(mutation => $"{mutation.Source}: {mutation.TableRoot}")
+            List<string> unknownTables = kApiCallSurvey.Value.Operations
+                .Where(operation => operation.Operation != kSelectOperation)
+                .Where(operation => !tables.ContainsKey(operation.TableRoot))
+                .Select(operation => $"{operation.Source}: {operation.TableRoot}")
                 .Distinct()
                 .ToList();
 
@@ -114,17 +205,10 @@ namespace FWO.Test
         {
             SkipWithoutSources();
 
-            Dictionary<string, TableMetadata> tables = ReadMetadata();
-            List<string> existingGaps = new();
-
-            foreach (FilteredMutation mutation in ReadFilteredMutations())
-            {
-                if (tables.TryGetValue(mutation.TableRoot, out TableMetadata? table))
-                {
-                    existingGaps.AddRange(FindMismatches(mutation, table));
-                }
-            }
-
+            HashSet<string> existingGaps = new(CollectGaps(FindFilterGaps, false)
+                .Concat(CollectGaps(FindReturnGaps, false))
+                .Concat(CollectGaps(FindUnrunnableQueryGaps, false))
+                .Select(gap => gap.Gap));
             List<string> repairedGaps = kKnownPermissionGaps.Where(gap => !existingGaps.Contains(gap)).ToList();
 
             Assert.That(repairedGaps, Is.Empty,
@@ -133,40 +217,113 @@ namespace FWO.Test
         }
 
         /// <summary>
-        /// Collects the roles which may run the mutation but cannot select one of the filtered columns.
+        /// Fails with the gaps a check found, naming the API call which uncovered each of them.
         /// </summary>
-        /// <returns>One entry per missing permission, in the format of FormatGap.</returns>
-        private static List<string> FindMismatches(FilteredMutation mutation, TableMetadata table)
+        private static void AssertNoGaps(List<ReportedGap> gaps, string message)
         {
-            List<string> mismatches = new();
-            if (!table.RolesByOperation.TryGetValue(mutation.Operation, out List<string>? roles))
-            {
-                return mismatches;
-            }
-
-            foreach (string role in roles.Where(role => MayRunMutation(mutation, table, role)))
-            {
-                table.SelectableColumns.TryGetValue(role, out HashSet<string>? selectable);
-                mismatches.AddRange(mutation.Columns
-                    .Where(column => selectable == null || !selectable.Contains(column))
-                    .Select(column => FormatGap(mutation.TableRoot, role, column)));
-            }
-            return mismatches;
+            List<string> reported = gaps.Select(gap => $"{gap.Source}: {gap.Gap}").ToList();
+            Assert.That(reported, Is.Empty,
+                message + Environment.NewLine + string.Join(Environment.NewLine, reported));
         }
 
         /// <summary>
-        /// Decides whether a role can run a mutation at all. An update writing a column the role may not
-        /// write is rejected for that column already, so its where clause never reaches the role and
+        /// Runs one check over every API call operation addressing a tracked table.
+        /// </summary>
+        /// <param name="findGaps">The check, returning one entry per gap in the format of FormatGap.</param>
+        /// <param name="skipKnownGaps">Whether the accepted mismatches are filtered out.</param>
+        private static List<ReportedGap> CollectGaps(
+            Func<ApiOperation, TableMetadata, IEnumerable<string>> findGaps, bool skipKnownGaps = true)
+        {
+            SkipWithoutSources();
+            ReportUncheckableCalls();
+
+            Dictionary<string, TableMetadata> tables = ReadMetadata();
+            List<ReportedGap> gaps = new();
+            foreach (ApiOperation operation in kApiCallSurvey.Value.Operations)
+            {
+                if (tables.TryGetValue(operation.TableRoot, out TableMetadata? table))
+                {
+                    gaps.AddRange(findGaps(operation, table)
+                        .Where(gap => !skipKnownGaps || !kKnownPermissionGaps.Contains(gap))
+                        .Select(gap => new ReportedGap(operation.Source, gap)));
+                }
+            }
+            return gaps;
+        }
+
+        /// <summary>
+        /// Collects the roles which may run the mutation but cannot select one of the filtered columns.
+        /// </summary>
+        private static IEnumerable<string> FindFilterGaps(ApiOperation operation, TableMetadata table)
+        {
+            if (operation.Operation == kSelectOperation)
+            {
+                yield break;
+            }
+
+            foreach (string role in RolesRunning(operation, table))
+            {
+                foreach (string column in operation.FilterColumns.Where(column => !table.MaySelect(role, column)))
+                {
+                    yield return FormatGap(operation.TableRoot, role, column);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Collects the roles which may run the mutation but cannot select what it returns. A mutation
+        /// returning nothing but affected_rows reads nothing and needs no select permission at all.
+        /// </summary>
+        private static IEnumerable<string> FindReturnGaps(ApiOperation operation, TableMetadata table)
+        {
+            if (operation.Operation == kSelectOperation || !operation.ReadsItsResult)
+            {
+                yield break;
+            }
+
+            foreach (string role in RolesRunning(operation, table))
+            {
+                if (!table.MaySelectAnything(role))
+                {
+                    yield return FormatGap(operation.TableRoot, role, kAnyColumn);
+                    continue;
+                }
+                foreach (string column in operation.ReturnedColumns.Where(column => !table.MaySelect(role, column)))
+                {
+                    yield return FormatGap(operation.TableRoot, role, column);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reports a query whose filter no role can satisfy, which makes it unusable for everybody.
+        /// </summary>
+        private static IEnumerable<string> FindUnrunnableQueryGaps(ApiOperation operation, TableMetadata table)
+        {
+            if (operation.Operation != kSelectOperation || operation.FilterColumns.Count == 0
+                || table.AnyRoleMaySelectAll(operation.FilterColumns))
+            {
+                yield break;
+            }
+
+            foreach (string column in operation.FilterColumns)
+            {
+                yield return FormatGap(operation.TableRoot, kAnyRole, column);
+            }
+        }
+
+        /// <summary>
+        /// The roles which can run a mutation. A mutation writing a column the role may not write is
+        /// rejected for that column already, so its where clause and its response never reach the role and
         /// demanding a select permission for it would only invite widening the read access for nothing.
         /// </summary>
-        private static bool MayRunMutation(FilteredMutation mutation, TableMetadata table, string role)
+        private static IEnumerable<string> RolesRunning(ApiOperation operation, TableMetadata table)
         {
-            if (mutation.Operation != kUpdateOperation || mutation.UpdatedColumns.Count == 0)
+            if (!table.RolesByOperation.TryGetValue(operation.Operation, out List<string>? roles))
             {
-                return true;
+                return new List<string>();
             }
-            return table.UpdatableColumns.TryGetValue(role, out HashSet<string>? updatable)
-                && mutation.UpdatedColumns.TrueForAll(updatable.Contains);
+            return roles.Where(role => table.MayWrite(operation, role));
         }
 
         /// <summary>
@@ -179,7 +336,21 @@ namespace FWO.Test
         }
 
         /// <summary>
-        /// Reads the tables of the metadata by the name their mutations carry in the GraphQL schema.
+        /// Writes what the checks could not look at to the test output, so a call growing beyond what the
+        /// reader understands is visible instead of counting as checked.
+        /// </summary>
+        private static void ReportUncheckableCalls()
+        {
+            List<string> uncheckable = kApiCallSurvey.Value.Uncheckable;
+            TestContext.Out.WriteLine($"{uncheckable.Count} part(s) of the API calls cannot be checked statically:");
+            foreach (string note in uncheckable)
+            {
+                TestContext.Out.WriteLine($"  {note}");
+            }
+        }
+
+        /// <summary>
+        /// Reads the tables of the metadata by the name their root fields carry in the GraphQL schema.
         /// </summary>
         private static Dictionary<string, TableMetadata> ReadMetadata()
         {
@@ -193,15 +364,15 @@ namespace FWO.Test
             {
                 foreach (JsonElement table in source.GetProperty("tables").EnumerateArray())
                 {
-                    tables.Add(ReadTableRoot(table.GetProperty("table")), ReadTablePermissions(table));
+                    tables[ReadTableRoot(table.GetProperty("table"))] = ReadTablePermissions(table);
                 }
             }
             return tables;
         }
 
         /// <summary>
-        /// Builds the name the mutations of a table carry, which Hasura prefixes with the schema for every
-        /// schema but public.
+        /// Builds the name the root fields of a table carry, which Hasura prefixes with the schema for
+        /// every schema but public.
         /// </summary>
         private static string ReadTableRoot(JsonElement table)
         {
@@ -211,7 +382,8 @@ namespace FWO.Test
         }
 
         /// <summary>
-        /// Reads which roles hold which permission on a table and which columns each role may select.
+        /// Reads which roles hold which permission on a table, which columns each role may select or
+        /// write, and the relationships of the table, which are no columns of it.
         /// </summary>
         private static TableMetadata ReadTablePermissions(JsonElement table)
         {
@@ -224,17 +396,45 @@ namespace FWO.Test
                 {
                     string role = entry.GetProperty("role").GetString() ?? "";
                     AddRole(metadata.RolesByOperation, operation, role);
-                    if (operation == kSelectOperation)
+                    AddPermittedColumns(metadata, operation, role, entry);
+                }
+            }
+            ReadRelationships(table, metadata.Relationships);
+            return metadata;
+        }
+
+        /// <summary>
+        /// Records the columns one permission entry grants, for the operations whose columns are checked.
+        /// </summary>
+        private static void AddPermittedColumns(TableMetadata metadata, string operation, string role,
+            JsonElement entry)
+        {
+            if (operation == kSelectOperation)
+            {
+                metadata.SelectableColumns[role] = ReadPermittedColumns(entry);
+            }
+            else if (operation == kUpdateOperation || operation == kInsertOperation)
+            {
+                metadata.WritableColumns[(operation, role)] = ReadPermittedColumns(entry);
+            }
+        }
+
+        /// <summary>
+        /// Reads the names of the relationships of a table, which appear in a filter and in a selection set
+        /// like a column but address another table.
+        /// </summary>
+        private static void ReadRelationships(JsonElement table, ISet<string> relationships)
+        {
+            foreach (string kind in kRelationshipKinds)
+            {
+                if (table.TryGetProperty(kind, out JsonElement declared))
+                {
+                    foreach (JsonElement relationship in declared.EnumerateArray())
                     {
-                        metadata.SelectableColumns[role] = ReadPermittedColumns(entry);
-                    }
-                    else if (operation == kUpdateOperation)
-                    {
-                        metadata.UpdatableColumns[role] = ReadPermittedColumns(entry);
+                        relationships.Add(relationship.GetProperty("name").GetString() ?? "");
                     }
                 }
             }
-            return metadata;
         }
 
         /// <summary>
@@ -251,13 +451,22 @@ namespace FWO.Test
         }
 
         /// <summary>
-        /// Reads the columns of one permission entry. A delete permission carries no columns at all.
+        /// Reads the columns of one permission entry. A delete permission carries no columns at all, and
+        /// Hasura writes a permission covering every column as "*" instead of listing them.
         /// </summary>
         private static HashSet<string> ReadPermittedColumns(JsonElement permissionEntry)
         {
+            if (!permissionEntry.GetProperty("permission").TryGetProperty("columns", out JsonElement declared))
+            {
+                return new();
+            }
+            if (declared.ValueKind == JsonValueKind.String)
+            {
+                return declared.GetString() == kAllColumnsMarker ? kAllColumns : new();
+            }
+
             HashSet<string> columns = new();
-            if (permissionEntry.GetProperty("permission").TryGetProperty("columns", out JsonElement declared)
-                && declared.ValueKind == JsonValueKind.Array)
+            if (declared.ValueKind == JsonValueKind.Array)
             {
                 foreach (JsonElement column in declared.EnumerateArray())
                 {
@@ -267,318 +476,95 @@ namespace FWO.Test
             return columns;
         }
 
-        /// <summary>
-        /// Reads every delete and update mutation of the embedded API calls which carries a where clause.
-        /// </summary>
-        private static List<FilteredMutation> ReadFilteredMutations()
-        {
-            DirectoryInfo apiCalls = kApiCallDirectory.Value
-                ?? throw new InvalidOperationException(kApiCallsOutOfReach);
 
-            List<FilteredMutation> mutations = new();
-            foreach (FileInfo apiCall in apiCalls.EnumerateFiles($"*{kApiCallSuffix}", SearchOption.AllDirectories))
-            {
-                mutations.AddRange(ReadFilteredMutations(FormatSource(apiCalls, apiCall),
-                    ApiQueries.Compact(File.ReadAllText(apiCall.FullName))));
-            }
-            return mutations;
+        /// <summary>
+        /// One root field of an API call: what it does to which table, what it filters on, what it returns
+        /// and what it writes.
+        /// </summary>
+        /// <param name="ReadsItsResult">Whether the call reads anything of the rows it touches, which a
+        /// mutation returning nothing but affected_rows does not.</param>
+        private sealed record ApiOperation(string Source, string Operation, string TableRoot,
+            List<string> FilterColumns, List<string> ReturnedColumns, List<string> WrittenColumns,
+            bool ReadsItsResult);
+
+        /// <summary>
+        /// One field of a selection set, or the placeholder for a fragment spread standing in for fields
+        /// which are defined in another file.
+        /// </summary>
+        private sealed record ApiField(string Name, string? Arguments, string? SubSelection, bool IsFragmentSpread)
+        {
+            public static ApiField FragmentSpread { get; } = new("", null, null, true);
         }
 
         /// <summary>
-        /// Reads the filtered mutations of a single API call. The call is compacted the same way it is
-        /// before it is sent, so the comments of the file cannot be mistaken for a mutation.
+        /// One missing permission together with the API call which uncovered it.
         /// </summary>
-        private static List<FilteredMutation> ReadFilteredMutations(string source, string apiCall)
-        {
-            List<FilteredMutation> mutations = new();
-            foreach (Match mutation in MutationRegex().Matches(apiCall).Cast<Match>())
-            {
-                string? arguments = ReadArguments(apiCall, mutation.Index + mutation.Length - 1);
-                string? filter = arguments == null ? null : ReadObjectArgument(arguments, FilterRegex());
-                if (filter == null)
-                {
-                    continue;
-                }
+        private sealed record ReportedGap(string Source, string Gap);
 
-                HashSet<string> columns = new();
-                CollectFilterColumns(filter, columns, 0);
-                mutations.Add(new FilteredMutation(source, mutation.Groups[1].Value,
-                    ReadMutationRoot(mutation.Groups[2].Value), columns.ToList(),
-                    ReadUpdatedColumns(arguments!)));
-            }
-            return mutations;
+        /// <summary>
+        /// What the API call definitions hold: the operations to check, and the parts of them no static
+        /// check can read.
+        /// </summary>
+        private sealed class ApiCallSurvey
+        {
+            public List<ApiOperation> Operations { get; } = new();
+            public List<string> Uncheckable { get; } = new();
         }
 
         /// <summary>
-        /// Reads the table a mutation addresses. Hasura appends _many to the mutation updating several
-        /// filters at once and _by_pk to the one addressing a single row without a where clause.
-        /// </summary>
-        private static string ReadMutationRoot(string mutationName)
-        {
-            return mutationName.EndsWith(kManyRootSuffix) ? mutationName[..^kManyRootSuffix.Length] : mutationName;
-        }
-
-        /// <summary>
-        /// Reads the argument list of a mutation, starting at its opening bracket.
-        /// </summary>
-        /// <returns>The arguments without the enclosing brackets, or null when they are not closed.</returns>
-        private static string? ReadArguments(string apiCall, int argumentStart)
-        {
-            int argumentEnd = IndexOfMatchingBracket(apiCall, argumentStart);
-            return argumentEnd < 0 ? null : apiCall[(argumentStart + 1)..argumentEnd];
-        }
-
-        /// <summary>
-        /// Reads the body of the object argument the given expression introduces.
-        /// </summary>
-        /// <returns>The body of the argument, or null when the mutation does not carry it.</returns>
-        private static string? ReadObjectArgument(string arguments, Regex argumentRegex)
-        {
-            Match argument = argumentRegex.Match(arguments);
-            if (!argument.Success)
-            {
-                return null;
-            }
-
-            int bodyStart = argument.Index + argument.Length - 1;
-            int bodyEnd = IndexOfMatchingBracket(arguments, bodyStart);
-            return bodyEnd < 0 ? null : arguments[(bodyStart + 1)..bodyEnd];
-        }
-
-        /// <summary>
-        /// Reads the columns a mutation writes, which is empty for a delete.
-        /// </summary>
-        private static List<string> ReadUpdatedColumns(string arguments)
-        {
-            string? assignment = ReadObjectArgument(arguments, AssignmentRegex());
-            return assignment == null
-                ? new()
-                : EnumerateMembers(assignment).Select(member => member.Name).ToList();
-        }
-
-        /// <summary>
-        /// Collects the columns a filter compares. A member comparing a column carries operators only,
-        /// every other member walks a relationship into another table and is left to the API call of it.
-        /// </summary>
-        private static void CollectFilterColumns(string filter, ISet<string> columns, int depth)
-        {
-            if (depth >= kMaxFilterDepth)
-            {
-                throw new InvalidOperationException($"Filter is nested deeper than {kMaxFilterDepth} levels.");
-            }
-
-            foreach ((string name, string? body) in EnumerateMembers(filter))
-            {
-                if (body == null)
-                {
-                    continue;
-                }
-                if (kLogicalOperators.Contains(name))
-                {
-                    CollectFilterColumns(body, columns, depth + 1);
-                }
-                else if (!name.StartsWith('_') && ComparesAColumn(body))
-                {
-                    columns.Add(name);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Decides whether the members of a filter member are comparison operators, which makes the member
-        /// itself a column and not a relationship.
-        /// </summary>
-        private static bool ComparesAColumn(string memberBody)
-        {
-            bool hasMember = false;
-            foreach ((string name, string? _) in EnumerateMembers(memberBody))
-            {
-                hasMember = true;
-                if (!name.StartsWith('_'))
-                {
-                    return false;
-                }
-            }
-            return hasMember;
-        }
-
-        /// <summary>
-        /// Walks the members of a GraphQL object.
-        /// </summary>
-        /// <returns>The name of every member with its body, which is null for a member holding a value.</returns>
-        private static IEnumerable<(string Name, string? Body)> EnumerateMembers(string objectBody)
-        {
-            int position = 0;
-            while (position < objectBody.Length)
-            {
-                Match member = MemberRegex().Match(objectBody, position);
-                if (!member.Success)
-                {
-                    yield break;
-                }
-
-                int valueStart = member.Index + member.Length;
-                int valueEnd = IsBracket(objectBody, valueStart) ? IndexOfMatchingBracket(objectBody, valueStart) : -1;
-                if (valueEnd < 0)
-                {
-                    yield return (member.Groups[1].Value, null);
-                    position = valueStart;
-                    continue;
-                }
-
-                yield return (member.Groups[1].Value, objectBody[(valueStart + 1)..valueEnd]);
-                position = valueEnd + 1;
-            }
-        }
-
-        /// <summary>
-        /// Decides whether an object or a list starts at the given position.
-        /// </summary>
-        private static bool IsBracket(string text, int position)
-        {
-            return position < text.Length && (text[position] == '{' || text[position] == '[');
-        }
-
-        /// <summary>
-        /// Finds the bracket closing the one at the given position. Brackets of another kind in between do
-        /// not change the nesting of the searched one and are therefore not counted.
-        /// </summary>
-        /// <returns>The position of the closing bracket, or -1 when it is missing.</returns>
-        private static int IndexOfMatchingBracket(string text, int openingPosition)
-        {
-            char opening = text[openingPosition];
-            char closing = ClosingBracketOf(opening);
-            int depth = 0;
-
-            for (int position = openingPosition; position < text.Length; position++)
-            {
-                if (text[position] == opening)
-                {
-                    depth++;
-                }
-                else if (text[position] == closing && --depth == 0)
-                {
-                    return position;
-                }
-            }
-            return -1;
-        }
-
-        /// <summary>
-        /// Reads the bracket closing an opening one.
-        /// </summary>
-        private static char ClosingBracketOf(char opening)
-        {
-            return opening switch
-            {
-                '{' => '}',
-                '[' => ']',
-                '(' => ')',
-                _ => throw new ArgumentException($"{opening} is no opening bracket.", nameof(opening))
-            };
-        }
-
-        /// <summary>
-        /// Names an API call by its path below fwo-api-calls, so a failure points at the file to repair.
-        /// </summary>
-        private static string FormatSource(DirectoryInfo apiCalls, FileInfo apiCall)
-        {
-            return Path.GetRelativePath(apiCalls.FullName, apiCall.FullName)
-                .Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        }
-
-        /// <summary>
-        /// Locates the Hasura metadata in the repository or in the directory the installer copies it to
-        /// next to the tests.
-        /// </summary>
-        /// <returns>The metadata file, or null when it is out of reach.</returns>
-        private static FileInfo? LocateMetadata()
-        {
-            return LocateBesideOrAbove(directory =>
-            {
-                FileInfo repository = new(Path.Combine(directory.FullName, "roles", "api", "files", kMetadataFile));
-                FileInfo installed = new(Path.Combine(directory.FullName, kMetadataFile));
-                return repository.Exists ? repository : installed.Exists ? installed : null;
-            });
-        }
-
-        /// <summary>
-        /// Locates the API call definitions in the repository or where the installer deploys them for the
-        /// UI, middleware and importer.
-        /// </summary>
-        /// <returns>The directory holding the API calls, or null when it is out of reach.</returns>
-        private static DirectoryInfo? LocateApiCalls()
-        {
-            return LocateBesideOrAbove(directory =>
-            {
-                DirectoryInfo repository = new(Path.Combine(directory.FullName, "roles", "common", "files", kApiCallDirectoryName));
-                DirectoryInfo installed = new(Path.Combine(directory.FullName, kApiCallDirectoryName));
-                return repository.Exists ? repository : installed.Exists ? installed : null;
-            });
-        }
-
-        /// <summary>
-        /// Walks from the directory of the test assembly up to the root and returns what the given lookup
-        /// finds first. The tests run from a repository checkout as well as from an installed system, where
-        /// the sources of the other components are not laid out the same way.
-        /// </summary>
-        private static TFound? LocateBesideOrAbove<TFound>(Func<DirectoryInfo, TFound?> lookup) where TFound : class
-        {
-            DirectoryInfo? directory = new(AppContext.BaseDirectory);
-            while (directory is not null)
-            {
-                TFound? found = lookup(directory);
-                if (found is not null)
-                {
-                    return found;
-                }
-                directory = directory.Parent;
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// Skips a test when the metadata or the API calls cannot be read, which happens wherever only
-        /// part of the sources is deployed. Reporting that plainly is better than passing on no input.
-        /// </summary>
-        private static void SkipWithoutSources()
-        {
-            if (kMetadataFileInfo.Value is null)
-            {
-                Assert.Ignore(kMetadataOutOfReach);
-            }
-            if (kApiCallDirectory.Value is null)
-            {
-                Assert.Ignore(kApiCallsOutOfReach);
-            }
-        }
-
-        [GeneratedRegex(@"\b(delete|update)_([A-Za-z0-9_]+)\s*\(", RegexOptions.None, kRegexTimeoutMilliseconds)]
-        private static partial Regex MutationRegex();
-
-        [GeneratedRegex(@"\bwhere\s*:\s*\{", RegexOptions.None, kRegexTimeoutMilliseconds)]
-        private static partial Regex FilterRegex();
-
-        [GeneratedRegex(@"\b_set\s*:\s*\{", RegexOptions.None, kRegexTimeoutMilliseconds)]
-        private static partial Regex AssignmentRegex();
-
-        [GeneratedRegex(@"([A-Za-z_][A-Za-z0-9_]*)\s*:\s*", RegexOptions.None, kRegexTimeoutMilliseconds)]
-        private static partial Regex MemberRegex();
-
-        /// <summary>
-        /// A delete or update mutation of an API call together with the columns its where clause filters on.
-        /// </summary>
-        private sealed record FilteredMutation(string Source, string Operation, string TableRoot,
-            List<string> Columns, List<string> UpdatedColumns);
-
-        /// <summary>
-        /// The permissions of one table: which roles hold which permission and which columns they may select.
+        /// The permissions of one table: which roles hold which permission, which columns they may select
+        /// or write, and the relationships which are no columns of the table.
         /// </summary>
         private sealed class TableMetadata
         {
             public Dictionary<string, List<string>> RolesByOperation { get; } = new();
             public Dictionary<string, HashSet<string>> SelectableColumns { get; } = new();
-            public Dictionary<string, HashSet<string>> UpdatableColumns { get; } = new();
+            public Dictionary<(string Operation, string Role), HashSet<string>> WritableColumns { get; } = new();
+            public HashSet<string> Relationships { get; } = new();
+
+            /// <summary>
+            /// Whether a role may select a column, which a relationship never is.
+            /// </summary>
+            public bool MaySelect(string role, string column)
+            {
+                if (Relationships.Contains(column))
+                {
+                    return true;
+                }
+                return SelectableColumns.TryGetValue(role, out HashSet<string>? columns)
+                    && (ReferenceEquals(columns, kAllColumns) || columns.Contains(column));
+            }
+
+            /// <summary>
+            /// Whether a role holds select permission on the table at all, which a _by_pk root field and a
+            /// returning block need before any single column matters.
+            /// </summary>
+            public bool MaySelectAnything(string role)
+            {
+                return SelectableColumns.ContainsKey(role);
+            }
+
+            /// <summary>
+            /// Whether any role at all may select every one of the given columns.
+            /// </summary>
+            public bool AnyRoleMaySelectAll(List<string> columns)
+            {
+                return SelectableColumns.Keys.Any(role => columns.TrueForAll(column => MaySelect(role, column)));
+            }
+
+            /// <summary>
+            /// Whether a role may write every column a mutation writes. A mutation writing a column the
+            /// role may not write is rejected for that column already and never runs for that role.
+            /// </summary>
+            public bool MayWrite(ApiOperation operation, string role)
+            {
+                if (operation.WrittenColumns.Count == 0)
+                {
+                    return true;
+                }
+                return WritableColumns.TryGetValue((operation.Operation, role), out HashSet<string>? columns)
+                    && (ReferenceEquals(columns, kAllColumns) || operation.WrittenColumns.TrueForAll(columns.Contains));
+            }
         }
     }
 }

--- a/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
@@ -23,6 +23,7 @@ namespace FWO.Test
         private const string kApiCallSuffix = ".graphql";
         private const string kPermissionSuffix = "_permissions";
         private const string kSelectOperation = "select";
+        private const string kUpdateOperation = "update";
         private const string kPublicSchema = "public";
         private const string kManyRootSuffix = "_many";
         private const int kMaxFilterDepth = 100;
@@ -34,23 +35,14 @@ namespace FWO.Test
         private static readonly List<string> kLogicalOperators = new() { "_and", "_or", "_not" };
 
         /// <summary>
-        /// Mismatches which exist in the metadata already. Every entry breaks the API call named with it
-        /// for the role named with it, and closing one widens the read access of that role, which is a
-        /// decision for the owner of the respective workflow. They are listed here so the check passes on
-        /// the current metadata while still failing for every mismatch added from now on.
+        /// Mismatches which are accepted although they exist. Every entry breaks the API call named with
+        /// it for the role named with it, and closing one widens the read access of that role, which is a
+        /// decision for the owner of the respective workflow. The list is empty because the metadata
+        /// currently holds no such mismatch; it stays here so an accepted one can be recorded with the
+        /// reason for accepting it instead of being silenced by weakening the check.
         /// ApiCalls_KnownPermissionGapsStillExist removes the risk of the list outliving the mismatches.
         /// </summary>
-        private static readonly List<string> kKnownPermissionGaps = new()
-        {
-            // monitor/updateAlert.graphql, reporter-viewall may acknowledge alerts but not read any
-            "alert|reporter-viewall|alert_id",
-            // monitor/acknowledgeAllOpenAlerts.graphql, same role and table as above
-            "alert|reporter-viewall|ack_by",
-            // modelling/removeSelectedNwGroupObject.graphql, middleware-server selects nwgroup_id only
-            "modelling_selected_objects|middleware-server|app_id",
-            // modelling/replaceUsedInterface.graphql, implementer may update conn_prop but not read
-            "modelling_connection|implementer|used_interface_id"
-        };
+        private static readonly List<string> kKnownPermissionGaps = new();
 
         /// <summary>
         /// Every column an API call filters a delete or update on has to be selectable by the roles which
@@ -134,7 +126,7 @@ namespace FWO.Test
                 return mismatches;
             }
 
-            foreach (string role in roles)
+            foreach (string role in roles.Where(role => MayRunMutation(mutation, table, role)))
             {
                 table.SelectableColumns.TryGetValue(role, out HashSet<string>? selectable);
                 mismatches.AddRange(mutation.Columns
@@ -142,6 +134,21 @@ namespace FWO.Test
                     .Select(column => FormatGap(mutation.TableRoot, role, column)));
             }
             return mismatches;
+        }
+
+        /// <summary>
+        /// Decides whether a role can run a mutation at all. An update writing a column the role may not
+        /// write is rejected for that column already, so its where clause never reaches the role and
+        /// demanding a select permission for it would only invite widening the read access for nothing.
+        /// </summary>
+        private static bool MayRunMutation(FilteredMutation mutation, TableMetadata table, string role)
+        {
+            if (mutation.Operation != kUpdateOperation || mutation.UpdatedColumns.Count == 0)
+            {
+                return true;
+            }
+            return table.UpdatableColumns.TryGetValue(role, out HashSet<string>? updatable)
+                && mutation.UpdatedColumns.TrueForAll(updatable.Contains);
         }
 
         /// <summary>
@@ -201,6 +208,10 @@ namespace FWO.Test
                     {
                         metadata.SelectableColumns[role] = ReadPermittedColumns(entry);
                     }
+                    else if (operation == kUpdateOperation)
+                    {
+                        metadata.UpdatableColumns[role] = ReadPermittedColumns(entry);
+                    }
                 }
             }
             return metadata;
@@ -259,7 +270,8 @@ namespace FWO.Test
             List<FilteredMutation> mutations = new();
             foreach (Match mutation in MutationRegex().Matches(apiCall).Cast<Match>())
             {
-                string? filter = ReadFilter(apiCall, mutation.Index + mutation.Length - 1);
+                string? arguments = ReadArguments(apiCall, mutation.Index + mutation.Length - 1);
+                string? filter = arguments == null ? null : ReadObjectArgument(arguments, FilterRegex());
                 if (filter == null)
                 {
                     continue;
@@ -268,7 +280,8 @@ namespace FWO.Test
                 HashSet<string> columns = new();
                 CollectFilterColumns(filter, columns, 0);
                 mutations.Add(new FilteredMutation(source, mutation.Groups[1].Value,
-                    ReadMutationRoot(mutation.Groups[2].Value), columns.ToList()));
+                    ReadMutationRoot(mutation.Groups[2].Value), columns.ToList(),
+                    ReadUpdatedColumns(arguments!)));
             }
             return mutations;
         }
@@ -283,27 +296,41 @@ namespace FWO.Test
         }
 
         /// <summary>
-        /// Reads the body of the where clause out of the argument list starting at the given bracket.
+        /// Reads the argument list of a mutation, starting at its opening bracket.
         /// </summary>
-        /// <returns>The body of the where clause, or null when the mutation has none.</returns>
-        private static string? ReadFilter(string apiCall, int argumentStart)
+        /// <returns>The arguments without the enclosing brackets, or null when they are not closed.</returns>
+        private static string? ReadArguments(string apiCall, int argumentStart)
         {
             int argumentEnd = IndexOfMatchingBracket(apiCall, argumentStart);
-            if (argumentEnd < 0)
+            return argumentEnd < 0 ? null : apiCall[(argumentStart + 1)..argumentEnd];
+        }
+
+        /// <summary>
+        /// Reads the body of the object argument the given expression introduces.
+        /// </summary>
+        /// <returns>The body of the argument, or null when the mutation does not carry it.</returns>
+        private static string? ReadObjectArgument(string arguments, Regex argumentRegex)
+        {
+            Match argument = argumentRegex.Match(arguments);
+            if (!argument.Success)
             {
                 return null;
             }
 
-            string arguments = apiCall[(argumentStart + 1)..argumentEnd];
-            Match filter = FilterRegex().Match(arguments);
-            if (!filter.Success)
-            {
-                return null;
-            }
+            int bodyStart = argument.Index + argument.Length - 1;
+            int bodyEnd = IndexOfMatchingBracket(arguments, bodyStart);
+            return bodyEnd < 0 ? null : arguments[(bodyStart + 1)..bodyEnd];
+        }
 
-            int filterStart = filter.Index + filter.Length - 1;
-            int filterEnd = IndexOfMatchingBracket(arguments, filterStart);
-            return filterEnd < 0 ? null : arguments[(filterStart + 1)..filterEnd];
+        /// <summary>
+        /// Reads the columns a mutation writes, which is empty for a delete.
+        /// </summary>
+        private static List<string> ReadUpdatedColumns(string arguments)
+        {
+            string? assignment = ReadObjectArgument(arguments, AssignmentRegex());
+            return assignment == null
+                ? new()
+                : EnumerateMembers(assignment).Select(member => member.Name).ToList();
         }
 
         /// <summary>
@@ -455,13 +482,17 @@ namespace FWO.Test
         [GeneratedRegex(@"\bwhere\s*:\s*\{", RegexOptions.None, kRegexTimeoutMilliseconds)]
         private static partial Regex FilterRegex();
 
+        [GeneratedRegex(@"\b_set\s*:\s*\{", RegexOptions.None, kRegexTimeoutMilliseconds)]
+        private static partial Regex AssignmentRegex();
+
         [GeneratedRegex(@"([A-Za-z_][A-Za-z0-9_]*)\s*:\s*", RegexOptions.None, kRegexTimeoutMilliseconds)]
         private static partial Regex MemberRegex();
 
         /// <summary>
         /// A delete or update mutation of an API call together with the columns its where clause filters on.
         /// </summary>
-        private sealed record FilteredMutation(string Source, string Operation, string TableRoot, List<string> Columns);
+        private sealed record FilteredMutation(string Source, string Operation, string TableRoot,
+            List<string> Columns, List<string> UpdatedColumns);
 
         /// <summary>
         /// The permissions of one table: which roles hold which permission and which columns they may select.
@@ -470,6 +501,7 @@ namespace FWO.Test
         {
             public Dictionary<string, List<string>> RolesByOperation { get; } = new();
             public Dictionary<string, HashSet<string>> SelectableColumns { get; } = new();
+            public Dictionary<string, HashSet<string>> UpdatableColumns { get; } = new();
         }
     }
 }

--- a/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
@@ -12,15 +11,20 @@ namespace FWO.Test
     /// that role, so a role which may delete or update a table but cannot select the columns its where
     /// clause filters on has the mutation rejected while it is validated. Nothing but a runtime error
     /// inside a background job reports that mismatch, which is why it is checked here instead.
-    /// The metadata and the API calls are embedded into this assembly at build time
-    /// (see FWO.Test.csproj), so no file of another component is read at runtime.
+    /// The metadata and the API calls are read from the repository, or from the places the installer
+    /// deploys them to, because an installed system holds only the sources of the tests themselves.
+    /// Where neither is reachable the checks are skipped instead of passing on no input at all.
     /// </summary>
     [TestFixture]
     internal partial class ApiPermissionAlignmentTest
     {
-        private const string kMetadataResource = "FWO.Test.replace_metadata.json";
-        private const string kApiCallPrefix = "FWO.Test.ApiCalls.";
+        private const string kMetadataFile = "replace_metadata.json";
+        private const string kApiCallDirectoryName = "fwo-api-calls";
         private const string kApiCallSuffix = ".graphql";
+        private const string kMetadataOutOfReach =
+            "The Hasura metadata is not reachable in this environment, so the permission alignment cannot be checked.";
+        private const string kApiCallsOutOfReach =
+            "The API call definitions are not reachable in this environment, so the permission alignment cannot be checked.";
         private const string kPermissionSuffix = "_permissions";
         private const string kSelectOperation = "select";
         private const string kUpdateOperation = "update";
@@ -33,6 +37,14 @@ namespace FWO.Test
         /// Operators combining several conditions. Their operands are conditions again and not columns.
         /// </summary>
         private static readonly List<string> kLogicalOperators = new() { "_and", "_or", "_not" };
+
+        /// <summary>
+        /// The sources under test. They are looked up once and are read from wherever the environment
+        /// keeps them, because the tests run from a repository checkout as well as from an installed
+        /// system, where the components do not share the layout of the repository.
+        /// </summary>
+        private static readonly Lazy<FileInfo?> kMetadataFileInfo = new(LocateMetadata);
+        private static readonly Lazy<DirectoryInfo?> kApiCallDirectory = new(LocateApiCalls);
 
         /// <summary>
         /// Mismatches which are accepted although they exist. Every entry breaks the API call named with
@@ -51,6 +63,8 @@ namespace FWO.Test
         [Test]
         public void ApiCalls_FilterOnlyColumnsTheirRolesMaySelect()
         {
+            SkipWithoutSources();
+
             Dictionary<string, TableMetadata> tables = ReadMetadata();
             List<string> mismatches = new();
 
@@ -76,6 +90,8 @@ namespace FWO.Test
         [Test]
         public void ApiCalls_AddressOnlyTrackedTables()
         {
+            SkipWithoutSources();
+
             Dictionary<string, TableMetadata> tables = ReadMetadata();
 
             List<string> unknownTables = ReadFilteredMutations()
@@ -96,6 +112,8 @@ namespace FWO.Test
         [Test]
         public void ApiCalls_KnownPermissionGapsStillExist()
         {
+            SkipWithoutSources();
+
             Dictionary<string, TableMetadata> tables = ReadMetadata();
             List<string> existingGaps = new();
 
@@ -165,7 +183,9 @@ namespace FWO.Test
         /// </summary>
         private static Dictionary<string, TableMetadata> ReadMetadata()
         {
-            using JsonDocument metadata = JsonDocument.Parse(ReadResource(kMetadataResource));
+            FileInfo metadataFile = kMetadataFileInfo.Value
+                ?? throw new InvalidOperationException(kMetadataOutOfReach);
+            using JsonDocument metadata = JsonDocument.Parse(File.ReadAllText(metadataFile.FullName));
             Dictionary<string, TableMetadata> tables = new();
 
             foreach (JsonElement source in metadata.RootElement.GetProperty("args")
@@ -252,11 +272,14 @@ namespace FWO.Test
         /// </summary>
         private static List<FilteredMutation> ReadFilteredMutations()
         {
+            DirectoryInfo apiCalls = kApiCallDirectory.Value
+                ?? throw new InvalidOperationException(kApiCallsOutOfReach);
+
             List<FilteredMutation> mutations = new();
-            foreach (string resource in Assembly.GetExecutingAssembly().GetManifestResourceNames()
-                .Where(name => name.StartsWith(kApiCallPrefix) && name.EndsWith(kApiCallSuffix)))
+            foreach (FileInfo apiCall in apiCalls.EnumerateFiles($"*{kApiCallSuffix}", SearchOption.AllDirectories))
             {
-                mutations.AddRange(ReadFilteredMutations(FormatSource(resource), ApiQueries.Compact(ReadResource(resource))));
+                mutations.AddRange(ReadFilteredMutations(FormatSource(apiCalls, apiCall),
+                    ApiQueries.Compact(File.ReadAllText(apiCall.FullName))));
             }
             return mutations;
         }
@@ -457,23 +480,77 @@ namespace FWO.Test
 
         /// <summary>
         /// Names an API call by its path below fwo-api-calls, so a failure points at the file to repair.
-        /// The directories of the path are separators of the resource name and are restored here.
         /// </summary>
-        private static string FormatSource(string resourceName)
+        private static string FormatSource(DirectoryInfo apiCalls, FileInfo apiCall)
         {
-            string path = resourceName[kApiCallPrefix.Length..^kApiCallSuffix.Length];
-            return path.Replace('.', Path.AltDirectorySeparatorChar) + kApiCallSuffix;
+            return Path.GetRelativePath(apiCalls.FullName, apiCall.FullName)
+                .Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
 
         /// <summary>
-        /// Reads an embedded resource of this assembly.
+        /// Locates the Hasura metadata in the repository or in the directory the installer copies it to
+        /// next to the tests.
         /// </summary>
-        private static string ReadResource(string resourceName)
+        /// <returns>The metadata file, or null when it is out of reach.</returns>
+        private static FileInfo? LocateMetadata()
         {
-            using Stream? resource = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName)
-                ?? throw new InvalidOperationException($"Embedded resource {resourceName} is missing.");
-            using StreamReader reader = new(resource);
-            return reader.ReadToEnd();
+            return LocateBesideOrAbove(directory =>
+            {
+                FileInfo repository = new(Path.Combine(directory.FullName, "roles", "api", "files", kMetadataFile));
+                FileInfo installed = new(Path.Combine(directory.FullName, kMetadataFile));
+                return repository.Exists ? repository : installed.Exists ? installed : null;
+            });
+        }
+
+        /// <summary>
+        /// Locates the API call definitions in the repository or where the installer deploys them for the
+        /// UI, middleware and importer.
+        /// </summary>
+        /// <returns>The directory holding the API calls, or null when it is out of reach.</returns>
+        private static DirectoryInfo? LocateApiCalls()
+        {
+            return LocateBesideOrAbove(directory =>
+            {
+                DirectoryInfo repository = new(Path.Combine(directory.FullName, "roles", "common", "files", kApiCallDirectoryName));
+                DirectoryInfo installed = new(Path.Combine(directory.FullName, kApiCallDirectoryName));
+                return repository.Exists ? repository : installed.Exists ? installed : null;
+            });
+        }
+
+        /// <summary>
+        /// Walks from the directory of the test assembly up to the root and returns what the given lookup
+        /// finds first. The tests run from a repository checkout as well as from an installed system, where
+        /// the sources of the other components are not laid out the same way.
+        /// </summary>
+        private static TFound? LocateBesideOrAbove<TFound>(Func<DirectoryInfo, TFound?> lookup) where TFound : class
+        {
+            DirectoryInfo? directory = new(AppContext.BaseDirectory);
+            while (directory is not null)
+            {
+                TFound? found = lookup(directory);
+                if (found is not null)
+                {
+                    return found;
+                }
+                directory = directory.Parent;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Skips a test when the metadata or the API calls cannot be read, which happens wherever only
+        /// part of the sources is deployed. Reporting that plainly is better than passing on no input.
+        /// </summary>
+        private static void SkipWithoutSources()
+        {
+            if (kMetadataFileInfo.Value is null)
+            {
+                Assert.Ignore(kMetadataOutOfReach);
+            }
+            if (kApiCallDirectory.Value is null)
+            {
+                Assert.Ignore(kApiCallsOutOfReach);
+            }
         }
 
         [GeneratedRegex(@"\b(delete|update)_([A-Za-z0-9_]+)\s*\(", RegexOptions.None, kRegexTimeoutMilliseconds)]

--- a/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
+++ b/roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs
@@ -37,6 +37,9 @@ namespace FWO.Test
             "The Hasura metadata is not reachable in this environment, so the permission alignment cannot be checked.";
         private const string kApiCallsOutOfReach =
             "The API call definitions are not reachable in this environment, so the permission alignment cannot be checked.";
+        private const string kAmbiguousTableRoot =
+            "Two tracked tables of the metadata reach the same root field name in the GraphQL schema, "
+            + "so the permissions of one of them would be checked against the calls of the other: ";
         private const string kPermissionSuffix = "_permissions";
         private const string kSelectOperation = "select";
         private const string kInsertOperation = "insert";
@@ -100,6 +103,34 @@ namespace FWO.Test
         private static readonly HashSet<string> kAllColumns = new() { kAllColumnsMarker };
 
         /// <summary>
+        /// Root field names two tables of kMetadataWithDistinctTableRoots reach, where the table of a
+        /// schema other than public carries its schema and the one of public does not.
+        /// </summary>
+        private static readonly List<string> kDistinctTableRoots = new() { "alert", "modelling_connection" };
+
+        /// <summary>
+        /// A metadata document tracking two tables which reach two root field names, as the tracked tables
+        /// of replace_metadata.json do.
+        /// </summary>
+        private const string kMetadataWithDistinctTableRoots = @"{""args"": {""metadata"": {""sources"": [
+            {""tables"": [
+                {""table"": {""schema"": ""public"", ""name"": ""alert""}},
+                {""table"": {""schema"": ""modelling"", ""name"": ""connection""}}
+            ]}
+        ]}}}";
+
+        /// <summary>
+        /// A metadata document tracking two tables which reach one root field name, because the schema a
+        /// table outside public is prefixed with is part of the name of the other one.
+        /// </summary>
+        private const string kMetadataWithAmbiguousTableRoot = @"{""args"": {""metadata"": {""sources"": [
+            {""tables"": [
+                {""table"": {""schema"": ""modelling"", ""name"": ""connection""}},
+                {""table"": {""schema"": ""public"", ""name"": ""modelling_connection""}}
+            ]}
+        ]}}}";
+
+        /// <summary>
         /// The sources under test. They are looked up once and are read from wherever the environment
         /// keeps them, because the tests run from a repository checkout as well as from an installed
         /// system, where the components do not share the layout of the repository.
@@ -121,22 +152,22 @@ namespace FWO.Test
             // issued by the importer: FWO.Recert sends them under the role of the logged in user
             // (RecertRefresh.cs, RecertHandler.cs). Granting the importer select on recertification would
             // widen its read access for a call it never makes. Dropping its insert permission instead is
-            // the cleaner repair and belongs to the owner of the recertification workflow.
+            // the cleaner repair and belongs to the owner of the recertification workflow. Tracked as
+            // issue #5220.
             "recertification|importer|<any column>",
 
             // The middleware-server role holds insert permission on report but report/addGeneratedReport
             // is sent over the user context connection of the scheduling user (ReportJob.cs), never under
             // the technical role. Granting it select on report would widen its read access to every
             // generated report for a call it never makes; dropping the insert permission is the cleaner
-            // repair and belongs to the owner of the report scheduling workflow.
+            // repair and belongs to the owner of the report scheduling workflow. Tracked as issue #5220.
             "report|middleware-server|<any column>",
 
             // v_rule_with_rule_owner_1 is tracked with no permission at all, so owner/getRuleOwnerships
             // exists in the schema of no role of this metadata. /settings/owners is open to admin and
             // auditor: admin is the built in role of Hasura and passes every permission, auditor is not
             // and its EditOwner.razor fails to load the rules of an owner. Which role should read the view
-            // is a decision for the owner of the ownership workflow; the gap is recorded here so it is not
-            // lost while it is open.
+            // is a decision for the owner of the ownership workflow. Tracked as issue #5210.
             "v_rule_with_rule_owner_1|<any role>|owner_id"
         };
 
@@ -214,6 +245,31 @@ namespace FWO.Test
             Assert.That(repairedGaps, Is.Empty,
                 "These accepted mismatches no longer exist and have to be removed from kKnownPermissionGaps:"
                 + Environment.NewLine + string.Join(Environment.NewLine, repairedGaps));
+        }
+
+        /// <summary>
+        /// Tables outside the public schema carry their schema in the root field name Hasura gives them,
+        /// which is the name the API calls address them by and the name they are read under here.
+        /// </summary>
+        [Test]
+        public void Metadata_ReadsTablesByTheirRootFieldName()
+        {
+            Dictionary<string, TableMetadata> tables = ReadMetadata(kMetadataWithDistinctTableRoots);
+
+            Assert.That(tables.Keys, Is.EquivalentTo(kDistinctTableRoots));
+        }
+
+        /// <summary>
+        /// Two tracked tables reaching one root field name are refused, because the calls of one of them
+        /// would otherwise be checked against the permissions of the other and pass on them.
+        /// </summary>
+        [Test]
+        public void Metadata_RefusesTwoTablesReachingOneRootFieldName()
+        {
+            InvalidOperationException? refusal = Assert.Throws<InvalidOperationException>(
+                () => ReadMetadata(kMetadataWithAmbiguousTableRoot));
+
+            Assert.That(refusal?.Message, Does.Contain("modelling_connection"));
         }
 
         /// <summary>
@@ -350,13 +406,25 @@ namespace FWO.Test
         }
 
         /// <summary>
-        /// Reads the tables of the metadata by the name their root fields carry in the GraphQL schema.
+        /// Reads the tables of the metadata file by the name their root fields carry in the GraphQL schema.
         /// </summary>
         private static Dictionary<string, TableMetadata> ReadMetadata()
         {
             FileInfo metadataFile = kMetadataFileInfo.Value
                 ?? throw new InvalidOperationException(kMetadataOutOfReach);
-            using JsonDocument metadata = JsonDocument.Parse(File.ReadAllText(metadataFile.FullName));
+            return ReadMetadata(File.ReadAllText(metadataFile.FullName));
+        }
+
+        /// <summary>
+        /// Reads the tables of a metadata document by the name their root fields carry in the GraphQL
+        /// schema. Two tracked tables reaching the same root name are refused instead of one of them
+        /// replacing the other, because the calls of one table would then be checked against the
+        /// permissions of the other and pass on them, which is the one thing this guard must not do.
+        /// </summary>
+        /// <param name="metadataJson">The content of the metadata file.</param>
+        private static Dictionary<string, TableMetadata> ReadMetadata(string metadataJson)
+        {
+            using JsonDocument metadata = JsonDocument.Parse(metadataJson);
             Dictionary<string, TableMetadata> tables = new();
 
             foreach (JsonElement source in metadata.RootElement.GetProperty("args")
@@ -364,7 +432,11 @@ namespace FWO.Test
             {
                 foreach (JsonElement table in source.GetProperty("tables").EnumerateArray())
                 {
-                    tables[ReadTableRoot(table.GetProperty("table"))] = ReadTablePermissions(table);
+                    string tableRoot = ReadTableRoot(table.GetProperty("table"));
+                    if (!tables.TryAdd(tableRoot, ReadTablePermissions(table)))
+                    {
+                        throw new InvalidOperationException(kAmbiguousTableRoot + tableRoot);
+                    }
                 }
             }
             return tables;

--- a/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
+++ b/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
@@ -32,13 +32,6 @@
 		<EmbeddedResource Include="..\..\..\ui\files\FWO.UI\wwwroot\css\site.css" LogicalName="FWO.Test.site.css" />
 	</ItemGroup>
 
-	<!-- Hasura metadata and API call definitions checked by ApiPermissionAlignmentTest. They are
-	     embedded at build time, so the test does not have to read any file of another component. -->
-	<ItemGroup>
-		<EmbeddedResource Include="..\..\..\api\files\replace_metadata.json" LogicalName="FWO.Test.replace_metadata.json" />
-		<EmbeddedResource Include="..\..\..\common\files\fwo-api-calls\**\*.graphql" LinkBase="ApiCalls" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\lib\files\FWO.Compliance\FWO.Compliance.csproj" />
 		<ProjectReference Include="..\..\..\lib\files\FWO.Report\FWO.Report.csproj" />

--- a/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
+++ b/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
@@ -32,6 +32,13 @@
 		<EmbeddedResource Include="..\..\..\ui\files\FWO.UI\wwwroot\css\site.css" LogicalName="FWO.Test.site.css" />
 	</ItemGroup>
 
+	<!-- Hasura metadata and API call definitions checked by ApiPermissionAlignmentTest. They are
+	     embedded at build time, so the test does not have to read any file of another component. -->
+	<ItemGroup>
+		<EmbeddedResource Include="..\..\..\api\files\replace_metadata.json" LogicalName="FWO.Test.replace_metadata.json" />
+		<EmbeddedResource Include="..\..\..\common\files\fwo-api-calls\**\*.graphql" LinkBase="ApiCalls" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\lib\files\FWO.Compliance\FWO.Compliance.csproj" />
 		<ProjectReference Include="..\..\..\lib\files\FWO.Report\FWO.Report.csproj" />

--- a/scripts/customizing/log_data_import/import_log_data_from_git.py
+++ b/scripts/customizing/log_data_import/import_log_data_from_git.py
@@ -111,6 +111,20 @@ def get_csv_search_directory(config_file: str, repository_directory: Path, logge
     return search_directory
 
 
+def find_csv_files(search_directory: Path, logger: logging.Logger) -> list[Path] | None:
+    """Find CSV files without allowing symbolic links to escape the selected directory."""
+    resolved_search_directory: Path = search_directory.resolve()
+    csv_files: list[Path] = sorted(search_directory.rglob(CSV_PATTERN))
+    for csv_file in csv_files:
+        if not csv_file.resolve().is_relative_to(resolved_search_directory):
+            logger.error(
+                "CSV file %s resolves outside the selected log data search directory",
+                csv_file.relative_to(search_directory),
+            )
+            return None
+    return csv_files
+
+
 def parse_optional_int(value: str) -> int | None:
     stripped_value: str = value.strip()
     return int(stripped_value) if stripped_value else None
@@ -460,7 +474,9 @@ def import_data(config_file: str, depth: int | None, logger: logging.Logger) -> 
     search_directory: Path | None = get_csv_search_directory(config_file, repository_directory, logger)
     if search_directory is None:
         return 1
-    csv_files: list[Path] = sorted(search_directory.rglob(CSV_PATTERN))
+    csv_files: list[Path] | None = find_csv_files(search_directory, logger)
+    if csv_files is None:
+        return 1
     conversion: ConversionResult = convert_repository_files(csv_files, repository_directory, logger)
     write_import_file(conversion.entries, conversion.converted_files, repository_directory)
     report_conversion_summary(conversion, logger)

--- a/scripts/customizing/log_data_import/import_log_data_from_git.py
+++ b/scripts/customizing/log_data_import/import_log_data_from_git.py
@@ -83,7 +83,15 @@ def get_optional_value(config_file: str, key: str, default: str, logger: logging
 
 
 def get_csv_search_directory(config_file: str, repository_directory: Path, logger: logging.Logger) -> Path | None:
-    """Return the configured CSV directory, refusing paths outside the cloned repository."""
+    """
+    Return the configured CSV directory, refusing paths outside the cloned repository.
+
+    The returned directory keeps the repository directory as its prefix instead of being resolved:
+    the files found below it are reported and acknowledged relative to the repository directory, and
+    a resolved prefix is no prefix of it any more as soon as the configured repository directory is
+    a symbolic link or is not written out in its shortest form. Only the containment check resolves,
+    because a symbolic link inside the repository must not be able to lead the search out of it.
+    """
     configured_start_path: str = get_optional_value(config_file, START_PATH_CONFIG_KEY, "", logger).strip()
     if not configured_start_path:
         return repository_directory
@@ -91,15 +99,16 @@ def get_csv_search_directory(config_file: str, repository_directory: Path, logge
     if start_path.is_absolute():
         logger.error("%s must be a repository-relative directory", START_PATH_CONFIG_KEY)
         return None
+    search_directory: Path = repository_directory / start_path
     resolved_repository_directory: Path = repository_directory.resolve()
-    resolved_search_directory: Path = (repository_directory / start_path).resolve()
+    resolved_search_directory: Path = search_directory.resolve()
     if not resolved_search_directory.is_relative_to(resolved_repository_directory):
         logger.error("%s must name a directory within the log data repository", START_PATH_CONFIG_KEY)
         return None
     if not resolved_search_directory.is_dir():
         logger.error("%s does not name an existing directory in the log data repository", START_PATH_CONFIG_KEY)
         return None
-    return resolved_search_directory
+    return search_directory
 
 
 def parse_optional_int(value: str) -> int | None:

--- a/scripts/customizing/log_data_import/import_log_data_from_git.py
+++ b/scripts/customizing/log_data_import/import_log_data_from_git.py
@@ -8,6 +8,7 @@ import logging
 import sys
 import urllib.parse
 from collections.abc import Mapping
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO, cast
@@ -32,6 +33,7 @@ OUTPUT_FILE: Path = Path(__file__).with_suffix(".json")
 # acknowledgement deletes and pushes, so it must not be something the log repository can provide
 MANIFEST_FILE: Path = OUTPUT_FILE.with_name(".fwo-log-import-manifest.json")
 MAX_PENDING_REUSES: int = 3
+MAX_REPORTED_EXAMPLE_ROWS: int = 5
 REUSES_KEY: str = "reuses"
 ACKNOWLEDGE_FAILURES_KEY: str = "acknowledge_failures"
 COMMIT_MESSAGE: str = "chore: remove imported log data"
@@ -39,6 +41,36 @@ REQUIRED_COLUMNS: set[str] = {"App ID", "Log count", "Src IP", "Dst IP", "Port"}
 OPTIONAL_COLUMNS: dict[str, str] = {"Log timestamp": "log_time", "Rule name": "rule_name"}
 PORT_PROTOCOLS: tuple[int, int] = (6, 17)
 LogDataEntry = dict[str, str | int | None]
+
+
+@dataclass
+class RejectedFile:
+    """
+    What could not be imported from one CSV file.
+
+    A file with an unconvertible row is kept in the repository as a whole, so the reason has to
+    survive the rejection of the file: the summary at the end of the run is the only place which
+    reports how much data is still waiting and which lines hold it back.
+    """
+
+    reason: str = ""
+    row_count: int = 0
+    examples: list[str] = field(default_factory=list[str])
+
+    def add_row(self, line_number: int, reason: str) -> None:
+        """Count one line which cannot be imported, keeping the first few as examples."""
+        self.row_count += 1
+        if len(self.examples) < MAX_REPORTED_EXAMPLE_ROWS:
+            self.examples.append(f"line {line_number}: {reason}")
+
+
+@dataclass
+class ConversionResult:
+    """What one run made of the CSV files found in the log data repository."""
+
+    entries: list[LogDataEntry] = field(default_factory=list[LogDataEntry])
+    converted_files: list[Path] = field(default_factory=list[Path])
+    rejected_files: dict[str, RejectedFile] = field(default_factory=dict[str, RejectedFile])
 
 
 def get_optional_value(config_file: str, key: str, default: str, logger: logging.Logger) -> str:
@@ -75,10 +107,14 @@ def parse_optional_int(value: str) -> int | None:
     return int(stripped_value) if stripped_value else None
 
 
-def convert_csv_file(csv_file: Path, repository_directory: Path, logger: logging.Logger) -> list[LogDataEntry]:
+def convert_csv_file(
+    csv_file: Path,
+    repository_directory: Path,
+    rejected: RejectedFile,
+    logger: logging.Logger,
+) -> list[LogDataEntry]:
     """Convert every row of one CSV file, rejecting the complete file if any row is invalid."""
     converted: list[LogDataEntry] = []
-    rejected_row_count: int = 0
     with csv_file.open(newline="", encoding="utf-8-sig") as file_handle:
         typed_file_handle: TextIO = file_handle
         reader: csv.DictReader[str] = csv.DictReader(typed_file_handle)
@@ -86,28 +122,80 @@ def convert_csv_file(csv_file: Path, repository_directory: Path, logger: logging
             raise ValueError(f"{csv_file} is missing one or more mandatory columns")
         for line_number, row in enumerate(reader, start=2):
             converted_row: LogDataEntry | None = convert_row_or_log_error(
-                row, csv_file, repository_directory, line_number, logger
+                row, csv_file, repository_directory, line_number, rejected, logger
             )
-            if converted_row is None:
-                rejected_row_count += 1
-            else:
+            if converted_row is not None:
                 converted.append(converted_row)
-    if rejected_row_count > 0:
-        raise ValueError(f"{rejected_row_count} row(s) could not be converted")
+    if rejected.row_count > 0:
+        raise ValueError(f"{rejected.row_count} row(s) could not be converted")
     return converted
 
 
 def convert_csv_file_or_log_error(
     csv_file: Path,
     repository_directory: Path,
+    rejected: RejectedFile,
     logger: logging.Logger,
 ) -> list[LogDataEntry] | None:
     """Convert one file, an unusable file is reported and skipped so the other files still import."""
     try:
-        return convert_csv_file(csv_file, repository_directory, logger)
+        return convert_csv_file(csv_file, repository_directory, rejected, logger)
     except (OSError, UnicodeDecodeError, ValueError) as exception:
         logger.warning("ignoring %s: %s", csv_file.relative_to(repository_directory), exception)
+        rejected.reason = str(exception)
         return None
+
+
+def convert_repository_files(
+    csv_files: list[Path],
+    repository_directory: Path,
+    logger: logging.Logger,
+) -> ConversionResult:
+    """Convert every CSV file found in the repository, keeping track of the skipped ones."""
+    result: ConversionResult = ConversionResult()
+    for csv_file in csv_files:
+        rejected: RejectedFile = RejectedFile()
+        file_entries: list[LogDataEntry] | None = convert_csv_file_or_log_error(
+            csv_file, repository_directory, rejected, logger
+        )
+        if file_entries is None:
+            result.rejected_files[csv_file.relative_to(repository_directory).as_posix()] = rejected
+            continue
+        result.entries.extend(file_entries)
+        result.converted_files.append(csv_file)
+    return result
+
+
+def report_conversion_summary(result: ConversionResult, logger: logging.Logger) -> None:
+    """
+    Report what the run imported and what it had to leave behind.
+
+    The middleware reads the output of this script into its own log, so this summary is what an
+    operator finds in middleware.log. The per-row warnings alone do not say how much data is still
+    waiting in the repository, and a file which keeps being skipped is invisible between the runs.
+    """
+    logger.info("converted %s CSV files into %s log entries", len(result.converted_files), len(result.entries))
+    if not result.rejected_files:
+        return
+    rejected_row_count: int = sum(rejected.row_count for rejected in result.rejected_files.values())
+    logger.info(
+        "%s CSV file(s) with %s not importable line(s) were kept in the log data repository for the next run",
+        len(result.rejected_files),
+        rejected_row_count,
+    )
+    for source_name, rejected in sorted(result.rejected_files.items()):
+        logger.info("not imported from %s: %s", source_name, describe_rejected_file(rejected))
+
+
+def describe_rejected_file(rejected: RejectedFile) -> str:
+    """Describe one skipped file, naming up to MAX_REPORTED_EXAMPLE_ROWS of its lines as examples."""
+    if not rejected.examples:
+        return rejected.reason
+    examples: str = "; ".join(rejected.examples)
+    remaining_row_count: int = rejected.row_count - len(rejected.examples)
+    if remaining_row_count > 0:
+        return f"{rejected.row_count} not importable line(s), for example {examples}; {remaining_row_count} more"
+    return f"{rejected.row_count} not importable line(s): {examples}"
 
 
 def convert_row_or_log_error(
@@ -115,12 +203,15 @@ def convert_row_or_log_error(
     csv_file: Path,
     repository_directory: Path,
     line_number: int,
+    rejected: RejectedFile,
     logger: logging.Logger,
 ) -> LogDataEntry | None:
+    """Convert one row, recording an unconvertible one for the summary of the run."""
     try:
         return convert_row(row)
     except (TypeError, ValueError) as exception:
         logger.warning("ignoring %s line %s: %s", csv_file.relative_to(repository_directory), line_number, exception)
+        rejected.add_row(line_number, str(exception))
         return None
 
 
@@ -361,16 +452,9 @@ def import_data(config_file: str, depth: int | None, logger: logging.Logger) -> 
     if search_directory is None:
         return 1
     csv_files: list[Path] = sorted(search_directory.rglob(CSV_PATTERN))
-    entries: list[LogDataEntry] = []
-    converted_files: list[Path] = []
-    for csv_file in csv_files:
-        file_entries: list[LogDataEntry] | None = convert_csv_file_or_log_error(csv_file, repository_directory, logger)
-        if file_entries is None:
-            continue
-        entries.extend(file_entries)
-        converted_files.append(csv_file)
-    write_import_file(entries, converted_files, repository_directory)
-    logger.info("converted %s CSV files into %s log entries", len(converted_files), len(entries))
+    conversion: ConversionResult = convert_repository_files(csv_files, repository_directory, logger)
+    write_import_file(conversion.entries, conversion.converted_files, repository_directory)
+    report_conversion_summary(conversion, logger)
     return 0
 
 

--- a/scripts/customizing/log_data_import/import_log_data_from_git.py
+++ b/scripts/customizing/log_data_import/import_log_data_from_git.py
@@ -12,7 +12,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO, cast
 
-from scripts.customizing.fwo_custom_lib.basic_helpers import get_logger, read_custom_config
+from scripts.customizing.fwo_custom_lib.basic_helpers import (
+    get_logger,
+    read_custom_config,
+    read_custom_config_with_default,
+)
 from scripts.customizing.fwo_custom_lib.git_helpers import (
     commit_and_push_deletions,
     parse_git_depth_arg,
@@ -21,6 +25,7 @@ from scripts.customizing.fwo_custom_lib.git_helpers import (
 
 DEFAULT_CONFIG_FILE: str = "/usr/local/fworch/etc/secrets/customizingConfig.json"
 DEFAULT_REPOSITORY_DIRECTORY: str = "/usr/local/fworch/etc/logDataRepo"
+START_PATH_CONFIG_KEY: str = "logDataGitRepoStartPath"
 CSV_PATTERN: str = "*.csv"
 OUTPUT_FILE: Path = Path(__file__).with_suffix(".json")
 # the manifest is deliberately kept outside the cloned repository: it decides which files the
@@ -37,10 +42,32 @@ LogDataEntry = dict[str, str | int | None]
 
 
 def get_optional_value(config_file: str, key: str, default: str, logger: logging.Logger) -> str:
-    try:
-        return read_custom_config(config_file, key, logger=logger)
-    except (KeyError, ValueError):
+    """Read an optional string setting, returning its default when it is absent or invalid."""
+    configured_value: object = read_custom_config_with_default(config_file, key, default, logger)
+    if not isinstance(configured_value, str):
+        logger.warning("%s must be a string in config file %s; using the default", key, config_file)
         return default
+    return configured_value
+
+
+def get_csv_search_directory(config_file: str, repository_directory: Path, logger: logging.Logger) -> Path | None:
+    """Return the configured CSV directory, refusing paths outside the cloned repository."""
+    configured_start_path: str = get_optional_value(config_file, START_PATH_CONFIG_KEY, "", logger).strip()
+    if not configured_start_path:
+        return repository_directory
+    start_path: Path = Path(configured_start_path)
+    if start_path.is_absolute():
+        logger.error("%s must be a repository-relative directory", START_PATH_CONFIG_KEY)
+        return None
+    resolved_repository_directory: Path = repository_directory.resolve()
+    resolved_search_directory: Path = (repository_directory / start_path).resolve()
+    if not resolved_search_directory.is_relative_to(resolved_repository_directory):
+        logger.error("%s must name a directory within the log data repository", START_PATH_CONFIG_KEY)
+        return None
+    if not resolved_search_directory.is_dir():
+        logger.error("%s does not name an existing directory in the log data repository", START_PATH_CONFIG_KEY)
+        return None
+    return resolved_search_directory
 
 
 def parse_optional_int(value: str) -> int | None:
@@ -330,7 +357,10 @@ def import_data(config_file: str, depth: int | None, logger: logging.Logger) -> 
     repo_url: str = f"https://{git_user}:{urllib.parse.quote(git_password, safe='')}@{git_repo}"
     if not update_git_repo(repo_url, str(repository_directory), logger, branch=branch or None, depth=depth):
         return 1
-    csv_files: list[Path] = sorted(repository_directory.rglob(CSV_PATTERN))
+    search_directory: Path | None = get_csv_search_directory(config_file, repository_directory, logger)
+    if search_directory is None:
+        return 1
+    csv_files: list[Path] = sorted(search_directory.rglob(CSV_PATTERN))
     entries: list[LogDataEntry] = []
     converted_files: list[Path] = []
     for csv_file in csv_files:

--- a/scripts/customizing/log_data_import/readme.md
+++ b/scripts/customizing/log_data_import/readme.md
@@ -17,6 +17,8 @@ The mandatory CSV headers are `App ID`, `Log count`, `Src IP`, `Dst IP`, and `Po
 
 If any row cannot be converted, the complete CSV file is excluded from the generated JSON and from acknowledgement. Other valid CSV files in the same run are still imported and removed. The rejected file remains in the repository so it can be corrected and retried without losing the application IDs needed by replacement mode.
 
+At the end of a run the script logs an `INFO` summary of what it converted and what it had to leave behind: the number of skipped CSV files, the total number of lines which could not be imported, and one line per skipped file naming up to five of its not importable lines with their line number and reason. A file rejected before its rows were read - because a mandatory column is missing or the file cannot be read - is reported with that reason instead of example lines. The middleware reads the script output into its own log, so the summary appears in `middleware.log`.
+
 The database keeps one row per application, source, destination and service. Repeated entries for the same flow are not stored a second time: entries which are repeated inside one import file are merged into a single entry with the summed log count, and an entry which is already stored is updated with the imported log count, action, log time and rule name instead of being inserted again. An entry without a protocol or without a port counts as one distinct flow, not as a wildcard.
 
 The generated JSON interface is:

--- a/scripts/customizing/log_data_import/readme.md
+++ b/scripts/customizing/log_data_import/readme.md
@@ -7,7 +7,7 @@ Configure these keys in `customizingConfig.json`:
 - `logDataGitRepo`, `logDataGitUser`, `logDataGitPassword` (required)
 - `logDataGitRepoTargetDir` (optional; default `/usr/local/fworch/etc/logDataRepo`)
 - `logDataGitBranch` (optional)
-- `logDataGitRepoStartPath` (optional): repository-relative directory from which CSV files are searched recursively. If omitted or empty, the whole repository is searched.
+- `logDataGitRepoStartPath` (optional): repository-relative directory from which CSV files are searched recursively. If omitted or empty, the whole repository is searched. Symbolic links to CSV files outside the selected directory are rejected.
 
 The script uses `GitPython`, which is not part of the system python. The installer creates a virtual environment for the customizing scripts at `/usr/local/fworch/scripts/customizing-venv` from `scripts/requirements.txt` and rewrites the shebangs of the deployed scripts to that environment, so the middleware picks up the dependencies when it executes the script. Custom scripts placed below `scripts/customizing` are treated the same way; add their dependencies to `scripts/requirements.txt`.
 

--- a/scripts/customizing/log_data_import/readme.md
+++ b/scripts/customizing/log_data_import/readme.md
@@ -7,6 +7,7 @@ Configure these keys in `customizingConfig.json`:
 - `logDataGitRepo`, `logDataGitUser`, `logDataGitPassword` (required)
 - `logDataGitRepoTargetDir` (optional; default `/usr/local/fworch/etc/logDataRepo`)
 - `logDataGitBranch` (optional)
+- `logDataGitRepoStartPath` (optional): repository-relative directory from which CSV files are searched recursively. If omitted or empty, the whole repository is searched.
 
 The script uses `GitPython`, which is not part of the system python. The installer creates a virtual environment for the customizing scripts at `/usr/local/fworch/scripts/customizing-venv` from `scripts/requirements.txt` and rewrites the shebangs of the deployed scripts to that environment, so the middleware picks up the dependencies when it executes the script. Custom scripts placed below `scripts/customizing` are treated the same way; add their dependencies to `scripts/requirements.txt`.
 

--- a/scripts/customizing/log_data_import/test_import_log_data_flow.py
+++ b/scripts/customizing/log_data_import/test_import_log_data_flow.py
@@ -19,18 +19,19 @@ def return_false(*_args: object, **_kwargs: object) -> bool:
     return False
 
 
-def write_config(tmp_path: Path, repository_directory: Path) -> str:
+def write_config(tmp_path: Path, repository_directory: Path, start_path: str | None = None) -> str:
     config_file: Path = tmp_path / "customizingConfigLogData.json"
+    config: dict[str, str] = {
+        "logDataGitRepo": "local.logdata/log_repo",
+        "logDataGitUser": "local",
+        "logDataGitPassword": "local",
+        "logDataGitRepoTargetDir": str(repository_directory),
+        "logDataGitBranch": "main",
+    }
+    if start_path is not None:
+        config[importer.START_PATH_CONFIG_KEY] = start_path
     config_file.write_text(
-        json.dumps(
-            {
-                "logDataGitRepo": "local.logdata/log_repo",
-                "logDataGitUser": "local",
-                "logDataGitPassword": "local",
-                "logDataGitRepoTargetDir": str(repository_directory),
-                "logDataGitBranch": "main",
-            }
-        ),
+        json.dumps(config),
         encoding="utf-8",
     )
     return str(config_file)
@@ -59,6 +60,52 @@ def test_import_data_writes_entries_and_manifest(tmp_path: Path, monkeypatch: py
     assert entries["logs"][0]["app_id"] == "APP-1"
     assert entries["logs"][0]["log_count"] == 42
     assert manifest["csv_files"] == ["2026-08-12/fw.csv"]
+
+
+def test_import_data_searches_the_whole_repository_without_a_start_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file, repository_directory, output_file = prepare_repository(tmp_path, monkeypatch)
+    (repository_directory / "other.csv").write_text(CSV_CONTENT.replace("APP-1", "APP-2"), encoding="utf-8")
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    result: int = importer.import_data(config_file, None, LOGGER)
+
+    entries: dict[str, Any] = json.loads(output_file.read_text(encoding="utf-8"))
+    assert result == 0
+    assert [entry["app_id"] for entry in entries["logs"]] == ["APP-1", "APP-2"]
+
+
+def test_import_data_limits_csv_search_to_the_configured_start_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _config_file, repository_directory, output_file = prepare_repository(tmp_path, monkeypatch)
+    config_file: str = write_config(tmp_path, repository_directory, "2026-08-12")
+    (repository_directory / "other.csv").write_text(CSV_CONTENT.replace("APP-1", "APP-2"), encoding="utf-8")
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    result: int = importer.import_data(config_file, None, LOGGER)
+
+    manifest: dict[str, Any] = json.loads(importer.MANIFEST_FILE.read_text(encoding="utf-8"))
+    entries: dict[str, Any] = json.loads(output_file.read_text(encoding="utf-8"))
+    assert result == 0
+    assert [entry["app_id"] for entry in entries["logs"]] == ["APP-1"]
+    assert manifest["csv_files"] == ["2026-08-12/fw.csv"]
+
+
+def test_import_data_rejects_a_start_path_outside_the_repository(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _config_file, repository_directory, output_file = prepare_repository(tmp_path, monkeypatch)
+    config_file: str = write_config(tmp_path, repository_directory, "../outside")
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER.name):
+        result: int = importer.import_data(config_file, None, LOGGER)
+
+    assert result == 1
+    assert "must name a directory within the log data repository" in caplog.text
+    assert not output_file.exists()
 
 
 def test_import_data_builds_the_repository_url_from_the_credentials(

--- a/scripts/customizing/log_data_import/test_import_log_data_flow.py
+++ b/scripts/customizing/log_data_import/test_import_log_data_flow.py
@@ -93,6 +93,46 @@ def test_import_data_limits_csv_search_to_the_configured_start_path(
     assert manifest["csv_files"] == ["2026-08-12/fw.csv"]
 
 
+def test_import_data_finds_csv_files_below_a_symlinked_repository_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A start path must not make the found files unreachable from the configured repository."""
+    _config_file, repository_directory, output_file = prepare_repository(tmp_path, monkeypatch)
+    linked_repository_directory: Path = tmp_path / "linked_repo"
+    linked_repository_directory.symlink_to(repository_directory)
+    config_file: str = write_config(tmp_path, linked_repository_directory, "2026-08-12")
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    result: int = importer.import_data(config_file, None, LOGGER)
+
+    manifest: dict[str, Any] = json.loads(importer.MANIFEST_FILE.read_text(encoding="utf-8"))
+    entries: dict[str, Any] = json.loads(output_file.read_text(encoding="utf-8"))
+    assert result == 0
+    assert [entry["app_id"] for entry in entries["logs"]] == ["APP-1"]
+    assert manifest["csv_files"] == ["2026-08-12/fw.csv"]
+
+
+def test_import_data_reports_a_rejected_file_below_an_abbreviated_repository_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A repository directory which is not written out in its shortest form is a valid one as well."""
+    _config_file, repository_directory, output_file = prepare_repository(tmp_path, monkeypatch)
+    (repository_directory / "2026-08-12" / "fw.csv").write_text(
+        CSV_CONTENT.replace(",443,6", ",443,1"), encoding="utf-8"
+    )
+    abbreviated_repository_directory: Path = repository_directory / "2026-08-12" / ".."
+    config_file: str = write_config(tmp_path, abbreviated_repository_directory, "2026-08-12")
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    result: int = importer.import_data(config_file, None, LOGGER)
+
+    manifest: dict[str, Any] = json.loads(importer.MANIFEST_FILE.read_text(encoding="utf-8"))
+    entries: dict[str, Any] = json.loads(output_file.read_text(encoding="utf-8"))
+    assert result == 0
+    assert entries["logs"] == []
+    assert manifest["csv_files"] == []
+
+
 def test_import_data_rejects_a_start_path_outside_the_repository(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/scripts/customizing/log_data_import/test_import_log_data_flow.py
+++ b/scripts/customizing/log_data_import/test_import_log_data_flow.py
@@ -93,6 +93,30 @@ def test_import_data_limits_csv_search_to_the_configured_start_path(
     assert manifest["csv_files"] == ["2026-08-12/fw.csv"]
 
 
+@pytest.mark.parametrize("target_outside_repository", [False, True])
+def test_import_data_rejects_a_csv_symlink_escaping_the_configured_start_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    target_outside_repository: bool,
+) -> None:
+    _config_file, repository_directory, output_file = prepare_repository(tmp_path, monkeypatch)
+    config_file: str = write_config(tmp_path, repository_directory, "2026-08-12")
+    target_directory: Path = tmp_path if target_outside_repository else repository_directory
+    target_file: Path = target_directory / "outside.csv"
+    target_file.write_text(CSV_CONTENT.replace("APP-1", "APP-2"), encoding="utf-8")
+    link_target: Path = Path("../../outside.csv") if target_outside_repository else Path("../outside.csv")
+    (repository_directory / "2026-08-12" / "linked.csv").symlink_to(link_target)
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER.name):
+        result: int = importer.import_data(config_file, None, LOGGER)
+
+    assert result == 1
+    assert "linked.csv resolves outside the selected log data search directory" in caplog.text
+    assert not output_file.exists()
+
+
 def test_import_data_finds_csv_files_below_a_symlinked_repository_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/scripts/customizing/log_data_import/test_import_log_data_flow.py
+++ b/scripts/customizing/log_data_import/test_import_log_data_flow.py
@@ -464,3 +464,160 @@ def test_import_data_keeps_a_file_with_a_broken_timestamp_for_retry(
     assert result == 0
     assert entries["logs"] == []
     assert manifest["csv_files"] == []
+
+
+def test_get_optional_value_falls_back_when_the_setting_is_not_a_string(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    config_file: Path = tmp_path / "customizingConfigLogData.json"
+    # a start path entered as a JSON number, the config file is edited by hand on the appliance
+    config: dict[str, object] = {importer.START_PATH_CONFIG_KEY: 20260812}
+    config_file.write_text(json.dumps(config), encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER.name):
+        value: str = importer.get_optional_value(str(config_file), importer.START_PATH_CONFIG_KEY, "fallback", LOGGER)
+
+    assert value == "fallback"
+    assert "must be a string in config file" in caplog.text
+
+
+def test_import_data_rejects_an_absolute_start_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _config_file, repository_directory, output_file = prepare_repository(tmp_path, monkeypatch)
+    # an absolute path is refused even when it points into the repository: the setting names a
+    # repository-relative directory, so an absolute one would silently survive a moved target dir
+    config_file: str = write_config(tmp_path, repository_directory, str(repository_directory / "2026-08-12"))
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER.name):
+        result: int = importer.import_data(config_file, None, LOGGER)
+
+    assert result == 1
+    assert "must be a repository-relative directory" in caplog.text
+    assert not output_file.exists()
+
+
+def test_import_data_rejects_a_start_path_which_does_not_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _config_file, repository_directory, output_file = prepare_repository(tmp_path, monkeypatch)
+    config_file: str = write_config(tmp_path, repository_directory, "2026-08-13")
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER.name):
+        result: int = importer.import_data(config_file, None, LOGGER)
+
+    assert result == 1, "a start path typo must not be read as an empty repository"
+    assert "does not name an existing directory" in caplog.text
+    assert not output_file.exists()
+
+
+def test_get_csv_search_directory_rejects_a_start_path_naming_a_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _config_file, repository_directory, _ = prepare_repository(tmp_path, monkeypatch)
+    config_file: str = write_config(tmp_path, repository_directory, "2026-08-12/fw.csv")
+
+    with caplog.at_level(logging.ERROR, logger=LOGGER.name):
+        search_directory: Path | None = importer.get_csv_search_directory(config_file, repository_directory, LOGGER)
+
+    assert search_directory is None
+    assert "does not name an existing directory" in caplog.text
+
+
+def test_import_data_recovers_from_a_manifest_which_is_not_an_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file, _repository_directory, output_file = prepare_repository(tmp_path, monkeypatch)
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+    importer.import_data(config_file, None, LOGGER)
+    # a manifest replaced by the bare file list, the shape an older script version wrote
+    importer.MANIFEST_FILE.write_text(json.dumps(["2026-08-12/fw.csv"]), encoding="utf-8")
+
+    result: int = importer.import_data(config_file, None, LOGGER)
+
+    manifest: dict[str, Any] = json.loads(importer.MANIFEST_FILE.read_text(encoding="utf-8"))
+    assert result == 0, "a manifest which is not an object must not stall every following run"
+    assert manifest["csv_files"] == ["2026-08-12/fw.csv"], "the repository was read again"
+    assert output_file.exists()
+
+
+def test_import_data_summarizes_a_run_without_rejections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    config_file, _repository_directory, _ = prepare_repository(tmp_path, monkeypatch)
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER.name):
+        assert importer.import_data(config_file, None, LOGGER) == 0
+
+    assert "converted 1 CSV files into 1 log entries" in caplog.text
+    assert "not importable line(s)" not in caplog.text, "a clean run must not report a rejection"
+
+
+def test_import_data_summarizes_the_not_importable_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    config_file, repository_directory, _ = prepare_repository(tmp_path, monkeypatch)
+    (repository_directory / "2026-08-12" / "fw.csv").write_text(
+        CSV_CONTENT + "APP-2,1,192.0.2.2,198.51.100.2,443,1\n" + "APP-3,0,192.0.2.3,198.51.100.3,443,6\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER.name):
+        assert importer.import_data(config_file, None, LOGGER) == 0
+
+    assert "1 CSV file(s) with 2 not importable line(s) were kept in the log data repository" in caplog.text
+    assert "not imported from 2026-08-12/fw.csv: 2 not importable line(s):" in caplog.text
+    assert "line 3: Port is only valid with Protocol 6 or 17" in caplog.text
+    assert "line 4: App ID, Log count, Src IP and Dst IP must be present" in caplog.text
+
+
+def test_import_data_counts_rejections_across_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    config_file, repository_directory, _ = prepare_repository(tmp_path, monkeypatch)
+    (repository_directory / "2026-08-12" / "fw.csv").write_text(
+        CSV_CONTENT + "APP-2,1,192.0.2.2,198.51.100.2,443,1\n", encoding="utf-8"
+    )
+    (repository_directory / "broken.csv").write_text("App ID,Log count\nAPP-1,42\n", encoding="utf-8")
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER.name):
+        assert importer.import_data(config_file, None, LOGGER) == 0
+
+    assert "converted 0 CSV files into 0 log entries" in caplog.text
+    assert "2 CSV file(s) with 1 not importable line(s) were kept" in caplog.text
+    # a file rejected before its rows were read has no example lines, only the reason
+    assert "not imported from broken.csv: " in caplog.text
+    assert "is missing one or more mandatory columns" in caplog.text
+
+
+def test_import_data_reports_at_most_five_example_lines_per_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    config_file, repository_directory, _ = prepare_repository(tmp_path, monkeypatch)
+    rejected_row_count: int = importer.MAX_REPORTED_EXAMPLE_ROWS + 2
+    rejected_rows: str = "".join(
+        f"APP-{row},1,192.0.2.{row},198.51.100.{row},443,1\n" for row in range(1, rejected_row_count + 1)
+    )
+    (repository_directory / "2026-08-12" / "fw.csv").write_text(
+        "App ID,Log count,Src IP,Dst IP,Port,Protocol\n" + rejected_rows, encoding="utf-8"
+    )
+    monkeypatch.setattr(importer, "update_git_repo", return_true)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER.name):
+        assert importer.import_data(config_file, None, LOGGER) == 0
+
+    summary: str = next(line for line in caplog.text.splitlines() if "not imported from" in line)
+    assert summary.count("line ") == importer.MAX_REPORTED_EXAMPLE_ROWS
+    assert f"{rejected_row_count} not importable line(s)" in summary
+    assert f"{rejected_row_count - importer.MAX_REPORTED_EXAMPLE_ROWS} more" in summary
+
+
+def test_describe_rejected_file_reports_a_file_without_example_lines() -> None:
+    rejected: importer.RejectedFile = importer.RejectedFile(reason="fw.csv is missing one or more mandatory columns")
+
+    assert importer.describe_rejected_file(rejected) == "fw.csv is missing one or more mandatory columns"

--- a/scripts/customizing/log_data_import/test_import_log_data_from_git.py
+++ b/scripts/customizing/log_data_import/test_import_log_data_from_git.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from scripts.customizing.log_data_import.import_log_data_from_git import LogDataEntry, convert_csv_file, convert_row
+from scripts.customizing.log_data_import.import_log_data_from_git import (
+    LogDataEntry,
+    RejectedFile,
+    convert_csv_file,
+    convert_row,
+)
 
 VALID_ROW: dict[str, str] = {
     "App ID": "APP-1",
@@ -47,15 +52,35 @@ def test_convert_csv_file_logs_invalid_rows_and_rejects_the_file(tmp_path: Path)
     original_level: int = logger.level
     logger.addHandler(collector)
     logger.setLevel(logging.WARNING)
+    rejected: RejectedFile = RejectedFile()
 
     try:
         with pytest.raises(ValueError, match=r"1 row\(s\) could not be converted"):
-            convert_csv_file(csv_file, tmp_path, logger)
+            convert_csv_file(csv_file, tmp_path, rejected, logger)
     finally:
         logger.removeHandler(collector)
         logger.setLevel(original_level)
 
     assert any("ignoring logs.csv line 3" in message for message in collector.messages)
+    assert rejected.row_count == 1
+    assert rejected.examples == ["line 3: Port is only valid with Protocol 6 or 17"]
+
+
+@pytest.mark.parametrize("blanked_column", ["App ID", "Src IP", "Dst IP"])
+def test_convert_row_rejects_a_blank_mandatory_value(blanked_column: str) -> None:
+    incomplete_row: dict[str, str] = {**VALID_ROW, blanked_column: "   "}
+
+    with pytest.raises(ValueError, match="must be present"):
+        convert_row(incomplete_row)
+
+
+@pytest.mark.parametrize("log_count", ["0", "-5"])
+def test_convert_row_rejects_a_log_count_below_one(log_count: str) -> None:
+    """A flow logged zero or fewer times carries no information the importer could store."""
+    unlogged_row: dict[str, str] = {**VALID_ROW, "Log count": log_count}
+
+    with pytest.raises(ValueError, match="must be present"):
+        convert_row(unlogged_row)
 
 
 class LogMessageCollector(logging.Handler):


### PR DESCRIPTION
## API select permissions

Hasura derives a role's `<table>_bool_exp` from that role's **select** permission. A role that may `delete` or `update` a table but cannot select the columns its `where` clause filters on has the mutation rejected during validation — the filter column is simply not a field of its boolean expression. The same applies to what a mutation gives back: a response passes through the select permission, and an `update_<table>_by_pk` root field is not part of the schema of a role without select permission on the table at all. Nothing but a runtime error, often inside a background job, reports either mismatch.

This surfaced with `replaceLogEntries`, which deletes existing rows by `owner_id` before inserting the new batch: `middleware-server` held delete and insert on `logging.log_entry` but no select, so `owner_id` was missing from its bool_exp and the atomic replace failed. Auditing the metadata for the same pattern turned up three more instances.

`roles/api/files/replace_metadata.json` — four select permissions added, each restricted to the columns the affected calls actually need. No delete, insert or update permission is widened; this only makes existing write permissions usable.

| Table | Role | Granted | Blocked call |
|---|---|---|---|
| `logging.log_entry` | `middleware-server` | `log_time`, `owner_id` | `replaceLogEntries`, `deleteLogEntriesOfOwners`, `deleteExpiredLogEntries` |
| `modelling.selected_objects` | `middleware-server` | `app_id` (beside existing `nwgroup_id`) | `removeSelectedNwGroupObject` |
| `public.alert` | `reporter-viewall` | `alert_id`, `ack_by` | `acknowledgeAllOpenAlerts`, `updateAlert` |
| `modelling.connection` | `implementer` | `id` | `updateConnectionProperties` |

The `implementer` grant is the `returning` case rather than the `where` case: `updateConnectionProperties` is the one connection update that role is allowed to make (`conn_prop`), it goes through `update_modelling_connection_by_pk`, and that root field is exposed only to a role holding select permission — with `{ updatedId: id }` as its selection set, `id` is the single column needed.

## The alignment guard

`roles/tests-unit/files/FWO.Test/ApiPermissionAlignmentTest.cs` and `ApiPermissionAlignmentTest.Sources.cs` guard the alignment so this class of gap cannot reappear silently. They parse `replace_metadata.json` and the `fwo-api-calls/*.graphql` definitions — from the repository checkout or from the paths the installer deploys them to, skipping rather than passing on empty input where neither is reachable — and check three directions plus the parser itself:

- `ApiCalls_FilterOnlyColumnsTheirRolesMaySelect` — every `where` column of a delete or update is selectable by each role permitted to run it. Roles that cannot write the `_set` columns anyway are excluded, so the check does not push for read access nobody needs.
- `ApiCalls_ReturnOnlyColumnsTheirRolesMaySelect` — every column behind a `returning` block, and select permission itself for a `_by_pk` root field.
- `ApiCalls_QueriesAreRunnableByAtLeastOneRole` — query filters. Which role issues a query is recorded nowhere, so only this weaker direction is decidable.
- `ApiCalls_AddressOnlyTrackedTables`, `Metadata_ReadsTablesByTheirRootFieldName` and `Metadata_RefusesTwoTablesReachingOneRootFieldName` keep the parser honest: an untracked table name is a typo or a forgotten `track_table`, and two tracked tables reaching one GraphQL root name are refused instead of one replacing the other, which would check one table's calls against another table's permissions and pass on them.

What no static check can read is written to the test output by `ReportUncheckableCalls` instead of being skipped silently: filters and object lists handed over as a variable (`where: $where`, `updates:`) are only known at run time, and a selection set behind a fragment spread lives in another file.

`kKnownPermissionGaps` records mismatches that exist but are not this PR's to close, with the reason and the tracking issue; `ApiCalls_KnownPermissionGapsStillExist` fails once an entry outlives its mismatch, so a waiver cannot become permanent unnoticed. Three entries, none of them closable by granting read access:

| Waived gap | Why not fixed here | Issue |
|---|---|---|
| `recertification` / `importer` | insert permission no call uses — dropping it is the repair, not granting select | #5220 |
| `report` / `middleware-server` | same; `addGeneratedReport` is sent over the scheduling user's connection | #5220 |
| `v_rule_with_rule_owner_1` / any role | the view is tracked with no permission at all, so `getRuleOwnerships` breaks for `auditor` | #5210 |

## Log data import

- `logDataGitRepoStartPath` (optional, repository-relative) restricts the CSV search to a subdirectory. Absolute paths, paths escaping the repository and paths that are not an existing directory are rejected. The configured directory and every discovered CSV target are resolved for containment, so symbolic links cannot lead the search outside the selected subtree or repository. The directory handed on keeps the configured repository directory as its prefix — the found files are reported relative to it, and a symlinked or non-canonical `logDataGitRepoTargetDir` must not break that.
- The script logs an `INFO` summary after each run: the files converted and entries produced, then the number of skipped files, the total count of not importable lines, and one line per skipped file naming up to 5 of its bad lines with line number and reason. A file rejected before its rows were read — missing mandatory column, unreadable — reports that reason instead of examples. The middleware reads script output into its own log, so the summary appears in `middleware.log`.
- Tests extended to 100 % statement and branch coverage of the script.

## Validation

`dotnet build --configuration Debug roles/FWO.sln` clean, `dotnet format` clean, full unit suite green (5107 passed, 0 failed, 17 pre-existing skips), `pytest scripts/customizing/log_data_import/` 51/51 at 100 % statement and branch coverage, `ruff check` and `ruff format` clean, `replace_metadata.json` parses.

## Notes for reviewers

- `replace_metadata.json` is applied wholesale on both fresh install and upgrade, so no separate upgrade step is needed and existing installations pick the permission changes up automatically.
- The guard is static: it checks the alignment against the metadata *file*, not against a running Hasura, and it cannot see the calls listed by `ReportUncheckableCalls`. One full `ImportLogDataJob` run against a real deployment, with `LogDataRetentionDays` set so expired rows exist, is still worth doing — that is the scenario the original bug was about.

