### PR TITLE
chore(deps): update NuGet packages

### DIFF
--- a/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
+++ b/roles/lib/files/FWO.Api.Client/FWO.Api.Client.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="GraphQL.Client" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
     <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.12" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="114.0.0" />

--- a/roles/lib/files/FWO.Data/FWO.Data.csproj
+++ b/roles/lib/files/FWO.Data/FWO.Data.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.12" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
   </ItemGroup>
 

--- a/roles/lib/files/FWO.Mail/FWO.Mail.csproj
+++ b/roles/lib/files/FWO.Mail/FWO.Mail.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="MimeKit" Version="4.17.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Report/FWO.Report.csproj
+++ b/roles/lib/files/FWO.Report/FWO.Report.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="HtmlAgilityPack" Version="1.13.0" />
-	  <PackageReference Include="PuppeteerSharp" Version="25.8.0" />
+	  <PackageReference Include="PuppeteerSharp" Version="25.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/lib/files/FWO.Services/FWO.Services.csproj
+++ b/roles/lib/files/FWO.Services/FWO.Services.csproj
@@ -10,7 +10,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="PuppeteerSharp" Version="25.8.0" />
+		<PackageReference Include="PuppeteerSharp" Version="25.10.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\FWO.Api.Client\FWO.Api.Client.csproj" />

--- a/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
+++ b/roles/middleware/files/FWO.Middleware.Server/FWO.Middleware.Server.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.12" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.2" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.17.2" />
-    <PackageReference Include="PuppeteerSharp" Version="25.8.0" />
-    <PackageReference Include="Quartz" Version="3.20.0" />
-    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.20.0" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.20.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.17.3" />
+    <PackageReference Include="PuppeteerSharp" Version="25.10.0" />
+    <PackageReference Include="Quartz" Version="3.21.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.21.0" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.21.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/roles/tests-integration/files/ui/ambient_role_smoke/FWO.Ui.AmbientRoleSmoke.csproj
+++ b/roles/tests-integration/files/ui/ambient_role_smoke/FWO.Ui.AmbientRoleSmoke.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.45.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.62.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
   </ItemGroup>
 
 </Project>

--- a/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
+++ b/roles/tests-unit/files/FWO.Test/FWO.Test.csproj
@@ -9,10 +9,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AngleSharp" Version="1.7.2" />
-		<PackageReference Include="bunit" Version="2.9.0" />
+		<PackageReference Include="AngleSharp" Version="1.8.0" />
+		<PackageReference Include="bunit" Version="2.10.3" />
 		<PackageReference Include="NSubstitute" Version="6.2.0" />
-		<PackageReference Include="PuppeteerSharp" Version="25.8.0" />
+		<PackageReference Include="PuppeteerSharp" Version="25.10.0" />
 		<PackageReference Include="NUnit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.3.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
@@ -22,7 +22,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.12" />
 	</ItemGroup>
 
 	<!-- Stylesheets checked by UiPopUpStyleTest. They are embedded at build time, so the test does

--- a/roles/ui/files/FWO.UI/FWO.Ui.csproj
+++ b/roles/ui/files/FWO.UI/FWO.Ui.csproj
@@ -17,7 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="IPAddressRange" Version="6.3.0" />
 		<PackageReference Include="BlazorTable" Version="1.17.0" />
-		<PackageReference Include="PuppeteerSharp" Version="25.8.0" />
+		<PackageReference Include="PuppeteerSharp" Version="25.10.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Update `AngleSharp` to `1.8.0`
Update `bunit` to `2.10.3`
Update `Microsoft.AspNetCore.Authentication.JwtBearer` to `10.0.12`
Update `Microsoft.AspNetCore.Components` to `10.0.12`
Update `Microsoft.AspNetCore.Http` to `2.3.13`
Update `Microsoft.AspNetCore.Mvc.Testing` to `10.0.12`
Update `Microsoft.AspNetCore.OpenApi` to `10.0.12`
Update `Microsoft.NET.Test.Sdk` to `18.9.0`
Update `Microsoft.OpenApi` to `2.12.2`
Update `Microsoft.Playwright` to `1.62.0`
Update `NUnit3TestAdapter` to `6.3.0`
Update `PuppeteerSharp` to `25.10.0`
Update `Quartz` to `3.21.0`
Update `Quartz.Extensions.Hosting` to `3.21.0`
Update `Quartz.Serialization.Json` to `3.21.0`
Update `Scalar.AspNetCore` to `2.17.3`

❗ diddn't update quartz to 4.x because it breaks all schedulers. Will update to them next time.