### PR TITLE
build: update NuGet packages and migrate Quartz

### DIFF
--- a/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
+++ b/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="GraphQL.Client" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.12" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="114.0.0" />

--- a/roles/lib/files/FWO.Data/FWO.Data.csproj
+++ b/roles/lib/files/FWO.Data/FWO.Data.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.12" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
   </ItemGroup>
 

--- a/roles/lib/files/FWO.Mail/FWO.Mail.csproj
+++ b/roles/lib/files/FWO.Mail/FWO.Mail.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="MimeKit" Version="4.17.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Report/FWO.Report.csproj
+++ b/roles/lib/files/FWO.Report/FWO.Report.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="HtmlAgilityPack" Version="1.13.0" />
-	  <PackageReference Include="PuppeteerSharp" Version="25.8.0" />
+	  <PackageReference Include="PuppeteerSharp" Version="25.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Services/FWO.Services.csproj
+++ b/roles/lib/files/FWO.Services/FWO.Services.csproj
@@ -10,7 +10,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="PuppeteerSharp" Version="25.8.0" />
+		<PackageReference Include="PuppeteerSharp" Version="25.10.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\FWO.Api.Client\FWO.Api.Client.csproj" />

--- a/roles/middleware/files/FWO.Middleware.Server/Controllers/SchedulerController.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Controllers/SchedulerController.cs
@@ -6,7 +6,6 @@ using FWO.Middleware.Server.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Quartz;
-using Quartz.Impl.Matchers;
 
 namespace FWO.Middleware.Server.Controllers
 {
@@ -46,14 +45,14 @@ namespace FWO.Middleware.Server.Controllers
             {
                 IReadOnlyCollection<ITrigger> triggers = await scheduler.GetTriggersOfJob(jobKey);
                 DateTimeOffset? nextFire = triggers
-                    .Select(trigger => trigger.GetNextFireTimeUtc())
+                    .Select(trigger => trigger.NextFireTimeUtc)
                     .Where(fireTime => fireTime.HasValue)
                     .Select(fireTime => (DateTimeOffset?)fireTime!.Value)
                     .OrderBy(fireTime => fireTime)
                     .FirstOrDefault();
 
                 DateTimeOffset? lastFire = triggers
-                    .Select(trigger => trigger.GetPreviousFireTimeUtc())
+                    .Select(trigger => trigger.PreviousFireTimeUtc)
                     .Where(fireTime => fireTime.HasValue)
                     .Select(fireTime => (DateTimeOffset?)fireTime!.Value)
                     .OrderByDescending(fireTime => fireTime)
@@ -106,7 +105,7 @@ namespace FWO.Middleware.Server.Controllers
             IScheduler scheduler = await schedulerFactory.GetScheduler();
             JobKey jobKey = new(parameters.JobName);
 
-            if (!await scheduler.CheckExists(jobKey))
+            if (!await scheduler.Exists(jobKey))
             {
                 return NotFound("Job not found.");
             }

--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.12" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.17.2" />
-    <PackageReference Include="PuppeteerSharp" Version="25.8.0" />
-    <PackageReference Include="Quartz" Version="3.20.0" />
-    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.20.0" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.20.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.17.3" />
+    <PackageReference Include="PuppeteerSharp" Version="25.10.0" />
+    <PackageReference Include="Quartz" Version="4.0.1" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="4.0.1" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/AutoDiscoverJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/AutoDiscoverJob.cs
@@ -36,7 +36,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ComplianceJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ComplianceJob.cs
@@ -31,7 +31,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken)
         {
             try
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/DailyCheckJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/DailyCheckJob.cs
@@ -40,7 +40,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ExternalRequestJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ExternalRequestJob.cs
@@ -31,7 +31,7 @@ namespace FWO.Middleware.Server.Jobs
         /// <summary>
         /// Execute the job
         /// </summary>
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             Log.WriteDebug(LogMessageTitle, "Job started");
 
@@ -55,7 +55,7 @@ namespace FWO.Middleware.Server.Jobs
                 await AlertHelper.LogErrorsWithAlert(apiConnection, globalConfig, 1, "External Request", GlobalConst.kExternalRequest, AlertCode.ExternalRequest, exc);
 
                 // Mark job as failed but don't refire immediately
-                throw new JobExecutionException(exc, refireImmediately: false);
+                throw new JobExecutionException(exc) { RefireImmediately = false };
             }
         }
 

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportAppDataJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportAppDataJob.cs
@@ -33,7 +33,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             Log.WriteDebug(LogMessageTitleImport, "Process started");
 

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportChangeNotifyJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportChangeNotifyJob.cs
@@ -30,7 +30,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportIpDataJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportIpDataJob.cs
@@ -31,7 +31,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             Log.WriteDebug(LogMessageTitle, "Process started");
 

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportLogDataJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ImportLogDataJob.cs
@@ -18,7 +18,7 @@ namespace FWO.Middleware.Server.Jobs
         private const string LogMessageTitle = "Import Log Data";
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/ReportJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/ReportJob.cs
@@ -43,7 +43,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/UpdateFlowsJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/UpdateFlowsJob.cs
@@ -34,7 +34,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/UpdateRuleOwnerMappingJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/UpdateRuleOwnerMappingJob.cs
@@ -29,7 +29,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/roles/middleware/files/FWO.Middleware.Server/Jobs/VarianceAnalysisJob.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Jobs/VarianceAnalysisJob.cs
@@ -35,7 +35,7 @@ namespace FWO.Middleware.Server.Jobs
         }
 
         /// <inheritdoc />
-        public async Task Execute(IJobExecutionContext context)
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             await VarianceAnalysis();
         }

--- a/roles/middleware/files/FWO.Middleware.Server/Services/DailyCheckSchedulerService.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/DailyCheckSchedulerService.cs
@@ -95,7 +95,7 @@ namespace FWO.Middleware.Server.Services
             var jobKey = new JobKey(JobKeyName);
             var triggerKey = new TriggerKey(TriggerKeyName);
 
-            if (await scheduler.CheckExists(jobKey))
+            if (await scheduler.Exists(jobKey))
             {
                 await scheduler.DeleteJob(jobKey);
                 Log.WriteInfo(SchedulerName, "Removed existing job");

--- a/roles/middleware/files/FWO.Middleware.Server/Services/JobExecutionTracker.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/JobExecutionTracker.cs
@@ -22,9 +22,9 @@ namespace FWO.Middleware.Server.Services
         /// <param name="context">The job execution context.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A completed task.</returns>
-        public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
 
         /// <summary>
@@ -33,9 +33,9 @@ namespace FWO.Middleware.Server.Services
         /// <param name="context">The job execution context.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A completed task.</returns>
-        public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        public ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace FWO.Middleware.Server.Services
         /// <param name="jobException">The exception thrown by the job, if any.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A completed task.</returns>
-        public Task JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
+        public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
         {
             string jobKey = context.JobDetail.Key.Name;
             bool success = jobException == null;
@@ -63,7 +63,7 @@ namespace FWO.Middleware.Server.Services
                 Log.WriteWarning("Job Execution", $"Job {jobKey} failed: {errorMessage}");
             }
 
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
 
         /// <summary>

--- a/roles/middleware/files/FWO.Middleware.Server/Services/QuartzSchedulerServiceBase.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/QuartzSchedulerServiceBase.cs
@@ -150,13 +150,13 @@ namespace FWO.Middleware.Server.Services
             var triggerKey = new TriggerKey(options.TriggerKeyName);
 
             // Ensure durable job exists for manual triggering
-            if (!await scheduler.CheckExists(jobKey))
+            if (!await scheduler.Exists(jobKey))
             {
                 IJobDetail durableJob = JobBuilder.Create<TJob>()
                     .WithIdentity(jobKey)
                     .StoreDurably()
                     .Build();
-                await scheduler.AddJob(durableJob, replace: true);
+                await scheduler.AddJob(durableJob, AddJobOptions.Replacing);
                 Log.WriteInfo(options.SchedulerName, "Added durable job for manual triggering");
             }
 

--- a/roles/middleware/files/FWO.Middleware.Server/Services/ReportSchedulerService.cs
+++ b/roles/middleware/files/FWO.Middleware.Server/Services/ReportSchedulerService.cs
@@ -56,14 +56,14 @@ namespace FWO.Middleware.Server.Services
             var triggerKey = new TriggerKey(TriggerKeyName);
 
             // Ensure the job exists as a durable job (so it can be manually triggered)
-            if (!await scheduler.CheckExists(jobKey))
+            if (!await scheduler.Exists(jobKey))
             {
                 IJobDetail durableJob = JobBuilder.Create<ReportJob>()
                     .WithIdentity(jobKey)
                     .StoreDurably()
                     .Build();
 
-                await scheduler.AddJob(durableJob, replace: true);
+                await scheduler.AddJob(durableJob, AddJobOptions.Replacing);
 
                 Log.WriteInfo(SchedulerName, "Added durable job for manual triggering");
             }
@@ -81,7 +81,7 @@ namespace FWO.Middleware.Server.Services
                 .ForJob(jobKey)
                 .StartNow()
                 .WithSimpleSchedule(x => x
-                    .WithIntervalInSeconds(DefaultIntervalSeconds)
+                    .WithInterval(TimeSpan.FromSeconds(DefaultIntervalSeconds))
                     .RepeatForever())
                 .Build();
 

--- a/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
+++ b/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
@@ -9,10 +9,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AngleSharp" Version="1.7.2" />
-		<PackageReference Include="bunit" Version="2.9.0" />
+		<PackageReference Include="AngleSharp" Version="1.8.0" />
+		<PackageReference Include="bunit" Version="2.10.3" />
 		<PackageReference Include="NSubstitute" Version="6.2.0" />
-		<PackageReference Include="PuppeteerSharp" Version="25.8.0" />
+		<PackageReference Include="PuppeteerSharp" Version="25.10.0" />
 		<PackageReference Include="NUnit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
@@ -22,7 +22,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.12" />
 	</ItemGroup>
 
 	<!-- Stylesheets checked by UiPopUpStyleTest. They are embedded at build time, so the test does

--- a/roles/tests-unit/files/FWO.Test/JobExecutionTests.cs
+++ b/roles/tests-unit/files/FWO.Test/JobExecutionTests.cs
@@ -19,7 +19,7 @@ namespace FWO.Test
             EmptyListJobApiConnection apiConnection = new();
             AutoDiscoverJob job = new(apiConnection, new SimulatedGlobalConfig());
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.EqualTo(1));
             Assert.That(apiConnection.Queries[0], Is.EqualTo(DeviceQueries.getManagementsDetails));
@@ -31,7 +31,7 @@ namespace FWO.Test
             ThrowingJobApiConnection apiConnection = new();
             AutoDiscoverJob job = new(apiConnection, new SimulatedGlobalConfig());
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.EqualTo(3));
             Assert.That(apiConnection.Queries[0], Is.EqualTo(DeviceQueries.getManagementsDetails));
@@ -49,7 +49,7 @@ namespace FWO.Test
             ThrowingJobApiConnection apiConnection = new();
             ComplianceJob job = new(apiConnection, new SimulatedGlobalConfig());
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.EqualTo(3));
             Assert.That(apiConnection.Queries[0], Is.EqualTo(ConfigQueries.getConfigItemsByUser));
@@ -73,7 +73,7 @@ namespace FWO.Test
             };
             ImportAppDataJob job = new(apiConnection, globalConfig);
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.GreaterThanOrEqualTo(4));
             Assert.That(apiConnection.Queries, Does.Contain(AuthQueries.getLdapConnections));
@@ -94,7 +94,7 @@ namespace FWO.Test
             };
             ImportAppDataJob job = new(apiConnection, globalConfig);
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.GreaterThanOrEqualTo(1));
             Assert.That(apiConnection.Queries, Does.Contain(MonitorQueries.addLogEntry));
@@ -110,7 +110,7 @@ namespace FWO.Test
             ExternalRequestNoOpApiConnection apiConnection = new();
             ExternalRequestJob job = new(apiConnection, new SimulatedGlobalConfig());
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.EqualTo(3));
             Assert.That(apiConnection.Queries[0], Is.EqualTo(ConfigQueries.getConfigItemsByUser));
@@ -124,7 +124,7 @@ namespace FWO.Test
             ThrowingJobApiConnection apiConnection = new();
             ExternalRequestJob job = new(apiConnection, new SimulatedGlobalConfig());
 
-            JobExecutionException? exception = Assert.ThrowsAsync<JobExecutionException>(async () => await job.Execute(null!));
+            JobExecutionException? exception = Assert.ThrowsAsync<JobExecutionException>(async () => await job.Execute(null!, CancellationToken.None));
             Assert.That(exception, Is.Not.Null);
             Assert.That(apiConnection.Queries, Has.Count.GreaterThanOrEqualTo(1));
         }
@@ -143,7 +143,7 @@ namespace FWO.Test
             };
             ImportChangeNotifyJob job = new(apiConnection, globalConfig);
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.GreaterThanOrEqualTo(3));
             Assert.That(apiConnection.Queries, Does.Contain(ConfigQueries.getConfigItemsByUser));
@@ -156,7 +156,7 @@ namespace FWO.Test
             ThrowingJobApiConnection apiConnection = new();
             ImportChangeNotifyJob job = new(apiConnection, new SimulatedGlobalConfig());
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.GreaterThanOrEqualTo(3));
             Assert.That(apiConnection.Queries, Does.Contain(MonitorQueries.addLogEntry));
@@ -176,7 +176,7 @@ namespace FWO.Test
                 ImportSubnetDataPath = "[]"
             });
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.EqualTo(1));
             Assert.That(apiConnection.Queries[0], Is.EqualTo(MonitorQueries.addDataImportLogEntry));
@@ -191,7 +191,7 @@ namespace FWO.Test
                 ImportSubnetDataPath = "{"
             });
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.GreaterThanOrEqualTo(1));
             Assert.That(apiConnection.Queries, Does.Contain(MonitorQueries.addLogEntry));
@@ -208,7 +208,7 @@ namespace FWO.Test
             EmptyListJobApiConnection apiConnection = new();
             VarianceAnalysisJob job = new(apiConnection, new SimulatedGlobalConfig());
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Does.Contain(OwnerQueries.getOwners));
         }
@@ -223,7 +223,7 @@ namespace FWO.Test
             EmptyListJobApiConnection apiConnection = new();
             UpdateRuleOwnerMappingJob job = new(apiConnection, new SimulatedGlobalConfig());
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Is.Empty);
         }
@@ -237,7 +237,7 @@ namespace FWO.Test
                 OwnerSoruceMappingID = (int)OwnerMappingSourceStm.NameField
             });
 
-            await job.Execute(null!);
+            await job.Execute(null!, CancellationToken.None);
 
             Assert.That(apiConnection.Queries, Has.Count.EqualTo(3));
             Assert.That(apiConnection.Queries[0], Is.EqualTo(ImportQueries.getPendingRuleOwnerImports));

--- a/roles/tests-unit/files/FWO.Test/QuartzSchedulerServiceBaseTest.cs
+++ b/roles/tests-unit/files/FWO.Test/QuartzSchedulerServiceBaseTest.cs
@@ -11,6 +11,7 @@ using NSubstitute;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using Quartz;
+using QuartzSchedulerOptions = FWO.Middleware.Server.Services.QuartzSchedulerOptions;
 using System.Globalization;
 
 namespace FWO.Test
@@ -21,7 +22,7 @@ namespace FWO.Test
     {
         private sealed class TestJob : IJob
         {
-            public Task Execute(IJobExecutionContext context) => Task.CompletedTask;
+            public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
         }
 
         private sealed class TestSchedulerService : QuartzSchedulerServiceBase<TestJob>
@@ -114,7 +115,7 @@ namespace FWO.Test
             IScheduler scheduler = Substitute.For<IScheduler>();
             await ConfigureQuartzScheduler(scheduler);
             ISchedulerFactory schedulerFactory = Substitute.For<ISchedulerFactory>();
-            schedulerFactory.GetScheduler().Returns(Task.FromResult(scheduler));
+            schedulerFactory.GetScheduler().Returns(ValueTask.FromResult(scheduler));
             CapturingApiConnection apiConnection = new();
             using TestApplicationLifetime appLifetime = new();
 
@@ -140,7 +141,7 @@ namespace FWO.Test
             IScheduler scheduler = Substitute.For<IScheduler>();
             await ConfigureQuartzScheduler(scheduler);
             ISchedulerFactory schedulerFactory = Substitute.For<ISchedulerFactory>();
-            schedulerFactory.GetScheduler().Returns(Task.FromResult(scheduler));
+            schedulerFactory.GetScheduler().Returns(ValueTask.FromResult(scheduler));
             CapturingApiConnection apiConnection = new();
             using TestApplicationLifetime appLifetime = new();
 
@@ -162,12 +163,12 @@ namespace FWO.Test
 
         private static Task ConfigureQuartzScheduler(IScheduler scheduler)
         {
-            scheduler.CheckExists(Arg.Any<JobKey>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
-            scheduler.AddJob(Arg.Any<IJobDetail>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
-            scheduler.UnscheduleJob(Arg.Any<TriggerKey>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
-            scheduler.DeleteJob(Arg.Any<JobKey>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
-            scheduler.ScheduleJob(Arg.Any<ITrigger>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(DateTimeOffset.Now));
-            scheduler.ScheduleJob(Arg.Any<IJobDetail>(), Arg.Any<ITrigger>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(DateTimeOffset.Now));
+            scheduler.Exists(Arg.Any<JobKey>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(false));
+            scheduler.AddJob(Arg.Any<IJobDetail>(), Arg.Any<AddJobOptions>(), Arg.Any<CancellationToken>()).Returns(ValueTask.CompletedTask);
+            scheduler.UnscheduleJob(Arg.Any<TriggerKey>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(false));
+            scheduler.DeleteJob(Arg.Any<JobKey>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(true));
+            scheduler.ScheduleJob(Arg.Any<ITrigger>(), cancellationToken: Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(DateTimeOffset.Now));
+            scheduler.ScheduleJob(Arg.Any<IJobDetail>(), Arg.Any<ITrigger>(), cancellationToken: Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(DateTimeOffset.Now));
             return Task.CompletedTask;
         }
 
@@ -175,7 +176,7 @@ namespace FWO.Test
         {
             try
             {
-                await scheduler.Received().ScheduleJob(Arg.Any<ITrigger>(), Arg.Any<CancellationToken>());
+                await scheduler.Received().ScheduleJob(Arg.Any<ITrigger>(), cancellationToken: Arg.Any<CancellationToken>());
                 return scheduler.ReceivedCalls().Count(call => call.GetMethodInfo().Name == nameof(IScheduler.ScheduleJob)
                     && call.GetArguments().Length > 0
                     && call.GetArguments()[0] is ITrigger);
@@ -190,7 +191,7 @@ namespace FWO.Test
         {
             try
             {
-                await scheduler.Received().ScheduleJob(Arg.Any<IJobDetail>(), Arg.Any<ITrigger>(), Arg.Any<CancellationToken>());
+                await scheduler.Received().ScheduleJob(Arg.Any<IJobDetail>(), Arg.Any<ITrigger>(), cancellationToken: Arg.Any<CancellationToken>());
                 return scheduler.ReceivedCalls().Count(call => call.GetMethodInfo().Name == nameof(IScheduler.ScheduleJob)
                     && call.GetArguments().Length > 1
                     && call.GetArguments()[0] is IJobDetail

--- a/roles/tests-unit/files/FWO.Test/SchedulerControllerTest.cs
+++ b/roles/tests-unit/files/FWO.Test/SchedulerControllerTest.cs
@@ -7,13 +7,33 @@ using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using NUnit.Framework;
 using Quartz;
-using Quartz.Impl.Matchers;
+using FWO.Middleware.Server.Jobs;
 
 namespace FWO.Test
 {
     [TestFixture]
     internal class SchedulerControllerTest
     {
+        /// <summary>
+        /// Verifies that Quartz interface callbacks update the execution result.
+        /// </summary>
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task JobListenerCallback_RecordsExecutionResult(bool failed)
+        {
+            JobExecutionTracker tracker = new();
+            IJobListener listener = tracker;
+            JobKey jobKey = new("tracked-job");
+            JobExecutionException? exception = failed ? new JobExecutionException("failure") : null;
+
+            await listener.JobWasExecuted(CreateExecutionContext(jobKey), exception);
+
+            JobExecutionResult? result = tracker.GetLastResult(jobKey.Name);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.Success, Is.EqualTo(!failed));
+            Assert.That(result.ErrorMessage, Is.EqualTo(failed ? "failure" : ""));
+        }
+
         [Test]
         public async Task GetJobs_ReturnsSortedJobsWithExecutionDetails()
         {
@@ -26,15 +46,12 @@ namespace FWO.Test
 
             JobExecutionTracker tracker = new();
             await tracker.JobWasExecuted(CreateExecutionContext(alphaJob), null);
-            await tracker.JobWasExecuted(CreateExecutionContext(betaJob), new JobExecutionException(new InvalidOperationException("boom"), refireImmediately: false));
+            await tracker.JobWasExecuted(CreateExecutionContext(betaJob), new JobExecutionException(new InvalidOperationException("boom")) { RefireImmediately = false });
 
-            IScheduler scheduler = Substitute.For<IScheduler>();
-            scheduler.GetJobKeys(GroupMatcher<JobKey>.AnyGroup(), CancellationToken.None)
-                .Returns(Task.FromResult<IReadOnlyCollection<JobKey>>(new List<JobKey> { betaJob, alphaJob }));
-            scheduler.GetTriggersOfJob(alphaJob, CancellationToken.None)
-                .Returns(Task.FromResult<IReadOnlyCollection<ITrigger>>(new List<ITrigger> { CreateSimpleTrigger() }));
-            scheduler.GetTriggersOfJob(betaJob, CancellationToken.None)
-                .Returns(Task.FromResult<IReadOnlyCollection<ITrigger>>(new List<ITrigger> { CreateCronTrigger() }));
+            await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder.Create().Build();
+            IScheduler scheduler = await schedulerFactory.GetScheduler();
+            await scheduler.ScheduleJob(JobBuilder.Create<ComplianceJob>().WithIdentity(alphaJob).Build(), CreateSimpleTrigger());
+            await scheduler.ScheduleJob(JobBuilder.Create<ComplianceJob>().WithIdentity(betaJob).Build(), CreateCronTrigger());
 
             SchedulerController controller = CreateController(scheduler, tracker);
 
@@ -70,8 +87,8 @@ namespace FWO.Test
         public async Task Run_ReturnsNotFoundWhenJobDoesNotExist()
         {
             IScheduler scheduler = Substitute.For<IScheduler>();
-            scheduler.CheckExists(new JobKey("missing-job"), CancellationToken.None)
-                .Returns(Task.FromResult(false));
+            scheduler.Exists(new JobKey("missing-job"), CancellationToken.None)
+                .Returns(ValueTask.FromResult(false));
 
             SchedulerController controller = CreateController(scheduler, new JobExecutionTracker());
 
@@ -85,23 +102,23 @@ namespace FWO.Test
         public async Task Run_TriggersExistingJob()
         {
             IScheduler scheduler = Substitute.For<IScheduler>();
-            scheduler.CheckExists(new JobKey("trigger-job"), CancellationToken.None)
-                .Returns(Task.FromResult(true));
-            scheduler.TriggerJob(new JobKey("trigger-job"), CancellationToken.None)
-                .Returns(Task.CompletedTask);
+            scheduler.Exists(new JobKey("trigger-job"), CancellationToken.None)
+                .Returns(ValueTask.FromResult(true));
+            scheduler.TriggerJob(new JobKey("trigger-job"), cancellationToken: CancellationToken.None)
+                .Returns(ValueTask.CompletedTask);
 
             SchedulerController controller = CreateController(scheduler, new JobExecutionTracker());
 
             ActionResult<bool> result = await controller.Run(new SchedulerJobTriggerParameters { JobName = "trigger-job" });
 
             Assert.That(result.Value, Is.True);
-            await scheduler.Received(1).TriggerJob(new JobKey("trigger-job"), CancellationToken.None);
+            await scheduler.Received(1).TriggerJob(new JobKey("trigger-job"), cancellationToken: CancellationToken.None);
         }
 
         private static SchedulerController CreateController(IScheduler scheduler, JobExecutionTracker tracker)
         {
             ISchedulerFactory schedulerFactory = Substitute.For<ISchedulerFactory>();
-            schedulerFactory.GetScheduler().Returns(Task.FromResult(scheduler));
+            schedulerFactory.GetScheduler().Returns(ValueTask.FromResult(scheduler));
             return new SchedulerController(schedulerFactory, tracker);
         }
 

--- a/roles/ui/files/FWO.UI/FWO.Ui.csproj
+++ b/roles/ui/files/FWO.UI/FWO.Ui.csproj
@@ -17,7 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="IPAddressRange" Version="6.3.0" />
 		<PackageReference Include="BlazorTable" Version="1.17.0" />
-		<PackageReference Include="PuppeteerSharp" Version="25.8.0" />
+		<PackageReference Include="PuppeteerSharp" Version="25.10.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Update Microsoft.AspNetCore.Components to 10.0.12
Update Microsoft.AspNetCore.Http to 2.3.13
Update PuppeteerSharp to 25.10.0
Update Microsoft.AspNetCore.Authentication.JwtBearer to 10.0.12
Update Microsoft.AspNetCore.OpenApi to 10.0.12
Update Scalar.AspNetCore to 2.17.3
Update Quartz to 4.0.1
Update Quartz.Extensions.Hosting to 4.0.1
Update Quartz.Serialization.Json to 4.0.1
Update AngleSharp to 1.8.0
Update bunit to 2.10.3
Update Microsoft.AspNetCore.Mvc.Testing to 10.0.12

Migrated the schedulers and tests to work with the new quatz changes.

Closing #5263, #5262, #5261, #5260 and #5239