### PR TITLE
fix(ui): AppRole Modal footer buttons alignment inconsistent

### DIFF
--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/EditAppRole.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/EditAppRole.razor
@@ -11,7 +11,7 @@
 @if(AppRoleHandler != null && Display)
 {
     <PopUp Title="@(AppRoleHandler.ReadOnly ? "" : (AppRoleHandler.AddMode ? userConfig.GetText("add_app_role") : userConfig.GetText("edit_app_role")))"
-           Size="PopupSize.Auto" Show="@Display" OnClose="Close">
+           Size="PopupSize.Auto" Show="@Display" OnClose="Close" FooterCssClass="@(!AppRoleHandler.AddMode ? "d-flex justify-content-between" : "d-flex justify-content-end")">
         <Body>
             @if(AppRoleHandler.NamingConvention.NetworkAreaRequired)
             {

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/EditAppRole.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/EditAppRole.razor
@@ -11,7 +11,7 @@
 @if(AppRoleHandler != null && Display)
 {
     <PopUp Title="@(AppRoleHandler.ReadOnly ? "" : (AppRoleHandler.AddMode ? userConfig.GetText("add_app_role") : userConfig.GetText("edit_app_role")))"
-           Size="PopupSize.Auto" Show="@Display" OnClose="Close" FooterCssClass="d-flex justify-content-between">
+           Size="PopupSize.Auto" Show="@Display" OnClose="Close">
         <Body>
             @if(AppRoleHandler.NamingConvention.NetworkAreaRequired)
             {

--- a/roles/ui/files/FWO.UI/Pages/NetworkModelling/EditAppRole.razor
+++ b/roles/ui/files/FWO.UI/Pages/NetworkModelling/EditAppRole.razor
@@ -11,7 +11,7 @@
 @if(AppRoleHandler != null && Display)
 {
     <PopUp Title="@(AppRoleHandler.ReadOnly ? "" : (AppRoleHandler.AddMode ? userConfig.GetText("add_app_role") : userConfig.GetText("edit_app_role")))"
-           Size="PopupSize.Auto" Show="@Display" OnClose="Close" FooterCssClass="@(!AppRoleHandler.AddMode ? "d-flex justify-content-between" : "d-flex justify-content-end")">
+           Size="PopupSize.Auto" Show="@Display" OnClose="Close" FooterCssClass="@(AppRoleHandler.AddMode ? "d-flex justify-content-end" : "d-flex justify-content-between")">
         <Body>
             @if(AppRoleHandler.NamingConvention.NetworkAreaRequired)
             {


### PR DESCRIPTION
❗ Added a condition for the footer css class. this may not be the optimal way but due to restrictions and structure of the blazortable footercss handling i found this to be the easiest way.

<img width="1148" height="695" alt="brave_ZgCuQ3BiyJ" src="https://github.com/user-attachments/assets/f23db1a8-e922-45b6-bbbd-aae21d89b657" />

<img width="1154" height="695" alt="brave_pisy3SpnPw" src="https://github.com/user-attachments/assets/4dd7256f-9b74-410c-83cb-73ec45b44c67" />


---

Closing #5258