### PR TITLE
Nuget Updates

### DIFF
--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,15 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />    
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />    
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.17.1" />
     <PackageReference Include="PuppeteerSharp" Version="25.8.0" />
-    <PackageReference Include="Quartz" Version="3.19.1" />
-    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.19.1" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.19.1" />
+    <PackageReference Include="Quartz" Version="3.20.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.20.0" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/tests-unit/files/FWO.Test/NotificationTest.cs
+++ b/roles/tests-unit/files/FWO.Test/NotificationTest.cs
@@ -15,7 +15,7 @@ using System.Reflection;
 namespace FWO.Test
 {
     [TestFixture]
-    [Parallelizable]
+    [NonParallelizable]
     internal class NotificationTest
     {
         readonly NotificationTestApiConn apiConnection = new();
@@ -588,6 +588,9 @@ namespace FWO.Test
         public async Task CollectRecipientsReturnsDummyRecipientsWhenDummyEmailIsEnabled()
         {
             List<UserGroup> ownerGroups = [];
+
+            globalConfig.UseDummyEmailAddress = true;
+
             NotificationService notificationService = await NotificationService.CreateAsync(NotificationClient.InterfaceRequest, globalConfig, apiConnection, ownerGroups);
             FwoNotification notification = new()
             {
@@ -609,7 +612,6 @@ namespace FWO.Test
         }
 
         [Test]
-        [NonParallelizable]
         public async Task CollectRecipientsLogsWarningForConfiguredResponsiblesWhenNoRecipientsResolve()
         {
             globalConfig.UseDummyEmailAddress = false;
@@ -639,7 +641,6 @@ namespace FWO.Test
         }
 
         [Test]
-        [NonParallelizable]
         public async Task CollectRecipientsLogsWarningForJsonOtherAddressesWhenNoRecipientsResolve()
         {
             globalConfig.UseDummyEmailAddress = false;
@@ -668,7 +669,6 @@ namespace FWO.Test
         }
 
         [Test]
-        [NonParallelizable]
         public async Task CollectRecipientsLogsWarningForGenericRecipientOptionWhenNoRecipientsResolve()
         {
             globalConfig.UseDummyEmailAddress = false;
@@ -697,8 +697,7 @@ namespace FWO.Test
             Assert.That(output, Does.Contain("No recipients resolved for notification client InterfaceRequest using option Requester"));
         }
 
-        [Test]
-        [NonParallelizable]
+        [Test]        
         public async Task CollectRecipientsDoesNotWarnForNoneRecipientOption()
         {
             globalConfig.UseDummyEmailAddress = false;


### PR DESCRIPTION
Update `Quartz` to `3.20.0`
Update `Quartz.Extensions.Hosting` to `3.20.0`
Update `Quartz.Serialization.Json` to `3.20.0`
Remove `Microsoft.OpenApi` from `Middleware` (Not needed and also had dependency mismatch with Microsoft.AspNetCore.OpenApi)

Changed `NotificationTest.cs` Tests to `[NonParallelizable]` because of sporadic test failure

Fix `CollectRecipientsReturnsDummyRecipientsWhenDummyEmailIsEnabled` Test failing sporadically on race condition cases because the Test running before setting `globalConfig.UseDummyEmailAddress = false`

Closing #5209, #5208 and #5171